### PR TITLE
Fixing Animated values on KeyboardCompatibleView

### DIFF
--- a/src/components/KeyboardCompatibleView.js
+++ b/src/components/KeyboardCompatibleView.js
@@ -42,7 +42,7 @@ export class KeyboardCompatibleView extends React.PureComponent {
     super(props);
 
     this.state = {
-      channelHeight: new Animated.Value('100%'),
+      channelHeight: new Animated.Value(0),
       // For some reason UI doesn't update sometimes, when state is updated using setValue.
       // So to force update the component, I am using following key, which will be incremented
       // for every keyboard slide up and down.
@@ -54,7 +54,7 @@ export class KeyboardCompatibleView extends React.PureComponent {
     // Following variable takes care of race condition between keyboardDidHide and keyboardDidShow.
     this._hidingKeyboardInProgress = false;
     this.rootChannelView = false;
-    this.initialHeight = undefined;
+    this.initialHeight = 0;
   }
 
   componentDidMount() {
@@ -100,7 +100,7 @@ export class KeyboardCompatibleView extends React.PureComponent {
        * adjust the view instead of having no difference in value to animate to
        */
       this.setState({ channelHeight: new Animated.Value(this.initialHeight) });
-      this.initialHeight = undefined;
+      this.initialHeight = 0;
       this.dismissKeyboard();
       this.removeKeyboardListeners();
       this.setState({ appState: nextAppState });


### PR DESCRIPTION
With react-native 0.63, came a runtime check on animated values - which disallowed anything other than pure numbers.

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
