### PR TITLE
[Feature] MessageSimple: Add Formal Override Points to provide Alternate Components

### DIFF
--- a/src/components/MessageSimple/index.js
+++ b/src/components/MessageSimple/index.js
@@ -2,10 +2,10 @@ import React from 'react';
 import styled from '@stream-io/styled-components';
 import { themed } from '../../styles/theme';
 
-import { MessageStatus } from './MessageStatus';
-import { MessageContent } from './MessageContent';
-import { MessageAvatar } from './MessageAvatar';
-import { MessageSystem } from '../MessageSystem';
+import { MessageAvatar as DefaultMessageAvatar } from './MessageAvatar';
+import { MessageContent as DefaultMessageContent } from './MessageContent';
+import { MessageStatus as DefaultMessageStatus } from './MessageStatus';
+import { MessageSystem as DefaultMessageSystem } from '../MessageSystem';
 
 import PropTypes from 'prop-types';
 
@@ -31,6 +31,26 @@ const Container = styled.View`
 export const MessageSimple = themed(
   class MessageSimple extends React.PureComponent {
     static propTypes = {
+      /** Custom UI component for the avatar next to a message */
+      MessageAvatar: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.elementType,
+      ]),
+      /** Custom UI component for message content */
+      MessageContent: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.elementType,
+      ]),
+      /** Custom UI component for message status (delivered/read) */
+      MessageStatus: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.elementType,
+      ]),
+      /** Custom UI component for Messages of type "system" */
+      MessageSystem: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.elementType,
+      ]),
       /** Custom UI component for message text */
       MessageText: PropTypes.oneOfType([PropTypes.node, PropTypes.elementType]),
       /** enabled reactions, this is usually set by the parent component based on channel configs */
@@ -177,6 +197,10 @@ export const MessageSimple = themed(
       repliesEnabled: true,
       forceAlign: false,
       showMessageStatus: true,
+      MessageAvatar: DefaultMessageAvatar,
+      MessageContent: DefaultMessageContent,
+      MessageStatus: DefaultMessageStatus,
+      MessageSystem: DefaultMessageSystem,
     };
 
     static themePath = 'message';
@@ -188,6 +212,10 @@ export const MessageSimple = themed(
         groupStyles,
         forceAlign,
         showMessageStatus,
+        MessageAvatar,
+        MessageContent,
+        MessageStatus,
+        MessageSystem,
       } = this.props;
 
       let pos;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -458,6 +458,14 @@ export interface MessageUIComponentProps
    * */
   forceAlign: string | boolean;
   showMessageStatus: boolean;
+  /** Custom UI component for the avatar next to a message */
+  MessageAvatar?: React.ElementType<MessageAvatarUIComponentProps>;
+  /** Custom UI component for message content */
+  MessageContent?: React.ElementType<MessageContentUIComponentProps>;
+  /** Custom UI component for message status (delivered/read) */
+  MessageStatus?: React.ElementType<MessageStatusUIComponentProps>;
+  /** Custom UI component for Messages of type "system" */
+  MessageSystem?: React.ElementType<MessageSystemProps>;
   /** Custom UI component for message text */
   MessageText?: React.ElementType<MessageTextProps>;
   /** https://github.com/beefe/react-native-actionsheet/blob/master/lib/styles.js */


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

I don't see any tests in the current codebase. Happy to add something if desired!

## Description of the pull request

It would be convenient if when we configure the `<MessageSimple` component that we could swap out the internal components it uses without having to completely re-implement or fork MessageSimple!