### PR TITLE
fix: Channel concurrency fixes

### DIFF
--- a/docusaurus/docs/reactnative/basics/hello_stream_chat.mdx
+++ b/docusaurus/docs/reactnative/basics/hello_stream_chat.mdx
@@ -425,7 +425,7 @@ export const App = () => {
     <OverlayProvider>
       <Chat client={client}>
         {channel ? (
-          <Channel channel={channel} keyboardVerticalOffset={0} thread={thread}>
+          <Channel channel={channel} keyboardVerticalOffset={0} thread={thread} threadList={!!thread}>
             {thread ? (
               <Thread />
             ) : (
@@ -540,7 +540,7 @@ export const App = () => {
       <View style={{ flex: 1 }}>
         <Chat client={client}>
           {channel ? (
-            <Channel channel={channel} keyboardVerticalOffset={60} thread={thread}>
+            <Channel channel={channel} keyboardVerticalOffset={60} thread={thread} threadList={!!thread}>
               {thread ? (
                 <Thread />
               ) : (

--- a/docusaurus/docs/reactnative/basics/stream_chat_with_navigation.mdx
+++ b/docusaurus/docs/reactnative/basics/stream_chat_with_navigation.mdx
@@ -242,7 +242,7 @@ export const ThreadScreen = () => {
   const { setThread, thread } = useAppThread();
 
   return (
-    <Channel channel={channel} thread={thread}>
+    <Channel channel={channel} thread={thread} threadList>
       <Thread onThreadDismount={() => setThread(undefined)} />
     </Channel>
   );

--- a/docusaurus/docs/reactnative/basics/troubleshooting.mdx
+++ b/docusaurus/docs/reactnative/basics/troubleshooting.mdx
@@ -30,7 +30,7 @@ We suggest you keep track of a `thread` state on your own and provide it to any 
 
 ```tsx {2}
 <Chat client={chatClient} i18nInstance={streami18n}>
-  <Channel channel={channel} thread={thread}>
+  <Channel channel={channel} thread={thread} threadList>
     <Thread onThreadDismount={() => setThread(null)} />
   </Channel>
 </Chat>
@@ -73,7 +73,7 @@ To do this make sure your `Channel` components are always aware of the thread st
 ```
 
 ```tsx
-<Channel channel={channel} thread={thread}>
+<Channel channel={channel} thread={thread} threadList>
   <Thread onThreadDismount={() => setThread(null)} />
 </Channel>
 ```

--- a/docusaurus/docs/reactnative/common-content/core-components/channel/props/thread_list.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/channel/props/thread_list.mdx
@@ -1,0 +1,6 @@
+Tells the Channel component if it is rendering a thread. We use this flag to avoid concurrency problems between a 
+regular channel and a channel containing a thread.
+
+| Type |
+| - |
+| boolean |

--- a/docusaurus/docs/reactnative/core-components/channel.mdx
+++ b/docusaurus/docs/reactnative/core-components/channel.mdx
@@ -111,6 +111,7 @@ import SendButton from '../common-content/core-components/channel/props/send_but
 import ShowThreadMessageInChannelButton from '../common-content/core-components/channel/props/show_thread_message_in_channel_button.mdx'
 import SupportedReactions from '../common-content/core-components/channel/props/supported_reactions.mdx';
 import Thread from '../common-content/core-components/channel/props/thread.mdx'
+import ThreadList from '../common-content/core-components/channel/props/thread_list.mdx';
 import ThreadRepliesEnabled from '../common-content/core-components/channel/props/thread_replies_enabled.mdx'
 import ThreadReply from '../common-content/core-components/channel/props/thread_reply.mdx';
 import TypingEventsEnabled from '../common-content/core-components/channel/props/typing_events_enabled.mdx'
@@ -662,6 +663,10 @@ Callback function to set the [ref](https://reactjs.org/docs/refs-and-the-dom.htm
 ### thread
 
 <Thread />
+
+## threadList
+
+<ThreadList />
 
 ### threadReply
 

--- a/docusaurus/docs/reactnative/ui-components/thread.mdx
+++ b/docusaurus/docs/reactnative/ui-components/thread.mdx
@@ -18,7 +18,7 @@ Component to render thread replies for a message, along with and input box for a
 ```tsx
 <OverlayProvider>
   <Chat client={client}>
-    <Channel channel={channel} thread={messageId}>
+    <Channel channel={channel} thread={messageId} threadList>
       <Thread />
     </Channel>
   </Chat>

--- a/examples/ExpoMessaging/App.js
+++ b/examples/ExpoMessaging/App.js
@@ -105,7 +105,7 @@ const ThreadScreen = () => {
   return (
     <SafeAreaView>
       <Chat client={chatClient} i18nInstance={streami18n}>
-        <Channel channel={channel} keyboardVerticalOffset={headerHeight} thread={thread}>
+        <Channel channel={channel} keyboardVerticalOffset={headerHeight} thread={thread} threadList>
           <View
             style={{
               flex: 1,

--- a/examples/NativeMessaging/App.js
+++ b/examples/NativeMessaging/App.js
@@ -104,7 +104,7 @@ const ThreadScreen = () => {
   return (
     <SafeAreaView>
       <Chat client={chatClient} i18nInstance={streami18n}>
-        <Channel channel={channel} keyboardVerticalOffset={headerHeight} thread={thread}>
+        <Channel channel={channel} keyboardVerticalOffset={headerHeight} thread={thread} threadList>
           <View
             style={{
               flex: 1,

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -93,6 +93,7 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
         enforceUniqueReaction
         keyboardVerticalOffset={0}
         thread={thread}
+        threadList
       >
         <View style={styles.container}>
           <ThreadHeader thread={thread} />

--- a/examples/TypeScriptMessaging/App.tsx
+++ b/examples/TypeScriptMessaging/App.tsx
@@ -172,7 +172,7 @@ const ThreadScreen: React.FC<ThreadScreenProps> = ({ navigation }) => {
   return (
     <SafeAreaView>
       <Chat client={chatClient} i18nInstance={streami18n}>
-        <Channel channel={channel} keyboardVerticalOffset={headerHeight} thread={thread}>
+        <Channel channel={channel} keyboardVerticalOffset={headerHeight} thread={thread} threadList>
           <View
             style={{
               flex: 1,

--- a/package/package.json
+++ b/package/package.json
@@ -81,7 +81,7 @@
     "path": "0.12.7",
     "react-art": "^17.0.2",
     "react-native-markdown-package": "1.8.1",
-    "stream-chat": "~3.13.1"
+    "stream-chat": "~4.0.0"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -75,6 +75,7 @@ import {
   ChannelContextValue,
   ChannelProvider,
 } from '../../contexts/channelContext/ChannelContext';
+import { useChannelState } from '../../contexts/channelsStateContext/useChannelState';
 import { ChatContextValue, useChatContext } from '../../contexts/chatContext/ChatContext';
 import {
   InputConfig,
@@ -100,7 +101,7 @@ import {
   TranslationContextValue,
   useTranslationContext,
 } from '../../contexts/translationContext/TranslationContext';
-import { TypingContextValue, TypingProvider } from '../../contexts/typingContext/TypingContext';
+import { TypingProvider } from '../../contexts/typingContext/TypingContext';
 import {
   LOLReaction,
   LoveReaction,
@@ -112,6 +113,7 @@ import { FlatList as FlatListDefault } from '../../native';
 import { generateRandomId, ReactionData } from '../../utils/utils';
 
 import type { MessageType } from '../MessageList/hooks/useMessageList';
+import type { UseChannelStateValue } from '../../contexts/channelsStateContext/useChannelState';
 
 import type {
   DefaultAttachmentType,
@@ -200,6 +202,7 @@ export type ChannelPropsWithContext<
       'messages' | 'loadingMore' | 'loadingMoreRecent'
     >
   > &
+  UseChannelStateValue<At, Ch, Co, Ev, Me, Re, Us> &
   Partial<
     Pick<
       MessagesContextValue<At, Ch, Co, Ev, Me, Re, Us>,
@@ -278,6 +281,7 @@ export type ChannelPropsWithContext<
   Partial<
     Pick<ThreadContextValue<At, Ch, Co, Ev, Me, Re, Us>, 'allowThreadMessagesInChannel' | 'thread'>
   > & {
+    shouldSyncChannel: boolean;
     /**
      * Additional props passed to keyboard avoiding view
      */
@@ -359,6 +363,10 @@ export type ChannelPropsWithContext<
     quotedRepliesEnabled?: boolean;
     reactionsEnabled?: boolean;
     readEventsEnabled?: boolean;
+    /**
+     * Tells if channel is rendering a thread list
+     */
+    threadList?: boolean;
     threadRepliesEnabled?: boolean;
     typingEventsEnabled?: boolean;
     uploadsEnabled?: boolean;
@@ -378,9 +386,9 @@ const ChannelWithContext = <
   const {
     additionalKeyboardAvoidingViewProps,
     additionalTextInputProps,
-    animatedLongPress,
     additionalTouchableProps,
     allowThreadMessagesInChannel = true,
+    animatedLongPress,
     AttachButton = AttachButtonDefault,
     Attachment = AttachmentDefault,
     AttachmentActions = AttachmentActionsDefault,
@@ -412,8 +420,8 @@ const ChannelWithContext = <
     EmptyStateIndicator = EmptyStateIndicatorDefault,
     enforceUniqueReaction = false,
     FileAttachment = FileAttachmentDefault,
-    FileAttachmentIcon = FileIconDefault,
     FileAttachmentGroup = FileAttachmentGroupDefault,
+    FileAttachmentIcon = FileIconDefault,
     FileUploadPreview = FileUploadPreviewDefault,
     flagMessage,
     FlatList = FlatListDefault,
@@ -452,10 +460,10 @@ const ChannelWithContext = <
     loadingMore: loadingMoreProp,
     loadingMoreRecent: loadingMoreRecentProp,
     markdownRules,
-    messageId,
     maxMessageLength: maxMessageLengthProp,
     maxNumberOfFiles = 10,
     maxTimeBetweenGroupedMessages,
+    members,
     Message = MessageDefault,
     messageActions,
     MessageAvatar = MessageAvatarDefault,
@@ -464,10 +472,11 @@ const ChannelWithContext = <
     MessageDeleted = MessageDeletedDefault,
     MessageFooter = MessageFooterDefault,
     MessageHeader,
+    messageId,
     MessageList = MessageListDefault,
     MessageReplies = MessageRepliesDefault,
     MessageRepliesAvatars = MessageRepliesAvatarsDefault,
-    messages: messagesProp,
+    messages,
     MessageSimple = MessageSimpleDefault,
     MessageStatus = MessageStatusDefault,
     MessageSystem = MessageSystemDefault,
@@ -481,14 +490,15 @@ const ChannelWithContext = <
     onChangeText,
     onDoubleTapMessage,
     onLongPressMessage,
-    onPressMessage,
     onPressInMessage,
+    onPressMessage,
     openSuggestions,
     OverlayReactionList = OverlayReactionListDefault,
     quotedRepliesEnabled: quotedRepliesEnabledProp,
     quotedReply,
     ReactionList = ReactionListDefault,
     reactionsEnabled: reactionsEnabledProp,
+    read,
     readEventsEnabled: readEventsEnabledProp,
     Reply = ReplyDefault,
     retry,
@@ -497,13 +507,23 @@ const ChannelWithContext = <
     SendButton = SendButtonDefault,
     sendImageAsync = false,
     setInputRef,
+    setMembers,
+    setMessages,
+    setRead,
+    setThreadMessages,
+    setTyping,
+    setWatcherCount,
+    setWatchers,
+    shouldSyncChannel,
     ShowThreadMessageInChannelButton = ShowThreadMessageInChannelButtonDefault,
     StickyHeader,
     supportedReactions = reactionData,
     t,
     thread: threadProps,
+    threadMessages,
     threadRepliesEnabled: threadRepliesEnabledProp,
     threadReply,
+    typing,
     typingEventsEnabled: typingEventsEnabledProp,
     TypingIndicator = TypingIndicatorDefault,
     TypingIndicatorContainer = TypingIndicatorContainerDefault,
@@ -511,6 +531,8 @@ const ChannelWithContext = <
     UploadProgressIndicator = UploadProgressIndicatorDefault,
     uploadsEnabled: uploadsEnabledProp,
     UrlPreview = CardDefault,
+    watcherCount,
+    watchers,
   } = props;
 
   const {
@@ -529,39 +551,20 @@ const ChannelWithContext = <
   const [loadingMore, setLoadingMore] = useState(false);
 
   const [loadingMoreRecent, setLoadingMoreRecent] = useState(false);
-  const [messages, setMessages] = useState<
-    PaginatedMessageListContextValue<At, Ch, Co, Ev, Me, Re, Us>['messages']
-  >([]);
-
-  const [members, setMembers] = useState<
-    ChannelContextValue<At, Ch, Co, Ev, Me, Re, Us>['members']
-  >({});
   const [quotedMessage, setQuotedMessage] =
     useState<boolean | MessageType<At, Ch, Co, Ev, Me, Re, Us>>(false);
-  const [read, setRead] = useState<ChannelContextValue<At, Ch, Co, Ev, Me, Re, Us>['read']>({});
   const [thread, setThread] = useState<ThreadContextValue<At, Ch, Co, Ev, Me, Re, Us>['thread']>(
     threadProps || null,
   );
   const [threadHasMore, setThreadHasMore] = useState(true);
   const [threadLoadingMore, setThreadLoadingMore] = useState(false);
-  const [threadMessages, setThreadMessages] = useState<
-    ThreadContextValue<At, Ch, Co, Ev, Me, Re, Us>['threadMessages']
-  >((threadProps?.id && channel?.state?.threads?.[threadProps.id]) || []);
-  const [typing, setTyping] = useState<TypingContextValue<At, Ch, Co, Ev, Me, Re, Us>['typing']>(
-    {},
-  );
-  const [watcherCount, setWatcherCount] =
-    useState<ChannelContextValue<At, Ch, Co, Ev, Me, Re, Us>['watcherCount']>();
-  const [watchers, setWatchers] = useState<
-    ChannelContextValue<At, Ch, Co, Ev, Me, Re, Us>['watchers']
-  >({});
 
   const { setTargetedMessage, targetedMessage } = useTargetedMessage(messageId);
 
   const channelId = channel?.id || '';
   useEffect(() => {
     const initChannel = () => {
-      if (!channel) return;
+      if (!channel || !shouldSyncChannel) return;
 
       /**
        * Loading channel at first unread message  requires channel to be initialized in the first place,
@@ -602,7 +605,7 @@ const ChannelWithContext = <
 
   const threadPropsExists = !!threadProps;
   useEffect(() => {
-    if (threadProps) {
+    if (threadProps && shouldSyncChannel) {
       setThread(threadProps);
       if (channel && threadProps?.id) {
         setThreadMessages(channel.state.threads?.[threadProps.id] || []);
@@ -681,7 +684,7 @@ const ChannelWithContext = <
   });
 
   const connectionRecoveredHandler = () => {
-    if (channel) {
+    if (channel && shouldSyncChannel) {
       copyChannelState();
       if (thread) {
         setThreadMessages([...channel.state.threads[thread.id]]);
@@ -690,29 +693,31 @@ const ChannelWithContext = <
   };
 
   const connectionChangedHandler = (event: ConnectionChangeEvent) => {
-    if (event.online) {
+    if (event.online && shouldSyncChannel) {
       resyncChannel();
     }
   };
 
   const handleEvent: EventHandler<At, Ch, Co, Ev, Me, Re, Us> = (event) => {
-    if (thread) {
-      const updatedThreadMessages =
-        (thread.id && channel && channel.state.threads[thread.id]) || threadMessages;
-      setThreadMessages(updatedThreadMessages);
-    }
+    if (shouldSyncChannel) {
+      if (thread) {
+        const updatedThreadMessages =
+          (thread.id && channel && channel.state.threads[thread.id]) || threadMessages;
+        setThreadMessages(updatedThreadMessages);
+      }
 
-    if (channel && thread && event.message?.id === thread.id) {
-      const updatedThread = channel.state.formatMessage(event.message);
-      setThread(updatedThread);
-    }
+      if (channel && thread && event.message?.id === thread.id) {
+        const updatedThread = channel.state.formatMessage(event.message);
+        setThread(updatedThread);
+      }
 
-    if (event.type === 'typing.start' || event.type === 'typing.stop') {
-      copyTypingState();
-    } else if (event.type === 'message.read') {
-      copyReadState();
-    } else if (channel) {
-      copyChannelState();
+      if (event.type === 'typing.start' || event.type === 'typing.stop') {
+        copyTypingState();
+      } else if (event.type === 'message.read') {
+        copyReadState();
+      } else if (channel) {
+        copyChannelState();
+      }
     }
   };
 
@@ -878,12 +883,18 @@ const ChannelWithContext = <
       const limit = 50;
       channel.state.threads[parentID] = [];
       const queryResponse = await channel.getReplies(parentID, {
-        limit: 50,
+        limit,
       });
 
       const updatedHasMore = queryResponse.messages.length === limit;
       const updatedThreadMessages = channel.state.threads[parentID] || [];
       loadMoreThreadFinished(updatedHasMore, updatedThreadMessages);
+      const { messages } = await channel.getMessagesById([parentID]);
+      const [threadMessage] = messages;
+      if (threadMessage) {
+        const formattedMessage = channel.state.formatMessage(threadMessage);
+        setThread(formattedMessage);
+      }
     } catch (err) {
       console.warn('Thread loading request failed with error', err);
       setError(err);
@@ -1591,7 +1602,7 @@ const ChannelWithContext = <
       loadingMoreRecentProp !== undefined ? loadingMoreRecentProp : loadingMoreRecent,
     loadMore,
     loadMoreRecent,
-    messages: messagesProp || messages,
+    messages,
     setLoadingMore,
     setLoadingMoreRecent,
   });
@@ -1770,6 +1781,28 @@ export const Channel = <
   const { client } = useChatContext<At, Ch, Co, Ev, Me, Re, Us>();
   const { t } = useTranslationContext();
 
+  const shouldSyncChannel = props.thread?.id ? !!props.threadList : true;
+
+  const {
+    members,
+    messages,
+    read,
+    setMembers,
+    setMessages,
+    setRead,
+    setThreadMessages,
+    setTyping,
+    setWatcherCount,
+    setWatchers,
+    threadMessages,
+    typing,
+    watcherCount,
+    watchers,
+  } = useChannelState<At, Ch, Co, Ev, Me, Re, Us>(
+    props.channel,
+    props.threadList ? props.thread?.id : undefined,
+  );
+
   return (
     <ChannelWithContext<At, Ch, Co, Ev, Me, Re, Us>
       {...{
@@ -1777,6 +1810,23 @@ export const Channel = <
         t,
       }}
       {...props}
+      shouldSyncChannel={shouldSyncChannel}
+      {...{
+        members,
+        messages: props.messages || messages,
+        read,
+        setMembers,
+        setMessages,
+        setRead,
+        setThreadMessages,
+        setTyping,
+        setWatcherCount,
+        setWatchers,
+        threadMessages,
+        typing,
+        watcherCount,
+        watchers,
+      }}
     />
   );
 };

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -559,6 +559,8 @@ const ChannelWithContext = <
   const [threadHasMore, setThreadHasMore] = useState(true);
   const [threadLoadingMore, setThreadLoadingMore] = useState(false);
 
+  const [syncingChannel, setSyncingChannel] = useState(false);
+
   const { setTargetedMessage, targetedMessage } = useTargetedMessage(messageId);
 
   const channelId = channel?.id || '';
@@ -735,7 +737,7 @@ const ChannelWithContext = <
       client.off('connection.changed', connectionChangedHandler);
       channel?.off(handleEvent);
     };
-  }, [channelId, connectionRecoveredHandler, handleEvent]);
+  }, [channelId, connectionChangedHandler, connectionRecoveredHandler, handleEvent]);
 
   const channelQueryCall = async (queryCall: () => void = () => null) => {
     setError(false);
@@ -904,7 +906,8 @@ const ChannelWithContext = <
   };
 
   const resyncChannel = async () => {
-    if (!channel) return;
+    if (!channel || syncingChannel) return;
+    setSyncingChannel(true);
 
     setError(false);
     try {
@@ -1002,6 +1005,8 @@ const ChannelWithContext = <
       setError(err);
       setLoading(false);
     }
+
+    setSyncingChannel(false);
   };
 
   const reloadChannel = () =>

--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { MAX_QUERY_CHANNELS_LIMIT } from '../utils';
 
+import { useActiveChannels } from '../../../contexts/channelsStateContext/useActiveChannels';
 import { useChatContext } from '../../../contexts/chatContext/ChatContext';
 
 import type { Channel, ChannelFilters, ChannelOptions, ChannelSort } from 'stream-chat';
@@ -50,6 +51,7 @@ export const usePaginatedChannels = <
   sort = {},
 }: Parameters<Ch, Co, Us>) => {
   const { client } = useChatContext<At, Ch, Co, Ev, Me, Re, Us>();
+  const activeChannels = useActiveChannels();
 
   const [channels, setChannels] = useState<Channel<At, Ch, Co, Ev, Me, Re, Us>[]>([]);
   const [error, setError] = useState(false);
@@ -78,7 +80,9 @@ export const usePaginatedChannels = <
     };
 
     try {
-      const channelQueryResponse = await client.queryChannels(filters, sort, newOptions);
+      const channelQueryResponse = await client.queryChannels(filters, sort, newOptions, {
+        skipInitialization: activeChannels.current,
+      });
 
       channelQueryResponse.forEach((channel) => channel.state.setIsUpToDate(true));
 

--- a/package/src/components/Message/MessageSimple/MessageReplies.tsx
+++ b/package/src/components/Message/MessageSimple/MessageReplies.tsx
@@ -220,12 +220,14 @@ const areEqual = <
   const {
     message: prevMessage,
     noBorder: prevNoBorder,
+    onOpenThread: prevOnOpenThread,
     t: prevT,
     threadList: prevThreadList,
   } = prevProps;
   const {
     message: nextMessage,
     noBorder: nextNoBorder,
+    onOpenThread: nextOnOpenThread,
     t: nextT,
     threadList: nextThreadList,
   } = nextProps;
@@ -241,6 +243,9 @@ const areEqual = <
 
   const tEqual = prevT === nextT;
   if (!tEqual) return false;
+
+  const onOpenThreadEqual = prevOnOpenThread === nextOnOpenThread;
+  if (!onOpenThreadEqual) return false;
 
   return true;
 };

--- a/package/src/components/Thread/components/ThreadFooterComponent.tsx
+++ b/package/src/components/Thread/components/ThreadFooterComponent.tsx
@@ -146,6 +146,18 @@ const areEqual = <
     prevThread?.reply_count === nextThread?.reply_count;
   if (!threadEqual) return false;
 
+  const latestReactionsEqual =
+    prevThread &&
+    nextThread &&
+    Array.isArray(prevThread.latest_reactions) &&
+    Array.isArray(nextThread.latest_reactions)
+      ? prevThread.latest_reactions.length === nextThread.latest_reactions.length &&
+        prevThread.latest_reactions.every(
+          ({ type }, index) => type === nextThread.latest_reactions?.[index].type,
+        )
+      : prevThread?.latest_reactions === nextThread?.latest_reactions;
+  if (!latestReactionsEqual) return false;
+
   return true;
 };
 

--- a/package/src/contexts/channelsStateContext/ChannelsStateContext.tsx
+++ b/package/src/contexts/channelsStateContext/ChannelsStateContext.tsx
@@ -1,0 +1,245 @@
+import React, { ReactNode, useCallback, useContext, useMemo, useReducer } from 'react';
+
+import type { ChannelContextValue } from '../channelContext/ChannelContext';
+import type { PaginatedMessageListContextValue } from '../paginatedMessageListContext/PaginatedMessageListContext';
+import type { ThreadContextValue } from '../threadContext/ThreadContext';
+import type { TypingContextValue } from '../typingContext/TypingContext';
+
+import type {
+  DefaultAttachmentType,
+  DefaultChannelType,
+  DefaultCommandType,
+  DefaultEventType,
+  DefaultMessageType,
+  DefaultReactionType,
+  DefaultUserType,
+  UnknownType,
+} from '../../types/types';
+
+export type ChannelState<
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+> = {
+  members: ChannelContextValue<At, Ch, Co, Ev, Me, Re, Us>['members'];
+  messages: PaginatedMessageListContextValue<At, Ch, Co, Ev, Me, Re, Us>['messages'];
+  read: ChannelContextValue<At, Ch, Co, Ev, Me, Re, Us>['read'];
+  subscriberCount: number;
+  threadMessages: ThreadContextValue<At, Ch, Co, Ev, Me, Re, Us>['threadMessages'];
+  typing: TypingContextValue<At, Ch, Co, Ev, Me, Re, Us>['typing'];
+  watcherCount: ChannelContextValue<At, Ch, Co, Ev, Me, Re, Us>['watcherCount'];
+  watchers: ChannelContextValue<At, Ch, Co, Ev, Me, Re, Us>['watchers'];
+};
+
+type ChannelsState<
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+> = { [cid: string]: ChannelState<At, Ch, Co, Ev, Me, Re, Us> };
+
+export type Keys = keyof ChannelState;
+
+export type Payload<
+  Key extends Keys = Keys,
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+> = {
+  cid: string;
+  key: Key;
+  value: ChannelState<At, Ch, Co, Ev, Me, Re, Us>[Key];
+};
+
+type SetStateAction<
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+> = { payload: Payload<Keys, At, Ch, Co, Ev, Me, Re, Us>; type: 'SET_STATE' };
+
+type IncreaseSubscriberCountAction = {
+  payload: { cid: string };
+  type: 'INCREASE_SUBSCRIBER_COUNT';
+};
+type DecreaseSubscriberCountAction = {
+  payload: { cid: string };
+  type: 'DECREASE_SUBSCRIBER_COUNT';
+};
+
+type Action<
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+> =
+  | SetStateAction<At, Ch, Co, Ev, Me, Re, Us>
+  | IncreaseSubscriberCountAction
+  | DecreaseSubscriberCountAction;
+
+export type ChannelsStateContextValue<
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+> = {
+  decreaseSubscriberCount: (value: { cid: string }) => void;
+  increaseSubscriberCount: (value: { cid: string }) => void;
+  setState: (value: Payload<Keys, At, Ch, Co, Ev, Me, Re, Us>) => void;
+  state: ChannelsState<At, Ch, Co, Ev, Me, Re, Us>;
+};
+
+type Reducer<
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+> = (
+  state: ChannelsState<At, Ch, Co, Ev, Me, Re, Us>,
+  action: Action<At, Ch, Co, Ev, Me, Re, Us>,
+) => ChannelsState<At, Ch, Co, Ev, Me, Re, Us>;
+
+function reducer(state: ChannelsState, action: Action) {
+  switch (action.type) {
+    case 'SET_STATE':
+      return {
+        ...state,
+        [action.payload.cid]: {
+          ...(state[action.payload.cid] || {}),
+          [action.payload.key]: action.payload.value,
+        },
+      };
+
+    case 'INCREASE_SUBSCRIBER_COUNT': {
+      const currentCount = state[action.payload.cid]?.subscriberCount ?? 0;
+      return {
+        ...state,
+        [action.payload.cid]: {
+          ...(state[action.payload.cid] || {}),
+          subscriberCount: currentCount + 1,
+        },
+      };
+    }
+
+    case 'DECREASE_SUBSCRIBER_COUNT': {
+      const currentCount = state[action.payload.cid]?.subscriberCount ?? 0;
+
+      // If there last subscribed Channel component unsubscribes, we clear the channel state.
+      if (currentCount === 0) {
+        const stateShallowCopy = {
+          ...state,
+        };
+
+        delete stateShallowCopy[action.payload.cid];
+
+        return stateShallowCopy;
+      }
+
+      return {
+        ...state,
+        [action.payload.cid]: {
+          ...(state[action.payload.cid] || {}),
+          subscriberCount: currentCount - 1,
+        },
+      };
+    }
+    default:
+      throw new Error();
+  }
+}
+
+const ChannelsStateContext = React.createContext({
+  removeChannelState: () => {
+    // do nothing.
+  },
+  setState: () => {
+    // do nothing.
+  },
+  state: {},
+} as unknown as ChannelsStateContextValue);
+
+export const ChannelsStateProvider = <
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+>({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [state, dispatch] = useReducer(reducer as Reducer<At, Ch, Co, Ev, Me, Re, Us>, {});
+
+  const setState = useCallback((payload: Payload<Keys, At, Ch, Co, Ev, Me, Re, Us>) => {
+    dispatch({ payload, type: 'SET_STATE' });
+  }, []);
+
+  const increaseSubscriberCount = useCallback((payload: { cid: string }) => {
+    dispatch({ payload, type: 'INCREASE_SUBSCRIBER_COUNT' });
+  }, []);
+
+  const decreaseSubscriberCount = useCallback((payload: { cid: string }) => {
+    dispatch({ payload, type: 'DECREASE_SUBSCRIBER_COUNT' });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      decreaseSubscriberCount,
+      increaseSubscriberCount,
+      setState,
+      state,
+    }),
+    [state],
+  );
+
+  return (
+    <ChannelsStateContext.Provider value={value as unknown as ChannelsStateContextValue}>
+      {children}
+    </ChannelsStateContext.Provider>
+  );
+};
+
+export const useChannelsStateContext = <
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+>() =>
+  useContext(ChannelsStateContext) as unknown as ChannelsStateContextValue<
+    At,
+    Ch,
+    Co,
+    Ev,
+    Me,
+    Re,
+    Us
+  >;

--- a/package/src/contexts/channelsStateContext/ChannelsStateContext.tsx
+++ b/package/src/contexts/channelsStateContext/ChannelsStateContext.tsx
@@ -4,6 +4,7 @@ import type { ChannelContextValue } from '../channelContext/ChannelContext';
 import type { PaginatedMessageListContextValue } from '../paginatedMessageListContext/PaginatedMessageListContext';
 import type { ThreadContextValue } from '../threadContext/ThreadContext';
 import type { TypingContextValue } from '../typingContext/TypingContext';
+import { getDisplayName } from '../utils/getDisplayName';
 
 import type {
   DefaultAttachmentType,
@@ -243,3 +244,28 @@ export const useChannelsStateContext = <
     Re,
     Us
   >;
+
+export const withChannelsStateContext = <
+  P extends UnknownType,
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+>(
+  Component: React.ComponentType<P>,
+): React.FC<Omit<P, keyof ChannelsStateContextValue<At, Ch, Co, Ev, Me, Re, Us>>> => {
+  const WithChannelsStateContextComponent = (
+    props: Omit<P, keyof ChannelsStateContextValue<At, Ch, Co, Ev, Me, Re, Us>>,
+  ) => {
+    const channelsStateContext = useChannelsStateContext<At, Ch, Co, Ev, Me, Re, Us>();
+
+    return <Component {...(props as P)} {...channelsStateContext} />;
+  };
+  WithChannelsStateContextComponent.displayName = `WithChannelsStateContext${getDisplayName(
+    Component,
+  )}`;
+  return WithChannelsStateContextComponent;
+};

--- a/package/src/contexts/channelsStateContext/useActiveChannels.ts
+++ b/package/src/contexts/channelsStateContext/useActiveChannels.ts
@@ -1,11 +1,14 @@
 import { useEffect, useRef } from 'react';
+
 import { useChannelsStateContext } from './ChannelsStateContext';
 
-// This needs to be a reference because the functions using it are not memoized (because they change too much even if you do
-// due to the dependencies they have) and they're called on connection state changes on the client which are subscribed on
-// mount with an useEffect so they're always getting only the first function reference which uses the old value of this
-// active channels array (would always be empty). Using a ref solves this problem cause then it will always be updated to
-// the latest one.
+/* 
+  This needs to be a reference because the functions using it are not memoized (because they change too much even if you do
+  due to the dependencies they have) and they're called on connection state changes on the client which are subscribed on
+  mount with an useEffect so they're always getting only the first function reference which uses the old value of this
+  active channels array (would always be empty). Using a ref solves this problem cause then it will always be updated to
+  the latest one.
+*/
 export const useActiveChannels = () => {
   const { state } = useChannelsStateContext();
   const activeChannelsRef = useRef(Object.keys(state));

--- a/package/src/contexts/channelsStateContext/useActiveChannels.ts
+++ b/package/src/contexts/channelsStateContext/useActiveChannels.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react';
+import { useChannelsStateContext } from './ChannelsStateContext';
+
+// This needs to be a reference because the functions using it are not memoized (because they change too much even if you do
+// due to the dependencies they have) and they're called on connection state changes on the client which are subscribed on
+// mount with an useEffect so they're always getting only the first function reference which uses the old value of this
+// active channels array (would always be empty). Using a ref solves this problem cause then it will always be updated to
+// the latest one.
+export const useActiveChannels = () => {
+  const { state } = useChannelsStateContext();
+  const activeChannelsRef = useRef(Object.keys(state));
+
+  useEffect(() => {
+    activeChannelsRef.current = Object.keys(state);
+  }, [state]);
+
+  return activeChannelsRef;
+};

--- a/package/src/contexts/channelsStateContext/useChannelState.ts
+++ b/package/src/contexts/channelsStateContext/useChannelState.ts
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import type { Channel as ChannelType } from 'stream-chat';
+
+import { useChannelsStateContext } from './ChannelsStateContext';
+
+import type { ChannelsStateContextValue, ChannelState, Keys } from './ChannelsStateContext';
+
+import type {
+  DefaultAttachmentType,
+  DefaultChannelType,
+  DefaultCommandType,
+  DefaultEventType,
+  DefaultMessageType,
+  DefaultReactionType,
+  DefaultUserType,
+  UnknownType,
+} from '../../types/types';
+
+type StateManagerParams<
+  Key extends Keys,
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+> = Omit<
+  ChannelsStateContextValue<At, Ch, Co, Ev, Me, Re, Us>,
+  'increaseSubscriberCount' | 'decreaseSubscriberCount'
+> & {
+  cid: string;
+  key: Key;
+};
+
+function useStateManager<
+  Key extends Keys,
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+>(
+  {
+    cid,
+    key,
+    setState,
+    state,
+  }: Omit<
+    StateManagerParams<Key, At, Ch, Co, Ev, Me, Re, Us>,
+    'increaseSubscriberCount' | 'decreaseSubscriberCount'
+  >,
+  initialValue?: ChannelState<At, Ch, Co, Ev, Me, Re, Us>[Key],
+) {
+  const memoizedInitialValue = useMemo(() => initialValue, []);
+  const value =
+    state[cid]?.[key] || (memoizedInitialValue as ChannelState<At, Ch, Co, Ev, Me, Re, Us>[Key]);
+
+  const setValue = useCallback(
+    (value: ChannelState<At, Ch, Co, Ev, Me, Re, Us>[Key]) => setState({ cid, key, value }),
+    [cid, key],
+  );
+
+  return [value, setValue] as const;
+}
+
+export type UseChannelStateValue<
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+> = {
+  members: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['members'];
+  messages: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['messages'];
+  read: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['read'];
+  setMembers: (value: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['members']) => void;
+  setMessages: (value: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['messages']) => void;
+  setRead: (value: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['read']) => void;
+  setThreadMessages: (value: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['threadMessages']) => void;
+  setTyping: (value: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['typing']) => void;
+  setWatcherCount: (value: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['watcherCount']) => void;
+  setWatchers: (value: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['watchers']) => void;
+  threadMessages: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['threadMessages'];
+  typing: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['typing'];
+  watcherCount: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['watcherCount'];
+  watchers: ChannelState<At, Ch, Co, Ev, Me, Re, Us>['watchers'];
+};
+
+export function useChannelState<
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+>(
+  channel: ChannelType<At, Ch, Co, Ev, Me, Re, Us> | undefined,
+  threadId?: string,
+): UseChannelStateValue<At, Ch, Co, Ev, Me, Re, Us> {
+  const cid = channel?.id || 'id'; // in case channel is not initialized, use generic id string for indexing
+  const { decreaseSubscriberCount, increaseSubscriberCount, setState, state } =
+    useChannelsStateContext<At, Ch, Co, Ev, Me, Re, Us>();
+
+  // Keeps track of how many Channel components are subscribed to this Channel state (Channel vs Thread concurrency)
+  useEffect(() => {
+    increaseSubscriberCount({ cid });
+    return () => {
+      decreaseSubscriberCount({ cid });
+    };
+  }, []);
+
+  const [members, setMembers] = useStateManager(
+    {
+      cid,
+      key: 'members',
+      setState,
+      state,
+    },
+    {},
+  );
+
+  const [messages, setMessages] = useStateManager(
+    {
+      cid,
+      key: 'messages',
+      setState,
+      state,
+    },
+    [],
+  );
+
+  const [read, setRead] = useStateManager(
+    {
+      cid,
+      key: 'read',
+      setState,
+      state,
+    },
+    {},
+  );
+
+  const [typing, setTyping] = useStateManager(
+    {
+      cid,
+      key: 'typing',
+      setState,
+      state,
+    },
+    {},
+  );
+
+  const [watcherCount, setWatcherCount] = useStateManager({
+    cid,
+    key: 'watcherCount',
+    setState,
+    state,
+  });
+
+  const [watchers, setWatchers] = useStateManager(
+    {
+      cid,
+      key: 'watchers',
+      setState,
+      state,
+    },
+    {},
+  );
+
+  const [threadMessages, setThreadMessages] = useStateManager(
+    {
+      cid,
+      key: 'threadMessages',
+      setState,
+      state,
+    },
+    (threadId && channel?.state?.threads?.[threadId]) || [],
+  );
+
+  return {
+    members,
+    messages,
+    read,
+    setMembers,
+    setMessages,
+    setRead,
+    setThreadMessages,
+    setTyping,
+    setWatcherCount,
+    setWatchers,
+    threadMessages,
+    typing,
+    watcherCount,
+    watchers,
+  };
+}

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -22,6 +22,7 @@ import { AttachmentPickerError as DefaultAttachmentPickerError } from '../../com
 import { AttachmentPickerBottomSheetHandle as DefaultAttachmentPickerBottomSheetHandle } from '../../components/AttachmentPicker/components/AttachmentPickerBottomSheetHandle';
 import { AttachmentPickerErrorImage as DefaultAttachmentPickerErrorImage } from '../../components/AttachmentPicker/components/AttachmentPickerErrorImage';
 import { CameraSelectorIcon as DefaultCameraSelectorIcon } from '../../components/AttachmentPicker/components/CameraSelectorIcon';
+import { ChannelsStateProvider } from '../../contexts/channelsStateContext/ChannelsStateContext';
 import { FileSelectorIcon as DefaultFileSelectorIcon } from '../../components/AttachmentPicker/components/FileSelectorIcon';
 import { ImageOverlaySelectedComponent as DefaultImageOverlaySelectedComponent } from '../../components/AttachmentPicker/components/ImageOverlaySelectedComponent';
 import { ImageSelectorIcon as DefaultImageSelectorIcon } from '../../components/AttachmentPicker/components/ImageSelectorIcon';
@@ -214,7 +215,7 @@ export const OverlayProvider = <
         <MessageOverlayProvider<At, Ch, Co, Ev, Me, Re, Us>>
           <AttachmentPickerProvider value={attachmentPickerContext}>
             <ImageGalleryProvider>
-              {children}
+              <ChannelsStateProvider<At, Ch, Co, Ev, Me, Re, Us>>{children}</ChannelsStateProvider>
               <ThemeProvider style={overlayContext.style}>
                 <Animated.View
                   pointerEvents={overlay === 'none' ? 'none' : 'auto'}

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -10657,10 +10657,10 @@ stream-buffers@~2.2.0:
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
   integrity sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=
 
-stream-chat@~3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-3.13.1.tgz#1692246dd74968dee7596a6a8c1e1a02656bb634"
-  integrity sha512-JWgVwRgmAE/a7P9i+LK2Lr2C4dXfRaedm2c4jKsZuMPR6KwINIy0kgdGyds3Xqmp4/LPSfhXZJ7wExmlfo9+7g==
+stream-chat@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-4.0.0.tgz#7aec92015c8d1a2ee1344ca32b2f51a70cace600"
+  integrity sha512-u4oTd4d19E23t0IVj60G/DhJVNIEUUQt7SI8Zx8Rhum9GLfQ8VwXsgcJYUsLHaiIjpMVjttyoYmR/F8RP8f3+w==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@types/jsonwebtoken" "^8.5.0"


### PR DESCRIPTION
This PR is meant to fix the concurrency problems we've been having with our Channel & ChannelList components.

It moves the basics of our Channel state to a parent level in order to have it shared between multiple instances of the same Channel (i.e. when you have a channel and a thread in the navigation stack).

Also, uses the new parameter from our js client to prevent initializing active channels when refreshing the channel list (happens on reconnect).

Blocked by https://github.com/GetStream/stream-chat-js/pull/740

We need to update the stream-chat-js version on our sample apps before merging this PR.

PS: This PR adds a breaking change (now channel components rendering threads should add the threadList prop when the thread is active). Also, the new parameter from stream-chat-js will make future SDK versions types compatible with the new client version only.