### PR TITLE
Provide dismissOverlay function as param to messageActions prop

### DIFF
--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -945,7 +945,7 @@ const MessageWithContext = <
         };
 
     const isThreadMessage = threadList || !!message.parent_id;
-
+    const dismissOverlay = () => setOverlay('none');
     const messageActions =
       typeof messageActionsProp !== 'function'
         ? messageActionsProp
@@ -954,6 +954,7 @@ const MessageWithContext = <
             canModifyMessage,
             copyMessage,
             deleteMessage,
+            dismissOverlay,
             editMessage,
             error,
             flagMessage,

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -945,7 +945,9 @@ const MessageWithContext = <
         };
 
     const isThreadMessage = threadList || !!message.parent_id;
+
     const dismissOverlay = () => setOverlay('none');
+
     const messageActions =
       typeof messageActionsProp !== 'function'
         ? messageActionsProp

--- a/src/contexts/messagesContext/MessagesContext.tsx
+++ b/src/contexts/messagesContext/MessagesContext.tsx
@@ -450,6 +450,7 @@ export type MessagesContextValue<
         canModifyMessage,
         copyMessage,
         deleteMessage,
+        dismissOverlay,
         editMessage,
         error,
         flagMessage,
@@ -468,6 +469,7 @@ export type MessagesContextValue<
         canModifyMessage: boolean;
         copyMessage: MessageAction | null;
         deleteMessage: MessageAction | null;
+        dismissOverlay: () => void;
         editMessage: MessageAction | null;
         error: boolean;
         flagMessage: MessageAction | null;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Without access to `dismissOverlay`, user won't be able to dismiss the overlay if he wants to add some custom action. This should be probably provided in other props as well such as editMessage, deleteMessage. Have added a story to backlog for that - https://stream-io.atlassian.net/browse/CRNS-356
