### PR TITLE
handleEvent fallback to state.threadMessages

### DIFF
--- a/src/components/ChannelInner.js
+++ b/src/components/ChannelInner.js
@@ -502,7 +502,9 @@ class ChannelInner extends PureComponent {
     let threadMessages = [];
     const threadState = {};
     if (this.state.thread) {
-      threadMessages = channel.state.threads[this.state.thread.id] || [];
+      threadMessages =
+        channel.state.threads[this.state.thread.id]
+        || this.state.threadMessages;
       threadState['threadMessages'] = threadMessages;
     }
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

When a socket connection is lost and recovered the channel.state.threads do not return in the initial reconnection. This resets thread messages to and empty array when you, for instance, background an app on Android for 30sec then pull it back up while still in the thread screen. If instead the fallback is the previous state of threadMessages, which defaults to an empty array and thus covers the current fallback, the messages are maintained through this recovery cycle.