### PR TITLE
Reuse expensive merge in theme

### DIFF
--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   FlatListProps,
@@ -42,6 +42,7 @@ import {
   useThreadContext,
 } from '../../contexts/threadContext/ThreadContext';
 import {
+  mergeThemes,
   ThemeProvider,
   useTheme,
 } from '../../contexts/themeContext/ThemeContext';
@@ -295,12 +296,17 @@ const MessageListWithContext = <
     TypingIndicatorContainer,
   } = props;
 
+  const { theme } = useTheme();
+
   const {
-    theme: {
-      colors: { accent_blue, white_snow },
-      messageList: { container, listContainer },
-    },
-  } = useTheme();
+    colors: { accent_blue, white_snow },
+    messageList: { container, listContainer },
+  } = theme;
+
+  const modifiedTheme = useMemo(
+    () => mergeThemes({ style: myMessageTheme, theme }),
+    [theme, myMessageTheme],
+  );
 
   const messageList = useMessageList<At, Ch, Co, Ev, Me, Re, Us>({
     inverted,
@@ -507,7 +513,7 @@ const MessageListWithContext = <
       if (wrapMessageInTheme) {
         return (
           <>
-            <ThemeProvider style={myMessageTheme}>
+            <ThemeProvider mergedStyle={modifiedTheme}>
               <Message
                 goToMessage={goToMessage}
                 groupStyles={

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -305,7 +305,7 @@ const MessageListWithContext = <
 
   const modifiedTheme = useMemo(
     () => mergeThemes({ style: myMessageTheme, theme }),
-    [theme, myMessageTheme],
+    [myMessageTheme, theme],
   );
 
   const messageList = useMessageList<At, Ch, Co, Ev, Me, Re, Us>({

--- a/src/components/MessageOverlay/MessageOverlay.tsx
+++ b/src/components/MessageOverlay/MessageOverlay.tsx
@@ -178,7 +178,7 @@ const MessageOverlayWithContext = <
 
   const modifiedTheme = useMemo(
     () => mergeThemes({ style: myMessageTheme, theme }),
-    [theme, myMessageThemeString],
+    [myMessageThemeString, theme],
   );
 
   const scrollViewRef = useRef<ScrollView>(null);

--- a/src/contexts/themeContext/ThemeContext.tsx
+++ b/src/contexts/themeContext/ThemeContext.tsx
@@ -41,7 +41,7 @@ export const ThemeProvider: React.FC<ThemeProviderInputValue> = (props) => {
     }
 
     return mergeThemes({ style, theme });
-  }, [theme, style, mergedStyle]);
+  }, [mergedStyle, style, theme]);
 
   return (
     <ThemeContext.Provider value={modifiedTheme}>

--- a/src/contexts/themeContext/ThemeContext.tsx
+++ b/src/contexts/themeContext/ThemeContext.tsx
@@ -8,26 +8,40 @@ export type DeepPartial<T> = {
 };
 
 export type ThemeProviderInputValue = {
+  mergedStyle?: Theme;
   style?: DeepPartial<Theme>;
+};
+
+export type MergedThemesParams = {
+  style?: DeepPartial<Theme>;
+  theme?: Theme;
+};
+
+export const mergeThemes = (params: MergedThemesParams) => {
+  const { style, theme } = params;
+  const finalTheme = (!theme || Object.keys(theme).length === 0
+    ? JSON.parse(JSON.stringify(defaultTheme))
+    : JSON.parse(JSON.stringify(theme))) as Theme;
+
+  if (style) {
+    merge(finalTheme, style);
+  }
+
+  return finalTheme;
 };
 
 export const ThemeContext = React.createContext({} as Theme);
 
 export const ThemeProvider: React.FC<ThemeProviderInputValue> = (props) => {
-  const { children, style } = props;
+  const { children, mergedStyle, style } = props;
   const { theme } = useTheme();
   const modifiedTheme = useMemo(() => {
-    const finalTheme =
-      Object.keys(theme).length === 0
-        ? JSON.parse(JSON.stringify(defaultTheme))
-        : JSON.parse(JSON.stringify(theme));
-
-    if (style) {
-      merge(finalTheme, style);
+    if (mergedStyle) {
+      return mergedStyle;
     }
 
-    return finalTheme;
-  }, [theme, style]);
+    return mergeThemes({ style, theme });
+  }, [theme, style, mergedStyle]);
 
   return (
     <ThemeContext.Provider value={modifiedTheme}>


### PR DESCRIPTION
This PR build's on @vishalnarkhede previous theme improvement to further reduce the number of merge's / lodash calls made. I introduced a new prop to ThemeProvider that instead of performing a merge uses the Theme directly, for messages and overlay this allows for reuse of the current theme. Essentially all theme merges should now only happen once or when a change occurs instead.
