### PR TITLE
In teach/handle channel hidden

### DIFF
--- a/src/components/ChannelList.js
+++ b/src/components/ChannelList.js
@@ -55,64 +55,64 @@ const ChannelList = withChatContext(
        * Function that overrides default behaviour when new message is received on channel that is not being watched
        *
        * @param {Component} thisArg Reference to ChannelList component
-       * @param {Event} event       [Event object](https://getstream.io/chat/docs/#event_object) corresponding to `notification.message_new` event
+       * @param {Event} event       [Event object](https://getstream.io/chat/docs/event_object) corresponding to `notification.message_new` event
        * */
       onMessageNew: PropTypes.func,
       /**
        * Function that overrides default behaviour when users gets added to a channel
        *
        * @param {Component} thisArg Reference to ChannelList component
-       * @param {Event} event       [Event object](https://getstream.io/chat/docs/#event_object) corresponding to `notification.added_to_channel` event
+       * @param {Event} event       [Event object](https://getstream.io/chat/docs/event_object) corresponding to `notification.added_to_channel` event
        * */
       onAddedToChannel: PropTypes.func,
       /**
        * Function that overrides default behaviour when users gets removed from a channel
        *
        * @param {Component} thisArg Reference to ChannelList component
-       * @param {Event} event       [Event object](https://getstream.io/chat/docs/#event_object) corresponding to `notification.removed_from_channel` event
+       * @param {Event} event       [Event object](https://getstream.io/chat/docs/event_object) corresponding to `notification.removed_from_channel` event
        * */
       onRemovedFromChannel: PropTypes.func,
       /**
        * Function that overrides default behaviour when channel gets updated
        *
        * @param {Component} thisArg Reference to ChannelList component
-       * @param {Event} event       [Event object](https://getstream.io/chat/docs/#event_object) corresponding to `channel.updated` event
+       * @param {Event} event       [Event object](https://getstream.io/chat/docs/event_object) corresponding to `channel.updated` event
        * */
       onChannelUpdated: PropTypes.func,
       /**
        * Function to customize behaviour when channel gets truncated
        *
        * @param {Component} thisArg Reference to ChannelList component
-       * @param {Event} event       [Event object](https://getstream.io/chat/docs/#event_object) corresponding to `channel.truncated` event
+       * @param {Event} event       [Event object](https://getstream.io/chat/docs/event_object) corresponding to `channel.truncated` event
        * */
       onChannelTruncated: PropTypes.func,
       /**
        * Function that overrides default behaviour when channel gets deleted. In absence of this prop, channel will be removed from the list.
        *
        * @param {Component} thisArg Reference to ChannelList component
-       * @param {Event} event       [Event object](https://getstream.io/chat/docs/#event_object) corresponding to `channel.deleted` event
+       * @param {Event} event       [Event object](https://getstream.io/chat/docs/event_object) corresponding to `channel.deleted` event
        * */
       onChannelDeleted: PropTypes.func,
       /**
        * Function that overrides default behaviour when channel gets hidden. In absence of this prop, channel will be removed from the list.
        *
        * @param {Component} thisArg Reference to ChannelList component
-       * @param {Event} event       [Event object](https://getstream.io/chat/docs/#event_object) corresponding to `channel.hidden` event
+       * @param {Event} event       [Event object](https://getstream.io/chat/docs/event_object) corresponding to `channel.hidden` event
        * */
       onChannelHidden: PropTypes.func,
       /**
        * Object containing query filters
-       * @see See [Channel query documentation](https://getstream.io/chat/docs/#query_channels) for a list of available fields for filter.
+       * @see See [Channel query documentation](https://getstream.io/chat/docs/query_channels) for a list of available fields for filter.
        * */
       filters: PropTypes.object,
       /**
        * Object containing query options
-       * @see See [Channel query documentation](https://getstream.io/chat/docs/#query_channels) for a list of available fields for options.
+       * @see See [Channel query documentation](https://getstream.io/chat/docs/query_channels) for a list of available fields for options.
        * */
       options: PropTypes.object,
       /**
        * Object containing sort parameters
-       * @see See [Channel query documentation](https://getstream.io/chat/docs/#query_channels) for a list of available fields for sort.
+       * @see See [Channel query documentation](https://getstream.io/chat/docs/query_channels) for a list of available fields for sort.
        * */
       sort: PropTypes.object,
       /** For flatlist  */

--- a/src/components/ChannelList.js
+++ b/src/components/ChannelList.js
@@ -94,6 +94,13 @@ const ChannelList = withChatContext(
        * */
       onChannelDeleted: PropTypes.func,
       /**
+       * Function that overrides default behaviour when channel gets hidden. In absence of this prop, channel will be removed from the list.
+       *
+       * @param {Component} thisArg Reference to ChannelList component
+       * @param {Event} event       [Event object](https://getstream.io/chat/docs/#event_object) corresponding to `channel.hidden` event
+       * */
+      onChannelHidden: PropTypes.func,
+      /**
        * Object containing query filters
        * @see See [Channel query documentation](https://getstream.io/chat/docs/#query_channels) for a list of available fields for filter.
        * */
@@ -347,7 +354,7 @@ const ChannelList = withChatContext(
 
           if (channelIndex < 0) return;
 
-          // Remove the deleted channel from the list.
+          // Remove the hidden channel from the list.
           channels.splice(channelIndex, 1);
           this.setState({
             channels: [...channels],

--- a/src/components/ChannelList.js
+++ b/src/components/ChannelList.js
@@ -333,6 +333,28 @@ const ChannelList = withChatContext(
     }
 
     handleEvent = async (e) => {
+      if (e.type === 'channel.hidden') {
+        if (
+          this.props.onChannelHidden &&
+          typeof this.props.onChannelHidden === 'function'
+        ) {
+          this.props.onChannelHidden(this, e);
+        } else {
+          const channels = this.state.channels;
+          const channelIndex = channels.findIndex(
+            (channel) => channel.cid === e.channel.cid,
+          );
+
+          if (channelIndex < 0) return;
+
+          // Remove the deleted channel from the list.
+          channels.splice(channelIndex, 1);
+          this.setState({
+            channels: [...channels],
+          });
+        }
+      }
+
       if (e.type === 'user.presence.changed' || e.type === 'user.updated') {
         let newChannels = this.state.channels;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -425,7 +425,7 @@ export interface ChannelListProps
   ): void;
   onChannelHidden?(
     thisArg: React.Component<ChannelListProps>,
-    e: Client.Event<Client.ChannelTruncatedEvent>,
+    e: Client.Event<Client.ChannelHiddenEvent>,
   ): void;
   // TODO: Create proper interface for followings in chat js client.
   /** Object containing query filters */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -423,6 +423,10 @@ export interface ChannelListProps
     thisArg: React.Component<ChannelListProps>,
     e: Client.Event<Client.ChannelTruncatedEvent>,
   ): void;
+  onChannelHidden?(
+    thisArg: React.Component<ChannelListProps>,
+    e: Client.Event<Client.ChannelTruncatedEvent>,
+  ): void;
   // TODO: Create proper interface for followings in chat js client.
   /** Object containing query filters */
   filters: object;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Checklist

- [x]  Channel gets removed from list when channel.hidden is received.
- [x] Introduce a new prop - **onChannelHidden**, which can be used to override default handler, similar to onMessageNew or onChannelTruncated
- [x] Add the new prop **onChannelHidden** to PropType list with little doc.
- [x] Include the new prop to typescript file
- [x] Fix documentation links

## Description of the pull request

This PR fixes #187 by handling the channel.hidden event. Unfortunately I can't test this right now but all I did is take the same method from the channel.deleted event so it should works.

I also fixed the documentation link in PropTypes.


