### PR TITLE
CRNS-325: Treat images from file picker as files

### DIFF
--- a/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -612,7 +612,14 @@ export const MessageInputProvider = <
         const mimeType = lookup(doc.name);
 
         if (mimeType && mimeType?.startsWith('image/')) {
-          uploadNewImage(doc);
+          /**
+           * TODO: The current tight coupling of images to the image
+           * picker does not allow images picked from the file picker
+           * to be rendered in a preview via the uploadNewImage call.
+           * This should be updated alongside allowing image a file
+           * uploads together.
+           */
+          uploadNewFile(doc);
         } else {
           uploadNewFile(doc);
         }


### PR DESCRIPTION
Images from the file picker need to be treated as files for the time being until we alter the single use scenario currently in place
