### PR TITLE
fix key override in Streami18n for translationsForLanguage and registerTranslations to append to current translations if they exist

### DIFF
--- a/src/utils/Streami18n.js
+++ b/src/utils/Streami18n.js
@@ -224,7 +224,10 @@ export class Streami18n {
 
     if (translationsForLanguage) {
       this.translations[this.currentLanguage] = {
-        [defaultNS]: translationsForLanguage,
+        [defaultNS]: {
+          ...(this.translations[this.currentLanguage][defaultNS] || []),
+          ...translationsForLanguage,
+        },
       };
     }
 
@@ -361,7 +364,10 @@ export class Streami18n {
     if (!this.translations[language]) {
       this.translations[language] = { [defaultNS]: translation };
     } else {
-      this.translations[language][defaultNS] = translation;
+      this.translations[language][defaultNS] = {
+        ...this.translations[language][defaultNS],
+        ...translation,
+      };
     }
 
     if (customMomentLocale) {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
- fix key override in Streami18n for translationsForLanguage and registerTranslations to append to current translations if they exist