### PR TITLE
FIX - Close image picker on unmount

### DIFF
--- a/src/components/MessageInput/MessageInput.tsx
+++ b/src/components/MessageInput/MessageInput.tsx
@@ -248,17 +248,17 @@ const MessageInputWithContext = <
   } = useAttachmentPickerContext();
 
   /**
-   * Mounting and un-mounting logic are un-related in following useEffect.
    * While mounting we want to pass maxNumberOfFiles (which is prop on Channel component)
    * to AttachmentPicker (on OverlayProvider)
-   *
-   * While un-mounting, we want to close the picker e.g., while navigating away.
    */
   useEffect(() => {
     setMaxNumberOfFiles(maxNumberOfFiles ?? 10);
-
-    return closeAttachmentPicker;
   }, []);
+
+  /**
+   * While un-mounting, we want to close the picker e.g., while navigating away.
+   */
+  useEffect(() => closeAttachmentPicker, [closeAttachmentPicker]);
 
   const selectedImagesLength = selectedImages.length;
   const imageUploadsLength = imageUploads.length;

--- a/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -579,8 +579,8 @@ export const MessageInputProvider = <
   const closeAttachmentPicker = () => {
     if (selectedPicker) {
       setSelectedPicker(undefined);
-      closePicker();
     }
+    closePicker();
   };
 
   const toggleAttachmentPicker = () => {

--- a/src/contexts/messageInputContext/hooks/useCreateMessageInputContext.ts
+++ b/src/contexts/messageInputContext/hooks/useCreateMessageInputContext.ts
@@ -202,7 +202,6 @@ export const useCreateMessageInputContext = <
       uploadsEnabled,
     }),
     [
-      sendThreadMessageInChannel,
       editingExists,
       fileUploadsValue,
       giphyActive,
@@ -211,6 +210,7 @@ export const useCreateMessageInputContext = <
       mentionedUsersLength,
       quotedMessageId,
       selectedPicker,
+      sendThreadMessageInChannel,
       showMoreOptions,
       text,
       threadId,


### PR DESCRIPTION
Image picker close function was changed resulting in a change being needed elsewhere to maintain functionality