### PR TITLE
docs: fix in hello_stream_chat.mdx

### DIFF
--- a/docusaurus/docs/reactnative/basics/hello_stream_chat.mdx
+++ b/docusaurus/docs/reactnative/basics/hello_stream_chat.mdx
@@ -14,7 +14,7 @@ import summary from '../assets/basics/hello-stream-chat/summary.png'
 import thread from '../assets/basics/hello-stream-chat/thread.png'
 
 Adding feature rich chat to a React Native application can be quite challenging when starting from scratch.
-There are many considerations, states, and edge cases that need need accounting for, styling, message grouping, read states, context menus, etc. all add to the complexity of the challenge.
+There are many considerations, states, and edge cases that need accounting for, styling, message grouping, read states, context menus, etc. all add to the complexity of the challenge.
 Stream Chat for React Native provides an easy to implement flexible solution.
 
 Stream Chat for React Native provides a way to add chat to an existing or new application with very little code.
@@ -46,7 +46,7 @@ Typically, you send this token from your backend to the client when a user regis
 See the <!-- TODO: Change to new docs -->[Tokens & Authentication](https://getstream.io/chat/docs/javascript/tokens_and_authentication/) documentation to learn more about creating tokens.
 You can use a [developer token](https://getstream.io/chat/docs/javascript/tokens_and_authentication/?language=javascript#developer-tokens) if desired, but for the purpose of this guide it will be assumed you have created and retrieved a `user_token`.
 
-To connect a user a the `connectUser` function should be called and provided with the user object and `user_token`.
+To connect a user the `connectUser` function should be called and provided with the user object and `user_token`.
 Connecting a user could be done in the login flow or elsewhere in the application after the client is instantiated.  
 
 ```ts


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
docs: Fixing the typos in the hello_steam_chat.mdx file.

Typos:
- https://getstream.io/chat/docs/sdk/reactnative/basics/hello_stream_chat/ Line number 2. Two times "need".
- https://getstream.io/chat/docs/sdk/reactnative/basics/hello_stream_chat/
"To connect `a user a` the connectUser function should be called and provided with the user object and user_token. Connecting a user could be done in the login flow or elsewhere in the application after the client is instantiated". The issue is marked inside ``.