### PR TITLE
CRNS-151: removing flex from view container to allow button to be clickable on android and ios and making android not crash from MessageInput

### DIFF
--- a/src/components/Attachment/Gallery.js
+++ b/src/components/Attachment/Gallery.js
@@ -55,7 +55,6 @@ const ImageContainer = styled.TouchableOpacity`
 `;
 
 const HeaderContainer = styled.View`
-  flex: 1;
   flex-direction: row;
   justify-content: flex-end;
   z-index: 1000;

--- a/src/components/MessageInput/MessageInput.js
+++ b/src/components/MessageInput/MessageInput.js
@@ -37,8 +37,10 @@ const Container = styled.View`
   border-radius: 10px;
   flex-direction: column;
   margin-horizontal: 10px;
-  padding-top: ${({ padding, theme }) =>
-    padding ? theme.messageInput.container.conditionalPadding : 0}px;
+  padding-top: ${({ imageUploads, theme }) =>
+    imageUploads && imageUploads.length
+      ? theme.messageInput.container.conditionalPadding
+      : 0}px;
   ${({ theme }) => theme.messageInput.container.css};
 `;
 
@@ -340,7 +342,7 @@ const MessageInput = (props) => {
     }
 
     return (
-      <Container padding={imageUploads && imageUploads.length > 0}>
+      <Container imageUploads={imageUploads}>
         {fileUploads && (
           <FileUploadPreview
             AttachmentFileIcon={AttachmentFileIcon}

--- a/src/components/MessageInput/__tests__/__snapshots__/MessageInput.test.js.snap
+++ b/src/components/MessageInput/__tests__/__snapshots__/MessageInput.test.js.snap
@@ -21,7 +21,7 @@ exports[`MessageInput should render MessageInput 1`] = `
       }
     >
       <View
-        padding={false}
+        imageUploads={Array []}
         style={
           Array [
             Object {

--- a/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -2063,7 +2063,7 @@ exports[`Thread should match thread snapshot 1`] = `
         </RCTScrollView>
       </View>
       <View
-        padding={false}
+        imageUploads={Array []}
         style={
           Array [
             Object {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

- CRNS-151: removing flex from view container to allow button to be clickable on android and ios and making android not crash from MessageInput