### PR TITLE
Ensure context update, when channel is changed

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -1467,6 +1467,7 @@ const ChannelWithContext = <
     additionalTextInputProps,
     AttachButton,
     autoCompleteTriggerSettings,
+    channelId,
     clearEditingState,
     clearQuotedMessageState,
     CommandsButton,
@@ -1497,6 +1498,7 @@ const ChannelWithContext = <
   });
 
   const messageListContext = useCreatePaginatedMessageListContext({
+    channelId,
     hasMore,
     loadingMore: loadingMoreProp !== undefined ? loadingMoreProp : loadingMore,
     loadingMoreRecent:
@@ -1520,6 +1522,7 @@ const ChannelWithContext = <
     CardCover,
     CardFooter,
     CardHeader,
+    channelId,
     copyMessage,
     DateHeader,
     deleteMessage,

--- a/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
+++ b/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
@@ -24,6 +24,7 @@ export const useCreateInputMessageInputContext = <
   additionalTextInputProps,
   AttachButton,
   autoCompleteTriggerSettings,
+  channelId,
   clearEditingState,
   clearQuotedMessageState,
   CommandsButton,
@@ -53,7 +54,12 @@ export const useCreateInputMessageInputContext = <
   ShowThreadMessageInChannelButton,
   UploadProgressIndicator,
   uploadsEnabled,
-}: InputMessageInputContextValue<At, Ch, Co, Ev, Me, Re, Us>) => {
+}: InputMessageInputContextValue<At, Ch, Co, Ev, Me, Re, Us> & {
+  /**
+   * To ensure we allow re-render, when channel is changed
+   */
+  channelId?: string;
+}) => {
   const editingExists = !!editing;
   const quotedMessageId = quotedMessage
     ? typeof quotedMessage === 'boolean'
@@ -106,6 +112,7 @@ export const useCreateInputMessageInputContext = <
     }),
     [
       compressImageQuality,
+      channelId,
       editingExists,
       initialValue,
       maxMessageLength,

--- a/src/components/Channel/hooks/useCreateMessagesContext.ts
+++ b/src/components/Channel/hooks/useCreateMessagesContext.ts
@@ -29,6 +29,7 @@ export const useCreateMessagesContext = <
   CardCover,
   CardFooter,
   CardHeader,
+  channelId,
   copyMessage,
   DateHeader,
   deleteMessage,
@@ -95,7 +96,12 @@ export const useCreateMessagesContext = <
   TypingIndicatorContainer,
   updateMessage,
   UrlPreview,
-}: MessagesContextValue<At, Ch, Co, Ev, Me, Re, Us>) => {
+}: MessagesContextValue<At, Ch, Co, Ev, Me, Re, Us> & {
+  /**
+   * To ensure we allow re-render, when channel is changed
+   */
+  channelId?: string;
+}) => {
   const additionalTouchablePropsLength = Object.keys(
     additionalTouchableProps || {},
   ).length;
@@ -190,6 +196,7 @@ export const useCreateMessagesContext = <
     }),
     [
       additionalTouchablePropsLength,
+      channelId,
       disableTypingIndicator,
       dismissKeyboardOnMessageTouch,
       initialScrollToFirstUnreadMessage,

--- a/src/components/Channel/hooks/useCreatePaginatedMessageListContext.ts
+++ b/src/components/Channel/hooks/useCreatePaginatedMessageListContext.ts
@@ -21,6 +21,7 @@ export const useCreatePaginatedMessageListContext = <
   Re extends UnknownType = DefaultReactionType,
   Us extends UnknownType = DefaultUserType
 >({
+  channelId,
   hasMore,
   loadingMore,
   loadingMoreRecent,
@@ -29,7 +30,9 @@ export const useCreatePaginatedMessageListContext = <
   messages,
   setLoadingMore,
   setLoadingMoreRecent,
-}: PaginatedMessageListContextValue<At, Ch, Co, Ev, Me, Re, Us>) => {
+}: PaginatedMessageListContextValue<At, Ch, Co, Ev, Me, Re, Us> & {
+  channelId?: string;
+}) => {
   const messagesUpdated = messages
     .map(
       ({ deleted_at, latest_reactions, reply_count, status, updated_at }) =>
@@ -60,7 +63,7 @@ export const useCreatePaginatedMessageListContext = <
       setLoadingMore,
       setLoadingMoreRecent,
     }),
-    [hasMore, loadingMoreRecent, loadingMore, messagesUpdated],
+    [channelId, hasMore, loadingMoreRecent, loadingMore, messagesUpdated],
   );
 
   return paginatedMessagesContext;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

- All the internal methods such as `sendMessage`, `updateMessage`, `loadMore` carry reference to old channel, after channel switch. To avoid this, add channelId as extra check on memoization of messagesContext and 