### PR TITLE
Optimistic reaction updates to UI

### DIFF
--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -172,70 +172,8 @@ const Message = withKeyboardContext(
       this.props.updateMessage(data.message);
     };
 
-    handleReaction = async (reactionType, event) => {
-      if (event !== undefined && event.preventDefault) {
-        event.preventDefault();
-      }
-
-      let userExistingReaction = null;
-
-      const currentUser = this.props.client.userID;
-      for (const reaction of this.props.message.own_reactions) {
-        // own user should only ever contain the current user id
-        // just in case we check to prevent bugs with message updates from breaking reactions
-        if (
-          currentUser === reaction.user.id &&
-          reaction.type === reactionType
-        ) {
-          userExistingReaction = reaction;
-        } else if (currentUser !== reaction.user.id) {
-          console.warn(
-            `message.own_reactions contained reactions from a different user, this indicates a bug`,
-          );
-        }
-      }
-
-      const originalMessage = this.props.message;
-      let reactionChangePromise;
-
-      /*
-    - Add the reaction to the local state
-    - Make the API call in the background
-    - If it fails, revert to the old message...
-    */
-      if (userExistingReaction) {
-        this.props.channel.state.removeReaction(userExistingReaction);
-
-        reactionChangePromise = this.props.channel.deleteReaction(
-          this.props.message.id,
-          userExistingReaction.type,
-        );
-      } else {
-        // add the reaction
-        const messageID = this.props.message.id;
-        const tmpReaction = {
-          message_id: messageID,
-          user: this.props.client.user,
-          type: reactionType,
-          created_at: new Date(),
-        };
-        const reaction = { type: reactionType };
-
-        this.props.channel.state.addReaction(tmpReaction);
-        reactionChangePromise = this.props.channel.sendReaction(
-          messageID,
-          reaction,
-        );
-      }
-
-      try {
-        // only wait for the API call after the state is updated
-        await reactionChangePromise;
-      } catch (e) {
-        // revert to the original message if the API call fails
-        this.props.updateMessage(originalMessage);
-      }
-    };
+    handleReaction = (reactionType) =>
+      this.props.handleReaction(this.props.message, reactionType);
 
     handleAction = async (name, value, event) => {
       event.preventDefault();

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -114,6 +114,13 @@ class MessageList extends PureComponent {
      *
      * */
     onMessageTouch: PropTypes.func,
+    /**
+     * Handler for reaction.
+     *
+     * @param message Message object
+     * @param reactionType e.g., love, haha
+     */
+    handleReaction: PropTypes.func,
     /** Should keyboard be dismissed when messaged is touched */
     dismissKeyboardOnMessageTouch: PropTypes.bool,
     eventHistory: PropTypes.object,
@@ -523,6 +530,7 @@ class MessageList extends PureComponent {
           editing={this.props.editing}
           threadList={this.props.threadList}
           messageActions={this.props.messageActions}
+          handleReaction={this.props.handleReaction}
           updateMessage={this.props.updateMessage}
           removeMessage={this.props.removeMessage}
           retrySendMessage={this.props.retrySendMessage}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -108,6 +108,10 @@ export interface ChannelContextValue {
     updatedMessage: Client.MessageResponse,
     extraState?: object,
   ): void;
+  handleReaction?(
+    message: Client.MessageResponse,
+    reactionType: string,
+  ): Promise<void>;
   editMessage?(message: Client.Message): void | Promise<Client.MessageResponse>;
   retrySendMessage?(message: Client.Message): void;
   removeMessage?(updatedMessage: Client.MessageResponse): void;
@@ -497,7 +501,7 @@ export interface MessageUIComponentProps
   ): any;
   hideReactionCount?: boolean;
   hideReactionOwners?: boolean;
-  handleReaction(reactionType: string, event?: React.BaseSyntheticEvent): void;
+  handleReaction(reactionType: string): Promise<void>;
   handleDelete?(): void;
   handleEdit?(): void;
   handleFlag(event?: React.BaseSyntheticEvent): void;


### PR DESCRIPTION
# Submit a pull request

Fixes - https://github.com/GetStream/stream-chat-react-native/issues/149

## Purpose
 - Update the reactions (add/remove) in UI without waiting for api calls.
 - In case of failure, reset the added/removed reactions.

## Changes

- Lifting `handleReaction` function up from `Message` (HOC) to `Channel` component.
- Lifting network status (state variable `online`) from `MessageList` to `Channel` component
- Updating channel state before calling sendReaction/removeReaction api.
- If promise gets rejected or api fails, then we reset the state update.

**NOTE** This PR is dependent on changes of following PR in js client - https://github.com/GetStream/stream-chat-js/pull/280



## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
