### PR TITLE
fix image picker not loading when swapping from keyboard

### DIFF
--- a/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -279,15 +279,19 @@ export const AttachmentPicker = React.forwardRef(
           setHasNextPage(true);
         }
       }
+    }, [currentIndex]);
+
+    useEffect(() => {
       if (
         selectedPicker === 'images' &&
         endCursor === undefined &&
-        currentIndex > -1
+        currentIndex > -1 &&
+        !loadingPhotos
       ) {
         setPhotoError(false);
         getMorePhotos();
       }
-    }, [currentIndex]);
+    }, [currentIndex, selectedPicker]);
 
     const selectedPhotos = photos.map((asset) => ({
       asset,


### PR DESCRIPTION
Fixes images not loading in picker when switching from keyboard on first load.