### PR TITLE
Better error handling in ChannelList

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "docs": "styleguidist build",
     "test": "jest",
     "docs-server": "styleguidist server",
-    "build-translations": "yarn run babel --config-file ./babel.i18next-extract.json 'src/**/*.{js,jsx,ts,tsx}' --quiet && yarn lint-fix",
+    "build-translations": "rm -rf .tmpi18ncache || true && mkdir .tmpi18ncache && yarn run babel --config-file ./babel.i18next-extract.json 'src/**/*.{js,jsx,ts,tsx}' --out-dir '.tmpi18ncache/' && rm -rf .tmpi18ncache && prettier --write 'src/i18n/*.{js,ts,md,json}' .eslintrc.json .prettierrc .babelrc",
     "prettier": "prettier --list-different '**/*.{js,ts,md,json}' .eslintrc.json .prettierrc .babelrc",
     "prettier-fix": "prettier --write '**/*.{js,ts,md,json}' .eslintrc.json .prettierrc .babelrc",
     "eslint": "eslint '**/*.{js,md}' --max-warnings 0",

--- a/src/components/ChannelListFooterLoadingIndicator.js
+++ b/src/components/ChannelListFooterLoadingIndicator.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import styled from '@stream-io/styled-components';
+import { Spinner } from './Spinner';
+
+const Container = styled.View`
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  ${({ theme }) => theme.channelListFooterLoadingIndicator.container.css}
+`;
+
+export const ChannelListFooterLoadingIndicator = () => (
+  <Container>
+    <Spinner />
+  </Container>
+);

--- a/src/components/ChannelListHeaderErrorIndicator.js
+++ b/src/components/ChannelListHeaderErrorIndicator.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from '@stream-io/styled-components';
+import { withTranslationContext } from '../context';
+import PropTypes from 'prop-types';
+
+const Container = styled.TouchableOpacity`
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  background-color: #fae6e8;
+  ${({ theme }) => theme.channelListHeaderErrorIndicator.container.css}
+`;
+
+const ErrorText = styled.Text`
+  color: red;
+  font-size: 12;
+  font-weight: bold;
+  padding: 3px;
+  ${({ theme }) => theme.channelListHeaderErrorIndicator.errorText.css}
+`;
+
+const ChannelListHeaderErrorIndicator = withTranslationContext(
+  ({ onPress, t }) => (
+    <Container
+      onPress={() => {
+        onPress && onPress();
+      }}
+    >
+      <ErrorText>{t('Error while loading, please reload/refresh')}</ErrorText>
+    </Container>
+  ),
+);
+
+ChannelListHeaderErrorIndicator.propTypes = {
+  onPress: PropTypes.func,
+};
+
+export { ChannelListHeaderErrorIndicator };

--- a/src/components/ChannelListHeaderNetworkDownIndicator.js
+++ b/src/components/ChannelListHeaderNetworkDownIndicator.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from '@stream-io/styled-components';
+import { withTranslationContext } from '../context';
+
+const Container = styled.View`
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  background-color: #fae6e8;
+  ${({ theme }) => theme.channelListHeaderErrorIndicator.container.css}
+`;
+
+const ErrorText = styled.Text`
+  color: red;
+  font-size: 12;
+  font-weight: bold;
+  padding: 3px;
+  ${({ theme }) => theme.channelListHeaderErrorIndicator.errorText.css}
+`;
+
+export const ChannelListHeaderNetworkDownIndicator = withTranslationContext(
+  ({ t }) => (
+    <Container>
+      <ErrorText>{t('Connection failure, reconnecting now ...')}</ErrorText>
+    </Container>
+  ),
+);

--- a/src/components/LoadingErrorIndicator.js
+++ b/src/components/LoadingErrorIndicator.js
@@ -1,19 +1,58 @@
 import React from 'react';
-import { Text } from 'react-native';
+import styled from '@stream-io/styled-components';
 import PropTypes from 'prop-types';
 import { withTranslationContext } from '../context';
 
-const LoadingErrorIndicator = ({ listType, t }) => {
+const Container = styled.TouchableOpacity`
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  ${({ theme }) => theme.loadingErrorIndicator.container.css}
+`;
+
+const ErrorText = styled.Text`
+  margin-top: 20px;
+  font-size: 14px;
+  font-weight: 600;
+  ${({ theme }) => theme.loadingErrorIndicator.errorText.css}
+`;
+
+const RetryText = styled.Text`
+  font-size: 30px;
+  font-weight: 600;
+  ${({ theme }) => theme.loadingErrorIndicator.retryText.css}
+`;
+
+const LoadingErrorIndicator = ({ listType, retry, t }) => {
   let Loader;
   switch (listType) {
     case 'channel':
-      Loader = <Text>{t('Error loading channel list ...')}</Text>;
+      Loader = (
+        <Container
+          onPress={() => {
+            retry && retry();
+          }}
+        >
+          <ErrorText>{t('Error loading channel list ...')}</ErrorText>
+          <RetryText>⟳</RetryText>
+        </Container>
+      );
       break;
     case 'message':
-      Loader = <Text>{t('Error loading messages for this channel ...')}</Text>;
+      Loader = (
+        <Container>
+          <ErrorText>
+            {t('Error loading messages for this channel ...')}
+          </ErrorText>
+        </Container>
+      );
       break;
     default:
-      Loader = <Text>{t('Error loading')}</Text>;
+      Loader = (
+        <Container>
+          <ErrorText>{t('Error loading')}</ErrorText>
+        </Container>
+      );
       break;
   }
 
@@ -22,6 +61,8 @@ const LoadingErrorIndicator = ({ listType, t }) => {
 
 LoadingErrorIndicator.propTypes = {
   listType: PropTypes.oneOf(['channel', 'message', 'default']),
+  // Calls the retry handler.
+  retry: PropTypes.func,
 };
 
 const LoadingErrorIndicatorWithContext = withTranslationContext(

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -5,7 +5,7 @@ import { themed } from '../styles/theme';
 
 const AnimatedView = Animated.createAnimatedComponent(View);
 
-const Circle = styled(AnimatedView)`
+export const Circle = styled(AnimatedView)`
   height: 30px;
   width: 30px;
   margin: 5px;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -17,7 +17,7 @@ export { Message } from './Message';
 export { MessageNotification } from './MessageNotification';
 export { MessageSystem } from './MessageSystem';
 export { ReactionList } from './ReactionList';
-export { Spinner } from './Spinner';
+export { Circle, Spinner } from './Spinner';
 export { SuggestionsProvider } from './SuggestionsProvider';
 export { UploadProgressIndicator } from './UploadProgressIndicator';
 export { Attachment } from './Attachment';

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -15,6 +15,7 @@
   "Error loading": "Error loading",
   "Error loading channel list ...": "Error loading channel list ...",
   "Error loading messages for this channel ...": "Error loading messages for this channel ...",
+  "Error while loading, please reload/refresh": "Error while loading, please reload/refresh",
   "Loading ...": "Loading ...",
   "Loading channels ...": "Loading channels ...",
   "Loading messages ...": "Loading messages ...",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -15,6 +15,7 @@
   "Error loading": "Erreur lors du chargement",
   "Error loading channel list ...": "Erreur lors du chargement de la liste de canaux",
   "Error loading messages for this channel ...": "Erreur lors du chargement des messages de ce canal",
+  "Error while loading, please reload/refresh": "Erreur lors du chargement, veuillez recharger/rafraîchir",
   "Loading ...": "Chargement ...",
   "Loading channels ...": "Chargement des canaux ...",
   "Loading messages ...": "Chargement des messages ...",

--- a/src/i18n/hi.json
+++ b/src/i18n/hi.json
@@ -15,6 +15,7 @@
   "Error loading": "लोड होने मे त्रुटि",
   "Error loading channel list ...": "चैनल सूची लोड करने में त्रुटि ...",
   "Error loading messages for this channel ...": "इस चैनल के लिए मेसेजेस लोड करने में त्रुटि हुई ...",
+  "Error while loading, please reload/refresh": "एरर, रिफ्रेश करे",
   "Loading ...": "लोड हो रहा है ...",
   "Loading channels ...": "चैनल लोड हो रहे हैं ...",
   "Loading messages ...": "मेसेजस लोड हो रहे हैं ...",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -15,6 +15,7 @@
   "Error loading": "Errore di caricamento",
   "Error loading channel list ...": "Errore durante il caricamento dei canali ...",
   "Error loading messages for this channel ...": "Errore durante il caricamento dei messaggi ...",
+  "Error while loading, please reload/refresh": "Errore durante il caricamento, trascina per ricaricare",
   "Loading ...": "Caricamento ...",
   "Loading channels ...": "Caricamento canali in corso ...",
   "Loading messages ...": "Caricamento messaggi ...",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -15,6 +15,7 @@
   "Error loading": "Probleem bij het laden",
   "Error loading channel list ...": "Probleem bij het laden van de kanalen",
   "Error loading messages for this channel ...": "Probleem bij het laden van de berichten in dit kanaal",
+  "Error while loading, please reload/refresh": "Probleem bij het laden, probeer opnieuw",
   "Loading ...": "Aan het laden ...",
   "Loading channels ...": "Kanalen aan het laden ...",
   "Loading messages ...": "Berichten aan het laden ...",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -15,6 +15,7 @@
   "Error loading": "Ошибка при загрузке",
   "Error loading channel list ...": "Ошибка загрузки списка каналов ...",
   "Error loading messages for this channel ...": "Ошибка загрузки сообщений для этого канала ...",
+  "Error while loading, please reload/refresh": "Ошибка загрузки, пожалуйста перезагрузите или обновите",
   "Loading ...": "Загружаю...",
   "Loading channels ...": "Загружаю каналы ...",
   "Loading messages ...": "Загружаю сообщения ...",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -15,6 +15,7 @@
   "Error loading": "Yükleme hatası",
   "Error loading channel list ...": "Kanal listesi yüklenirken hata oluştu ...",
   "Error loading messages for this channel ...": "Bu kanal için mesajlar yüklenirken hata oluştu ...",
+  "Error while loading, please reload/refresh": "Yüklenirken hata oluştu, lütfen tekrar deneyin",
   "Loading ...": "Yükleniyor ...",
   "Loading channels ...": "Kanallar yükleniyor ...",
   "Loading messages ...": "Mesajlar yükleniyor ...",

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -29,7 +29,22 @@ export const defaultTheme = {
     text: {},
     fallback: {},
   },
-
+  channelListHeaderErrorIndicator: {
+    container: {},
+    errorText: {},
+  },
+  channelListHeaderNetworkDownIndicator: {
+    container: {},
+    errorText: {},
+  },
+  channelListFooterLoadingIndicator: {
+    container: {},
+  },
+  loadingErrorIndicator: {
+    container: {},
+    errorText: {},
+    retryText: {},
+  },
   channelPreview: {
     container: {},
     details: {},

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -390,6 +390,27 @@ export interface ChannelListProps
   LoadingErrorIndicator?: React.ElementType<LoadingErrorIndicatorProps>;
   /** The indicator to use when channel list is empty */
   EmptyStateIndicator?: React.ElementType<EmptyStateIndicatorProps>;
+  /**
+   * The indicator to display network-down error at top of list, if there is connectivity issue
+   * Default: [ChannelListHeaderNetworkDownIndicator](https://getstream.github.io/stream-chat-react-native/#ChannelListHeaderNetworkDownIndicator)
+   */
+  HeaderNetworkDownIndicator?: React.ElementType<
+    ChannelListHeaderNetworkDownIndicatorProps
+  >;
+  /**
+   * The indicator to display error at top of list, if there was an error loading some page/channels after the first page.
+   * Default: [ChannelListHeaderErrorIndicator](https://getstream.github.io/stream-chat-react-native/#ChannelListHeaderErrorIndicator)
+   */
+  HeaderErrorIndicator?: React.ElementType<
+    ChannelListHeaderErrorIndicatorProps
+  >;
+  /**
+   * Loading indicator to display at bottom of the list, while loading further pages.
+   * Default: [ChannelListFooterLoadingIndicator](https://getstream.github.io/stream-chat-react-native/#ChannelListFooterLoadingIndicator)
+   */
+  FooterLoadingIndicator?: React.ElementType<
+    ChannelListFooterLoadingIndicatorProps
+  >;
 
   List?: React.ElementType<ChannelListUIComponentProps>;
 
@@ -486,8 +507,18 @@ export interface ChannelListUIComponentProps
   extends ChannelListProps,
     ChannelListState,
     StyledComponentProps {
+  reloadList(): void;
   loadNextPage(): void;
+  refreshList(): void;
 }
+
+export interface ChannelListHeaderNetworkDownIndicatorProps
+  extends TranslationContextValue {}
+export interface ChannelListHeaderErrorIndicatorProps
+  extends TranslationContextValue {
+  onPress?: () => void;
+}
+export interface ChannelListFooterLoadingIndicatorProps {}
 
 export interface ChannelPreviewProps
   extends ChannelListUIComponentProps,
@@ -997,6 +1028,7 @@ export interface LoadingErrorIndicatorProps
   extends StyledComponentProps,
     TranslationContextValue {
   listType?: listType;
+  retry?: () => void;
 }
 export interface LoadingIndicatorProps
   extends StyledComponentProps,
@@ -1252,6 +1284,18 @@ export class MessageTextContainer extends React.PureComponent<
 > {}
 
 export class ChannelList extends React.PureComponent<ChannelListProps, any> {}
+export class ChannelListHeaderErrorIndicator extends React.PureComponent<
+  ChannelListHeaderErrorIndicatorProps,
+  any
+> {}
+export class ChannelListHeaderNetworkDownIndicator extends React.PureComponent<
+  ChannelListHeaderNetworkDownIndicatorProps,
+  any
+> {}
+export class ChannelListFooterLoadingIndicator extends React.PureComponent<
+  ChannelListFooterLoadingIndicatorProps,
+  any
+> {}
 
 export class Thread extends React.PureComponent<ThreadProps, any> {}
 export class ChannelPreviewMessenger extends React.PureComponent<


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Tasks

- [X] Handle state updates properly. `setState` doesn't ensure immediate update of state, which was overlooked in this component. Going for following approach:

```js
setStateAsync = (newState) => {
    return new Promise((resolve) => {
        this.setState(newState, resolve);
    });
};
```

- [X] Retry the queryChannels api call 3 times in case of failure. And add the interval of 2 seconds between then, instead of hammering.

- [X] Add retry functionality/button on main error indicator. (Mostly everyone write their own error indicators according to their own design)

<img width="947" alt="Screenshot 2020-05-29 at 09 51 28" src="https://user-images.githubusercontent.com/11586388/83235339-01758e80-a192-11ea-9e35-653a3074b064.png">


- [X] Add pull to refresh functionality along with inline header error indicators. So far if some queryChannels api call for fetching n-th page failed, we used to wipe out the list and show the error indicator (from 2nd task) all over the screen. With current approach, user will still see the already fetched channels even if there was some error. He can simply pull to refresh to reload the list.

<img width="806" alt="Screenshot 2020-05-28 at 17 59 22" src="https://user-images.githubusercontent.com/11586388/83235416-236f1100-a192-11ea-97f4-4776576fed65.png">
<img width="806" alt="Screenshot 2020-05-28 at 17 59 40" src="https://user-images.githubusercontent.com/11586388/83235404-1eaa5d00-a192-11ea-9e43-85501d7470e9.png">

- [x] Translations for new messages
- [x] Typescript changes
