### PR TITLE
Add async/await to uploadNewImage function in MessageInput

### DIFF
--- a/src/components/MessageInput.js
+++ b/src/components/MessageInput.js
@@ -592,10 +592,10 @@ class MessageInput extends PureComponent {
     this.uploadNewImage(result);
   };
 
-  uploadNewImage = (image) => {
+  uploadNewImage = async (image) => {
     const id = generateRandomId();
     /* eslint-disable */
-    this.setState((prevState) => {
+    await this.setState((prevState) => {
       return {
         numberOfUploads: prevState.numberOfUploads + 1,
         imageOrder: prevState.imageOrder.concat([id]),


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Vish, we're running into a race conditions issue where the `img` pulled off state in `_uploadImage` is undefined on the first pass through the code for gif uploads. Since the state is not yet set, an infinite loading state is triggered. The upload works properly after we click the preview icon to retry the upload, as the state has had time to update.

https://github.com/GetStream/stream-chat-react-native/blob/32953a3efce28f4927739d7835ed2b467500e4bb/src/components/MessageInput.js#L561
