### PR TITLE
adding in a boolean values to MessageSimple to enable hiding reaction count/owner in the ReactionPicker

### DIFF
--- a/src/components/MessageSimple/MessageContent.js
+++ b/src/components/MessageSimple/MessageContent.js
@@ -221,6 +221,8 @@ class MessageContent extends React.PureComponent {
      * `editing` prop is then used by MessageInput component to switch to edit mode.
      */
     handleEdit: PropTypes.func,
+    // enable hiding reaction count from reaction picker
+    hideReactionCount: PropTypes.bool,
     // enable hiding reaction owners from reaction picker
     hideReactionOwners: PropTypes.bool,
     /** @see See [keyboard context](https://getstream.io/chat/docs/#keyboardcontext) */
@@ -339,6 +341,7 @@ class MessageContent extends React.PureComponent {
       readOnly,
       Message,
       handleReaction,
+      hideReactionCount,
       hideReactionOwners,
       threadList,
       retrySendMessage,
@@ -546,6 +549,7 @@ class MessageContent extends React.PureComponent {
             <ReactionPicker
               reactionPickerVisible={this.state.reactionPickerVisible}
               handleReaction={handleReaction}
+              hideReactionCount={hideReactionCount}
               hideReactionOwners={hideReactionOwners}
               latestReactions={message.latest_reactions}
               reactionCounts={message.reaction_counts}

--- a/src/components/MessageSimple/MessageContent.js
+++ b/src/components/MessageSimple/MessageContent.js
@@ -221,6 +221,8 @@ class MessageContent extends React.PureComponent {
      * `editing` prop is then used by MessageInput component to switch to edit mode.
      */
     handleEdit: PropTypes.func,
+    // enable hiding reaction owners from reaction picker
+    hideReactionOwners: PropTypes.bool,
     /** @see See [keyboard context](https://getstream.io/chat/docs/#keyboardcontext) */
     dismissKeyboard: PropTypes.func,
     /** Handler for actions. Actions in combination with attachments can be used to build [commands](https://getstream.io/chat/docs/#channel_commands). */
@@ -337,6 +339,7 @@ class MessageContent extends React.PureComponent {
       readOnly,
       Message,
       handleReaction,
+      hideReactionOwners,
       threadList,
       retrySendMessage,
       messageActions,
@@ -543,6 +546,7 @@ class MessageContent extends React.PureComponent {
             <ReactionPicker
               reactionPickerVisible={this.state.reactionPickerVisible}
               handleReaction={handleReaction}
+              hideReactionOwners={hideReactionOwners}
               latestReactions={message.latest_reactions}
               reactionCounts={message.reaction_counts}
               handleDismiss={() => {

--- a/src/components/MessageSimple/index.js
+++ b/src/components/MessageSimple/index.js
@@ -158,6 +158,8 @@ export const MessageSimple = themed(
       handleAction: PropTypes.func,
       /** Handler resend the message. */
       handleRetry: PropTypes.func,
+      /** enable hiding reaction owners from reaction picker. */
+      hideReactionOwners: PropTypes.bool,
       /** Current [message object](https://getstream.io/chat/docs/#message_format) */
       message: PropTypes.object,
       /**

--- a/src/components/MessageSimple/index.js
+++ b/src/components/MessageSimple/index.js
@@ -158,6 +158,8 @@ export const MessageSimple = themed(
       handleAction: PropTypes.func,
       /** Handler resend the message. */
       handleRetry: PropTypes.func,
+      // enable hiding reaction count from reaction picker
+      hideReactionCount: PropTypes.bool,
       /** enable hiding reaction owners from reaction picker. */
       hideReactionOwners: PropTypes.bool,
       /** Current [message object](https://getstream.io/chat/docs/#message_format) */

--- a/src/components/ReactionPicker.js
+++ b/src/components/ReactionPicker.js
@@ -49,6 +49,7 @@ export const ReactionPicker = themed(
     static themePath = 'message.reactionPicker';
 
     static propTypes = {
+      hideReactionCount: PropTypes.bool,
       hideReactionOwners: PropTypes.bool,
       reactionPickerVisible: PropTypes.bool,
       handleDismiss: PropTypes.func,
@@ -82,6 +83,7 @@ export const ReactionPicker = themed(
 
     render() {
       const {
+        hideReactionCount,
         hideReactionOwners,
         reactionPickerVisible,
         handleDismiss,
@@ -153,7 +155,9 @@ export const ReactionPicker = themed(
                       >
                         {icon}
                       </Emoji>
-                      <ReactionCount>{count > 0 ? count : ''}</ReactionCount>
+                      <ReactionCount>
+                        {!hideReactionCount && count > 0 ? count : ''}
+                      </ReactionCount>
                     </Column>
                   );
                 })}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -495,6 +495,8 @@ export interface MessageUIComponentProps
     message: Client.MessageResponse,
     e: GestureResponderEvent,
   ): any;
+  hideReactionCount?: boolean;
+  hideReactionOwners?: boolean;
   handleReaction(reactionType: string, event?: React.BaseSyntheticEvent): void;
   handleDelete?(): void;
   handleEdit?(): void;
@@ -744,6 +746,7 @@ export interface ReactionListProps {
 }
 
 export interface ReactionPickerProps {
+  hideReactionCount?: boolean;
   hideReactionOwners: boolean;
   reactionPickerVisible: boolean;
   handleDismiss?(): void;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
- adding in a boolean values to MessageSimple to enable hiding reaction count/owner in the ReactionPicker