### PR TITLE
chore(deps): remove expo-permissions

### DIFF
--- a/docusaurus/docs/ReactNative/Basics/getting_started.mdx
+++ b/docusaurus/docs/ReactNative/Basics/getting_started.mdx
@@ -132,5 +132,5 @@ Stream Chat React Native is set up for parity on Expo, expo requires a different
 
 ```bash
 expo install stream-chat-expo
-expo install @react-native-community/netinfo expo-blur expo-document-picker expo-file-system expo-haptics expo-image-manipulator expo-image-picker expo-media-library expo-permissions expo-sharing react-native-gesture-handler react-native-reanimated react-native-safe-area-context react-native-svg`
+expo install @react-native-community/netinfo expo-blur expo-document-picker expo-file-system expo-haptics expo-image-manipulator expo-image-picker expo-media-library expo-sharing react-native-gesture-handler react-native-reanimated react-native-safe-area-context react-native-svg`
 ```


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Remove expo-permission to avoid warning on Expo v41:
```
expo-permissions is now deprecated — the functionality has been moved to other expo packages that directly use these permissions (e.g. expo-location, expo-camera). The package will be removed in the upcoming releases
```

I also remove support for the old version of `@react-native-community/netinfo`. Because it can't work on the new version of Expo.