### PR TITLE
NOTICKET: Update ReactionPicker to send username instead of ID

### DIFF
--- a/src/components/ReactionPicker.js
+++ b/src/components/ReactionPicker.js
@@ -124,7 +124,7 @@ export const ReactionPicker = themed(
                               borderWidth: 1,
                             },
                           }}
-                          name={latestUser.name}
+                          name={latestUser.name || latestUser.id}
                         />
                       ) : (
                         !hideReactionOwners && (

--- a/src/components/ReactionPicker.js
+++ b/src/components/ReactionPicker.js
@@ -124,7 +124,7 @@ export const ReactionPicker = themed(
                               borderWidth: 1,
                             },
                           }}
-                          name={latestUser.id}
+                          name={latestUser.name}
                         />
                       ) : (
                         !hideReactionOwners && (


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [] Code changes are tested (add some information if not applicable)

## Description of the pull request
First character of a user ID is displayed above emojis in reactions. The code reads as though this should be the initials of the users name.

I have not tested this as it is a small change, and the user object should contain the key "name", as it appears in other areas of the application