### PR TITLE
Reload channel upon connection.changed

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -393,6 +393,11 @@ export const Channel = <
     // The more complex sync logic is done in Chat.js
     // listen to client.connection.recovered and all channel events
     client.on('connection.recovered', handleEvent);
+    client.on('connection.changed', (e) => {
+      if (e.online) {
+        reloadChannel();
+      }
+    });
     channel?.on(handleEvent);
   };
 
@@ -415,6 +420,21 @@ export const Channel = <
     if (!initError) {
       copyChannelState();
       listenToChanges();
+    }
+  };
+
+  const reloadChannel = async () => {
+    setError(false);
+    if (channel && channel.cid) {
+      try {
+        await channel.watch();
+      } catch (err) {
+        setError(err);
+        return;
+      }
+
+      setLastRead(new Date());
+      copyChannelState();
     }
   };
 


### PR DESCRIPTION
Related to - https://github.com/GetStream/stream-chat-react-native/issues/494

v2.2.1 fixed the issue on reloading the ChannelList in case of connection.changed event. Although it skipped following two cases
- If user is on Channel screen, the updated messages will reflect on ChannelList, but not on Channel component. This is because there no way for Channel component to know when ChannelList has refreshed.
- If app has standalone Channel component.

These two scenarios have been covered here.

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
