### PR TITLE
Adding setFlatListRef prop to ChannelList and MessageList

### DIFF
--- a/src/components/ChannelList.js
+++ b/src/components/ChannelList.js
@@ -135,6 +135,8 @@ const ChannelList = withChatContext(
        *
        * You can find list of all the available FlatList props here - https://facebook.github.io/react-native/docs/flatlist#props
        *
+       * **NOTE** Don't use `additionalFlatListProps` to get access to ref of flatlist. Use `setFlatListRef` instead.
+       *
        * e.g.
        * ```
        * <ChannelList
@@ -144,6 +146,16 @@ const ChannelList = withChatContext(
        * ```
        */
       additionalFlatListProps: PropTypes.object,
+      /**
+       * Use `setFlatListRef` to get access to ref to inner FlatList.
+       *
+       * e.g.
+       * <ChannelList
+       *  setFlatListRef={(ref) => {
+       *    // Use ref for your own good
+       *  }}
+       */
+      setFlatListRef: PropTypes.func,
     };
 
     static defaultProps = {

--- a/src/components/ChannelListMessenger.js
+++ b/src/components/ChannelListMessenger.js
@@ -61,6 +61,8 @@ const ChannelListMessenger = withChatContext(
        *
        * You can find list of all the available FlatList props here - https://facebook.github.io/react-native/docs/flatlist#props
        *
+       * **NOTE** Don't use `additionalFlatListProps` to get access to ref of flatlist. Use `setFlatListRef` instead.
+       *
        * e.g.
        * ```
        * <ChannelListMessenger
@@ -69,6 +71,16 @@ const ChannelListMessenger = withChatContext(
        * ```
        */
       additionalFlatListProps: PropTypes.object,
+      /**
+       * Use `setFlatListRef` to get access to ref to inner FlatList.
+       *
+       * e.g.
+       * <ChannelListMessenger
+       *  setFlatListRef={(ref) => {
+       *    // Use ref for your own good
+       *  }}
+       */
+      setFlatListRef: PropTypes.func,
     };
 
     static defaultProps = {
@@ -98,6 +110,9 @@ const ChannelListMessenger = withChatContext(
 
     renderChannels = () => (
       <FlatList
+        ref={(flRef) => {
+          this.props.setFlatListRef && this.props.setFlatListRef(flRef);
+        }}
         data={this.props.channels}
         onEndReached={this.props.loadNextPage}
         onEndReachedThreshold={this.props.loadMoreThreshold}

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -224,6 +224,8 @@ class MessageList extends PureComponent {
      *
      * You can find list of all the available FlatList props here - https://facebook.github.io/react-native/docs/flatlist#props
      *
+     * **NOTE** Don't use `additionalFlatListProps` to get access to ref of flatlist. Use `setFlatListRef` instead.
+     *
      * e.g.
      * ```
      * <MessageList
@@ -231,6 +233,16 @@ class MessageList extends PureComponent {
      * ```
      */
     additionalFlatListProps: PropTypes.object,
+    /**
+     * Use `setFlatListRef` to get access to ref to inner FlatList.
+     *
+     * e.g.
+     * <MessageList
+     *  setFlatListRef={(ref) => {
+     *    // Use ref for your own good
+     *  }}
+     */
+    setFlatListRef: PropTypes.func,
   };
 
   static defaultProps = {
@@ -623,7 +635,10 @@ class MessageList extends PureComponent {
           style={{ flex: 1, alignItems: 'center', width: '100%' }}
         >
           <ListContainer
-            ref={(fl) => (this.flatList = fl)}
+            ref={(fl) => {
+              this.flatList = fl;
+              this.props.setFlatListRef && this.props.setFlatListRef(fl);
+            }}
             data={messagesWithDates}
             onScroll={this.handleScroll}
             ListFooterComponent={HeaderComponent}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 // TypeScript Version: 2.8
 
 import * as React from 'react';
-import { Text, GestureResponderEvent } from 'react-native';
+import { Text, GestureResponderEvent, FlatList } from 'react-native';
 import * as Client from 'stream-chat';
 import * as SeamlessImmutable from 'seamless-immutable';
 import * as i18next from 'i18next';
@@ -435,7 +435,34 @@ export interface ChannelListProps
   /** Object containing sort parameters */
   sort?: object;
   loadMoreThreshold?: number;
+  /**
+   * Besides existing (default) UX behaviour of underlying flatlist of ChannelList component, if you want
+   * to attach some additional props to un derlying flatlist, you can add it to following prop.
+   *
+   * You can find list of all the available FlatList props here - https://facebook.github.io/react-native/docs/flatlist#props
+   *
+   * **NOTE** Don't use `additionalFlatListProps` to get access to ref of flatlist. Use `setFlatListRef` instead.
+   * e.g.
+   * ```
+   * <MessageList
+   *  filters={filters}
+   *  sort={sort}
+   *  additionalFlatListProps={{ bounces: true }} />
+   * ```
+   */
   additionalFlatListProps?: object;
+  /**
+   * Use `setFlatListRef` to get access to ref to inner FlatList.
+   *
+   * e.g.
+   * <MessageList
+   *  setFlatListRef={(ref) => {
+   *    // Use ref for your own good
+   *  }}
+   */
+  setFlatListRef?(
+    ref: React.RefObject<FlatList<Client.Channel>>,
+  ): PropTypes.func;
 }
 
 export interface ChannelListState {
@@ -530,7 +557,32 @@ export interface MessageListProps
   /** https://github.com/beefe/react-native-actionsheet/blob/master/lib/styles.js */
   actionSheetStyles?: object;
   AttachmentFileIcon?: React.ElementType<FileIconUIComponentProps>;
+  /**
+   * Besides existing (default) UX behaviour of underlying flatlist of ChannelList component, if you want
+   * to attach some additional props to un derlying flatlist, you can add it to following prop.
+   *
+   * You can find list of all the available FlatList props here - https://facebook.github.io/react-native/docs/flatlist#props
+   *
+   * **NOTE** Don't use `additionalFlatListProps` to get access to ref of flatlist. Use `setFlatListRef` instead.
+   * e.g.
+   * ```
+   * <MessageList
+   *  filters={filters}
+   *  sort={sort}
+   *  additionalFlatListProps={{ bounces: true }} />
+   * ```
+   */
   additionalFlatListProps?: object;
+  /**
+   * Use `setFlatListRef` to get access to ref to inner FlatList.
+   *
+   * e.g.
+   * <MessageList
+   *  setFlatListRef={(ref) => {
+   *    // Use ref for your own custom functionality
+   *  }}
+   */
+  setFlatListRef?(ref: React.RefObject<FlatList<object>>): void;
 }
 
 declare type MessageAction = 'edit' | 'delete' | 'reactions' | 'reply';


### PR DESCRIPTION
We already have additionalFlatList prop on ChannelList and MessageList which allows user to add any custom prop to inner flatlist. But this can not be used to set ref on flatlist, since it will override ref set by MessageList component, disrupting the original behavior. So instead `setFlatListRef` can be used instead to get access to ref.

Issue - https://github.com/GetStream/stream-chat-react-native/issues/201

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
