### PR TITLE
message input picker bug

### DIFF
--- a/src/components/MessageInput.js
+++ b/src/components/MessageInput.js
@@ -838,7 +838,7 @@ class MessageInput extends PureComponent {
                   break;
                 default:
               }
-            }, 10);
+            }, 201); // 201ms to fire after the animation is complete https://github.com/beefe/react-native-actionsheet/blob/master/lib/ActionSheetCustom.js#L78
           }}
           styles={this.props.actionSheetStyles}
         />


### PR DESCRIPTION
change action sheet onPress timeout from 10 ms to 201 because the animated timing of the actionsheet is 200ms leading to an animation firing after the image picker appears and causes the image picker render to be overridden

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
