### PR TITLE
CRNS-283: Allow uninitialized channel on Channel component

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -545,10 +545,26 @@ const ChannelWithContext = <
 
   const channelId = channel?.id || '';
   useEffect(() => {
-    if (channel) {
+    const initChannel = () => {
+      if (!channel) return;
+
+      /**
+       * Loading channel at first unread message  requires channel to be initialized in the first place,
+       * since we use read state on channel to decide what offset to load channel at.
+       * Also there is no usecase from UX perspective, why one would need loading uninitialized channel at particular message.
+       * If the channel is not initiated, then we need to do channel.watch, which is more expensive for backend than channel.query.
+       */
+      if (!channel.initialized) {
+        loadChannel();
+        return;
+      }
+
       if (messageId) {
         loadChannelAtMessage({ messageId });
-      } else if (
+        return;
+      }
+
+      if (
         initialScrollToFirstUnreadMessage &&
         channel.countUnread() > scrollToFirstUnreadThreshold
       ) {
@@ -556,7 +572,9 @@ const ChannelWithContext = <
       } else {
         loadChannel();
       }
-    }
+    };
+
+    initChannel();
 
     return () => {
       client.off('connection.recovered', handleEvent);

--- a/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/src/components/ChannelPreview/ChannelPreview.tsx
@@ -65,6 +65,7 @@ const ChannelPreviewWithContext = <
   const [lastMessage, setLastMessage] = useState<
     | ReturnType<ChannelState<At, Ch, Co, Ev, Me, Re, Us>['formatMessage']>
     | MessageResponse<At, Ch, Co, Me, Re, Us>
+    | undefined
   >(channel.state.messages[channel.state.messages.length - 1]);
   const [forceUpdate, setForceUpdate] = useState(0);
   const [unread, setUnread] = useState(channel.countUnread());
@@ -80,8 +81,8 @@ const ChannelPreviewWithContext = <
   useEffect(() => {
     if (
       channelLastMessage &&
-      (channelLastMessage.id !== lastMessage.id ||
-        channelLastMessage.updated_at !== lastMessage.updated_at)
+      (channelLastMessage.id !== lastMessage?.id ||
+        channelLastMessage.updated_at !== lastMessage?.updated_at)
     ) {
       setLastMessage(channelLastMessage);
     }

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -347,7 +347,11 @@ const MessageListWithContext = <
 
   const [stickyHeaderDate, setStickyHeaderDate] = useState<Date>(new Date());
   const stickyHeaderDateRef = useRef(new Date());
-
+  /**
+   * channel.lastRead throws error if the channel is not initialized.
+   */
+  const getLastReadSafely = () =>
+    channel?.initialized ? channel.lastRead() : undefined;
   /**
    * We need topMessage and channelLastRead values to set the initial scroll position.
    * So these values only get used if `initialScrollToFirstUnreadMessage` prop is true.
@@ -355,13 +359,15 @@ const MessageListWithContext = <
   const topMessage = useRef<
     MessageType<At, Ch, Co, Ev, Me, Re, Us> | undefined
   >(messageList[messageListLength - 1] || undefined);
-  const channelLastRead = useRef(channel?.lastRead());
+  const channelLastRead = useRef(getLastReadSafely());
 
   const viewableMessages = useRef<string[]>([]);
 
   const isUnreadMessage = (
     message: MessageType<At, Ch, Co, Ev, Me, Re, Us> | undefined,
-    lastRead: ReturnType<StreamChannel<At, Ch, Co, Ev, Me, Re, Us>['lastRead']>,
+    lastRead?: ReturnType<
+      StreamChannel<At, Ch, Co, Ev, Me, Re, Us>['lastRead']
+    >,
   ) =>
     message && lastRead && message.created_at && lastRead < message.created_at;
 
@@ -495,7 +501,7 @@ const MessageListWithContext = <
      * OR if the scroll is already set.
      */
     if (initialScrollToFirstUnreadMessage && !initialScrollSet.current) {
-      channelLastRead.current = channel?.lastRead();
+      channelLastRead.current = getLastReadSafely();
       topMessage.current = messageList[messageListLength - 1];
     }
   }, [messageListLength]);
@@ -515,9 +521,9 @@ const MessageListWithContext = <
     index: number;
     item: MessageType<At, Ch, Co, Ev, Me, Re, Us>;
   }) => {
-    if (!channel) return null;
+    if (!channel || !channel.initialized) return null;
 
-    const lastRead = channel?.lastRead();
+    const lastRead = getLastReadSafely();
 
     const lastMessage = messageList?.[index + 1];
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

- We used to allow un-initialized `channel` as prop on Channel component in v2. Just making sure in this PR, that we still do.
- `ChannelPreview` breaks if you send message on channel with no messages. Fixed that issue.
