### PR TITLE
Add additionalTextInputProps? to MessageInputProps

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -289,6 +289,7 @@ export interface MessageInputProps
   AttachmentFileIcon?: React.ElementType<FileIconUIComponentProps>;
   AttachButton?: React.ElementType<AttachButtonProps>;
   SendButton: React.ElementType<SendButtonProps>;
+  additionalTextInputProps?: object;
 }
 
 export interface DocumentPickerFile {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

`MessageInput` component handles optional `additionalTextInputProps`, but it's not present on `MessgeInputProps`. So, I've added the type. 
