### PR TITLE
Disable "Save Image" functionality for multi-image Gallery

### DIFF
--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -232,6 +232,10 @@ class Gallery extends React.PureComponent {
           <SafeAreaView style={{ flex: 1, backgroundColor: 'transparent' }}>
             <ImageViewer
               imageUrls={images}
+              // TODO: We don't have 'save image' functionality.
+              // Until we do, lets disable this feature. saveToLocalByLongPress prop basically
+              // opens up popup menu to with an option "Save to the album", which basically does nothing.
+              saveToLocalByLongPress={false}
               onCancel={() => {
                 this.setState({ viewerModalOpen: false });
               }}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Due to Stream Chat not having "save image" functionality, that [functionality was disabled](https://github.com/GetStream/stream-chat-react-native/blob/master/src/components/Gallery.js#L132), but only for image galleries with one image. So, i'm also disabling for multi image gallery.