### PR TITLE
add `this` to props on `MessageContent` handlers

### DIFF
--- a/src/components/MessageSimple/MessageContent.js
+++ b/src/components/MessageSimple/MessageContent.js
@@ -333,11 +333,11 @@ class MessageContent extends React.PureComponent {
   };
 
   handleDelete = async () => {
-    await this.props.handleDelete();
+    await this.props.handleDelete(this);
   };
 
   handleEdit = () => {
-    this.props.handleEdit();
+    this.props.handleEdit(this);
   };
 
   /**
@@ -352,12 +352,12 @@ class MessageContent extends React.PureComponent {
         'Please use this.props.openReactionPicker instead.',
     );
 
-    await this.props.openReactionPicker();
+    await this.props.openReactionPicker(this);
   };
 
   openReactionSelector = () => {
     console.warn(
-      'openReactionSelector has been deprecared and will be removed in next major release.' +
+      'openReactionSelector has been deprecated and will be removed in next major release.' +
         'Please use this.props.openReactionPicker instead.',
     );
   };
@@ -365,16 +365,16 @@ class MessageContent extends React.PureComponent {
   onActionPress = (action) => {
     switch (action) {
       case MESSAGE_ACTIONS.edit:
-        this.handleEdit();
+        this.handleEdit(this);
         break;
       case MESSAGE_ACTIONS.delete:
-        this.handleDelete();
+        this.handleDelete(this);
         break;
       case MESSAGE_ACTIONS.reply:
         this.openThread();
         break;
       case MESSAGE_ACTIONS.reactions:
-        this.props.openReactionPicker();
+        this.props.openReactionPicker(this);
         break;
       default:
         break;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

The `MessageContent` takes custom handlers as properties that will override the native ones. Unlike other overridable functions, the handlers are not passed `this` as an argument. Adding `this` allows the user to intercept calls to `handleEdit`, `handleDelete`, etc. and then pass on to the originally defined function.