### PR TITLE
Trim whitespace from image url in cards

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -137,5 +137,5 @@ export const makeImageCompatibleUrl = (url) => {
   let newUrl = url;
   if (url.indexOf('//') === 0) newUrl = 'https:' + url;
 
-  return newUrl;
+  return newUrl.trim();
 };


### PR DESCRIPTION
I noticed that occasionally the internal og scraper was adding some whitespace to the image urls, causing them not to show. so figured they should trim them so that they render correctly

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
