### PR TITLE
Add useNativeDriver to animations to prevent console warnings

### DIFF
--- a/src/components/KeyboardCompatibleView.js
+++ b/src/components/KeyboardCompatibleView.js
@@ -144,6 +144,7 @@ export class KeyboardCompatibleView extends React.PureComponent {
       Animated.timing(this.state.channelHeight, {
         toValue: finalHeight,
         duration: this.props.keyboardOpenAnimationDuration,
+        useNativeDriver: false,
       }).start(() => {
         // Force the final value, in case animation halted in between.
         this.state.channelHeight.setValue(finalHeight);
@@ -160,6 +161,7 @@ export class KeyboardCompatibleView extends React.PureComponent {
     Animated.timing(this.state.channelHeight, {
       toValue: this.initialHeight,
       duration: this.props.keyboardDismissAnimationDuration,
+      useNativeDriver: false,
     }).start(() => {
       // Force the final value, in case animation halted in between.
       this.state.channelHeight.setValue(this.initialHeight);
@@ -187,6 +189,7 @@ export class KeyboardCompatibleView extends React.PureComponent {
       Animated.timing(this.state.channelHeight, {
         toValue: this.initialHeight,
         duration: this.props.keyboardDismissAnimationDuration,
+        useNativeDriver: false,
       }).start((response) => {
         this.state.channelHeight.setValue(this.initialHeight);
         if (response && !response.finished) {

--- a/src/components/MessageNotification.js
+++ b/src/components/MessageNotification.js
@@ -53,6 +53,7 @@ class MessageNotification extends PureComponent {
     Animated.timing(this.state.notificationOpacity, {
       toValue: this.props.showNotification ? 1 : 0,
       duration: 500,
+      useNativeDriver: true,
     }).start();
   }
 
@@ -61,6 +62,7 @@ class MessageNotification extends PureComponent {
       Animated.timing(this.state.notificationOpacity, {
         toValue: this.props.showNotification ? 1 : 0,
         duration: 500,
+        useNativeDriver: true,
       }).start();
     }
   }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

We recently started seeing warnings in the debug console that Animated values need to specify true/false for useNativeDriver. Added false calls for the non-native supported height properties and added true for the native supported opacity properties.

https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated#caveats
