### PR TITLE
Bug fixes with message component

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -376,7 +376,7 @@ slack or whatsapp. In this example we are going to add name of the sender on top
 
 I can foresee different types of designs for this:
 
-## Sender's name on the very top of message bubble (above text container, attachments)
+### Sender's name on the very top of message bubble (above text container, attachments)
 
   In this case, we are going to override `MessageContent` component via prop to add
   the name of sender, right before MessageContent (which includes attachments and message text)

--- a/src/components/Attachment.js
+++ b/src/components/Attachment.js
@@ -41,7 +41,11 @@ export const Attachment = withMessageContentContext(
         groupStyle: PropTypes.oneOf(['single', 'top', 'middle', 'bottom']),
         /** Handler for long press event on attachment */
         onLongPress: PropTypes.func,
-
+        /**
+         * Provide any additional props for child `TouchableOpacity`.
+         * Please check docs for TouchableOpacity for supported props - https://reactnative.dev/docs/touchableopacity#props
+         */
+        additionalTouchableProps: PropTypes.object,
         /**
          * Custom UI component to display enriched url preview.
          * Deaults to https://github.com/GetStream/stream-chat-react-native/blob/master/src/components/Card.js

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -73,6 +73,11 @@ export const Card = withMessageContentContext(
         type: PropTypes.string,
         alignment: PropTypes.string,
         onLongPress: PropTypes.func,
+        /**
+         * Provide any additional props for child `TouchableOpacity`.
+         * Please check docs for TouchableOpacity for supported props - https://reactnative.dev/docs/touchableopacity#props
+         */
+        additionalTouchableProps: PropTypes.object,
         Header: PropTypes.oneOfType([PropTypes.node, PropTypes.elementType]),
         Cover: PropTypes.oneOfType([PropTypes.node, PropTypes.elementType]),
         Footer: PropTypes.oneOfType([PropTypes.node, PropTypes.elementType]),
@@ -113,6 +118,7 @@ export const Card = withMessageContentContext(
           type,
           alignment,
           onLongPress,
+          additionalTouchableProps,
           Header,
           Cover,
           Footer,
@@ -125,6 +131,7 @@ export const Card = withMessageContentContext(
             }}
             onLongPress={onLongPress}
             alignment={alignment}
+            {...additionalTouchableProps}
           >
             {Header && <Header {...this.props} />}
             {Cover && <Cover {...this.props} />}

--- a/src/components/FileAttachment.js
+++ b/src/components/FileAttachment.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import styled from '@stream-io/styled-components';
 
 import { AttachmentActions } from './AttachmentActions';
+import { withMessageContentContext } from '../context';
 
 const FileContainer = styled.View`
   display: flex;
@@ -56,40 +57,44 @@ const goToURL = (url) => {
   });
 };
 
-export const FileAttachment = ({
-  attachment,
-  actionHandler,
-  AttachmentFileIcon,
-  onLongPress,
-  alignment,
-  groupStyle,
-}) => (
-  <TouchableOpacity
-    onPress={() => {
-      goToURL(attachment.asset_url);
-    }}
-    onLongPress={onLongPress}
-  >
-    <FileContainer alignment={alignment} groupStyle={groupStyle}>
-      <AttachmentFileIcon
-        filename={attachment.title}
-        mimeType={attachment.mime_type}
-      />
-      <FileDetails>
-        <FileTitle ellipsizeMode="tail" numberOfLines={2}>
-          {attachment.title}
-        </FileTitle>
-        <FileSize>{attachment.file_size} KB</FileSize>
-      </FileDetails>
-    </FileContainer>
-    {attachment.actions && attachment.actions.length > 0 && (
-      <AttachmentActions
-        key={'key-actions-' + attachment.id}
-        {...attachment}
-        actionHandler={actionHandler}
-      />
-    )}
-  </TouchableOpacity>
+export const FileAttachment = withMessageContentContext(
+  ({
+    attachment,
+    actionHandler,
+    AttachmentFileIcon,
+    onLongPress,
+    alignment,
+    groupStyle,
+    additionalTouchableProps,
+  }) => (
+    <TouchableOpacity
+      onPress={() => {
+        goToURL(attachment.asset_url);
+      }}
+      onLongPress={onLongPress}
+      {...additionalTouchableProps}
+    >
+      <FileContainer alignment={alignment} groupStyle={groupStyle}>
+        <AttachmentFileIcon
+          filename={attachment.title}
+          mimeType={attachment.mime_type}
+        />
+        <FileDetails>
+          <FileTitle ellipsizeMode="tail" numberOfLines={2}>
+            {attachment.title}
+          </FileTitle>
+          <FileSize>{attachment.file_size} KB</FileSize>
+        </FileDetails>
+      </FileContainer>
+      {attachment.actions && attachment.actions.length > 0 && (
+        <AttachmentActions
+          key={'key-actions-' + attachment.id}
+          {...attachment}
+          actionHandler={actionHandler}
+        />
+      )}
+    </TouchableOpacity>
+  ),
 );
 
 FileAttachment.propTypes = {
@@ -111,6 +116,11 @@ FileAttachment.propTypes = {
   groupStyle: PropTypes.oneOf(['single', 'top', 'middle', 'bottom']),
   /** Handler for long press event on attachment */
   onLongPress: PropTypes.func,
+  /**
+   * Provide any additional props for child `TouchableOpacity`.
+   * Please check docs for TouchableOpacity for supported props - https://reactnative.dev/docs/touchableopacity#props
+   */
+  additionalTouchableProps: PropTypes.object,
   /**
    * Custom UI component for attachment icon for type 'file' attachment.
    * Defaults to and accepts same props as: https://github.com/GetStream/stream-chat-react-native/blob/master/src/components/FileIcon.js

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -70,6 +70,11 @@ class Gallery extends React.PureComponent {
       }),
     ),
     onLongPress: PropTypes.func,
+    /**
+     * Provide any additional props for child `TouchableOpacity`.
+     * Please check docs for TouchableOpacity for supported props - https://reactnative.dev/docs/touchableopacity#props
+     */
+    additionalTouchableProps: PropTypes.object,
     alignment: PropTypes.string,
   };
 
@@ -82,7 +87,7 @@ class Gallery extends React.PureComponent {
   }
 
   render() {
-    const { t } = this.props;
+    const { t, additionalTouchableProps } = this.props;
     if (!this.props.images || this.props.images.length === 0) return null;
 
     const images = [...this.props.images].map((i) => ({
@@ -100,6 +105,7 @@ class Gallery extends React.PureComponent {
               this.props.onLongPress();
             }}
             alignment={this.props.alignment}
+            {...additionalTouchableProps}
           >
             <Image
               style={{
@@ -160,6 +166,7 @@ class Gallery extends React.PureComponent {
                 });
               }}
               onLongPress={this.props.onLongPress}
+              {...additionalTouchableProps}
             >
               {i === 3 && images.length > 4 ? (
                 <View

--- a/src/components/MessageSimple/MessageContent.js
+++ b/src/components/MessageSimple/MessageContent.js
@@ -167,7 +167,9 @@ class MessageContent extends React.PureComponent {
      *    <MessageSimple
      *      {...props}
      *      onPress={(thisArg, message, e) => {
-     *        thisArg.openReactionSelector();
+     *        props.openReactionPicker();
+     *        // Or if you want to open actionsheet
+     *        // thisArg.showActionSheet();
      *      }}
      *  )
      * }
@@ -185,7 +187,9 @@ class MessageContent extends React.PureComponent {
     onPress: PropTypes.func,
     /**
      * Function that overrides default behaviour when message is long pressed
-     * e.g. if you would like to open reaction picker on message long press:
+     * e.g.
+     *
+     * if you would like to open reaction picker on message long press:
      *
      * ```
      * import { MessageSimple } from 'stream-chat-react-native' // or 'stream-chat-expo'
@@ -195,7 +199,9 @@ class MessageContent extends React.PureComponent {
      *    <MessageSimple
      *      {...props}
      *      onLongPress={(thisArg, message, e) => {
-     *        thisArg.openReactionSelector();
+     *        props.openReactionPicker();
+     *        // Or if you want to open actionsheet
+     *        // thisArg.showActionSheet();
      *      }}
      *  )
      * }
@@ -239,6 +245,11 @@ class MessageContent extends React.PureComponent {
      * e.g., user avatar (to which message belongs to) is only showed for last (bottom) message in group.
      */
     groupStyles: PropTypes.array,
+    /**
+     * Provide any additional props for `TouchableOpacity` which wraps `MessageContent` component here.
+     * Please check docs for TouchableOpacity for supported props - https://reactnative.dev/docs/touchableopacity#props
+     */
+    additionalTouchableProps: PropTypes.object,
     /**
      * Style object for actionsheet (used to message actions).
      * Supported styles: https://github.com/beefe/react-native-actionsheet/blob/master/lib/styles.js
@@ -418,11 +429,13 @@ class MessageContent extends React.PureComponent {
     await this.props.openReactionPicker();
   };
 
-  openReactionSelector = () => {
+  openReactionSelector = async () => {
     console.warn(
       'openReactionSelector has been deprecared and will be removed in next major release.' +
         'Please use this.props.openReactionPicker instead.',
     );
+
+    await this.props.openReactionPicker();
   };
 
   onActionPress = (action) => {
@@ -460,6 +473,7 @@ class MessageContent extends React.PureComponent {
       retrySendMessage,
       messageActions,
       groupStyles,
+      additionalTouchableProps,
       reactionsEnabled,
       getTotalReactionCount,
       repliesEnabled,
@@ -576,6 +590,7 @@ class MessageContent extends React.PureComponent {
       activeOpacity: 0.7,
       disabled: disabled || readOnly,
       hasReactions,
+      ...additionalTouchableProps,
     };
 
     if (message.status === 'failed')
@@ -584,6 +599,7 @@ class MessageContent extends React.PureComponent {
     const context = {
       onLongPress: contentProps.onLongPress,
       disabled: disabled || readOnly,
+      additionalTouchableProps,
     };
 
     return (

--- a/src/components/MessageSimple/index.js
+++ b/src/components/MessageSimple/index.js
@@ -280,6 +280,11 @@ export const MessageSimple = themed(
        * Supported styles: https://github.com/beefe/react-native-actionsheet/blob/master/lib/styles.js
        */
       actionSheetStyles: PropTypes.object,
+      /**
+       * Provide any additional props for `TouchableOpacity` which wraps inner MessageContent component here.
+       * Please check docs for TouchableOpacity for supported props - https://reactnative.dev/docs/touchableopacity#props
+       */
+      additionalTouchableProps: PropTypes.object,
       formatDate: PropTypes.func,
       /**
        * e.g.,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -133,6 +133,8 @@ export interface MessageContentContext
   extends React.Context<MessageContentContextValue> {}
 export interface MessageContentContextValue {
   onLongPress?: (event: GestureResponderEvent) => void;
+  disabled?: boolean;
+  additionalTouchableProps?: object;
 }
 
 //================================================================================================
@@ -716,6 +718,7 @@ export interface MessageUIComponentProps
   actionSheetStyles?: object;
   AttachmentFileIcon?: React.ElementType<FileIconUIComponentProps>;
   formatDate(date: string): string;
+  additionalTouchableProps?: object;
 }
 
 export interface MessageHeaderUIComponentProps
@@ -868,7 +871,9 @@ export interface CommandsItemProps extends StyledComponentProps {
   args: string;
   description: string;
 }
-export interface FileAttachmentProps extends StyledComponentProps {
+export interface FileAttachmentProps
+  extends MessageContentContextValue,
+    StyledComponentProps {
   /** The attachment to render */
   attachment: Client.Attachment;
   /**


### PR DESCRIPTION
 - Adding support for prop `additionalTouchableProps` in `MessageSimple` to allow adding additional prop to inner TouchableOpacity components
 - Same (additionalTouchableProps) prop gets forwarded to all inner components which has some touchable feedback attached such as Gallery, FileAttachment, etc

fixes https://github.com/GetStream/stream-chat-react-native/issues/186

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
