### PR TITLE
Enable default MessageSystem to take in formatDate props

### DIFF
--- a/src/components/MessageList/MessageSystem.js
+++ b/src/components/MessageList/MessageSystem.js
@@ -46,7 +46,11 @@ const DateText = styled.Text`
  * they can attach a message with that update. That message will be available
  * in message list as (type) system message.
  */
-const MessageSystem = ({ message }) => {
+const MessageSystem = (props) => {
+  const {
+    message,
+    formatDate,
+  } = props;
   const { tDateTimeParser } = useContext(TranslationContext);
   return (
     <Container testID='message-system'>
@@ -54,9 +58,13 @@ const MessageSystem = ({ message }) => {
       <TextContainer>
         <Text>{message.text.toUpperCase()}</Text>
         <DateText>
-          {tDateTimeParser(message.created_at)
+          {formatDate ? (
+            formatDate(message.date)
+          ) : (
+            tDateTimeParser(message.created_at)
             .calendar()
-            .toUpperCase()}
+            .toUpperCase()
+          )}
         </DateText>
       </TextContainer>
       <Line />
@@ -67,6 +75,13 @@ const MessageSystem = ({ message }) => {
 MessageSystem.propTypes = {
   /** Current [message object](https://getstream.io/chat/docs/#message_format) */
   message: PropTypes.object.isRequired,
+  /**
+   * Formatter function for date object.
+   *
+   * @param date Date object of message
+   * @returns string
+   */
+  formatDate: PropTypes.func,
 };
 
 export default MessageSystem;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA]
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

`MessageList` allows the format of the date messages to be customized via a custom  `DateSeparator` with its own `formatDate` function, but the default `MessageSystem` component doesn't. This PR enables `formatDate` to be passed into the default `MessageSystem` component.

Granted, neither `MessageSystem` nor `DateSeparator` components are hard to write from scratch anyways, so I understand if you don't want to bloat the default `MessageSystem`, but I do think that being consistent about the date formatting of the two default props is a nice touch. Let me know what you think.
