### PR TITLE
fix: fixed AppState subscription logic to support RN 0.65

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -108,7 +108,7 @@
     "@types/lodash": "4.14.169",
     "@types/mime-types": "2.1.0",
     "@types/react": "17.0.5",
-    "@types/react-native": "0.64.5",
+    "@types/react-native": "0.65.1",
     "@types/react-test-renderer": "17.0.1",
     "@typescript-eslint/eslint-plugin": "4.24.0",
     "@typescript-eslint/parser": "4.24.0",

--- a/package/src/components/Chat/hooks/useIsOnline.ts
+++ b/package/src/components/Chat/hooks/useIsOnline.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useAppStateListener } from '../../../hooks/useAppStateListener';
 import { NetInfo } from '../../../native';
@@ -41,22 +41,23 @@ export const useIsOnline = <
 
   const clientExits = !!client;
 
-  const onBackground = closeConnectionOnBackground
-    ? () => {
-        for (const cid in client.activeChannels) {
-          const channel = client.activeChannels[cid];
-          channel?.state.setIsUpToDate(false);
-        }
-        client.closeConnection();
-        setIsOnline(false);
-      }
-    : undefined;
+  const onBackground = useCallback(() => {
+    if (!closeConnectionOnBackground) return;
 
-  const onForeground = closeConnectionOnBackground
-    ? () => {
-        client.openConnection();
-      }
-    : undefined;
+    for (const cid in client.activeChannels) {
+      const channel = client.activeChannels[cid];
+      channel?.state.setIsUpToDate(false);
+    }
+
+    client.closeConnection();
+    setIsOnline(false);
+  }, [closeConnectionOnBackground, client]);
+
+  const onForeground = useCallback(() => {
+    if (!closeConnectionOnBackground) return;
+
+    client.openConnection();
+  }, [closeConnectionOnBackground, client]);
 
   useAppStateListener(onForeground, onBackground);
 

--- a/package/src/hooks/useAppStateListener.ts
+++ b/package/src/hooks/useAppStateListener.ts
@@ -1,21 +1,35 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
 
 export const useAppStateListener = (onForeground?: () => void, onBackground?: () => void) => {
   const [appState, setAppState] = useState(AppState.currentState);
-
-  const handleAppStateChange = (nextAppState: AppStateStatus) => {
-    if (appState === 'background' && nextAppState === 'active' && onForeground) {
-      onForeground();
-    } else if (appState.match(/active|inactive/) && nextAppState === 'background' && onBackground) {
-      onBackground();
-    }
-    setAppState(nextAppState);
-  };
+  const handleAppStateChange = useCallback(
+    (nextAppState: AppStateStatus) => {
+      if (appState === 'background' && nextAppState === 'active' && onForeground) {
+        onForeground();
+      } else if (
+        appState.match(/active|inactive/) &&
+        nextAppState === 'background' &&
+        onBackground
+      ) {
+        onBackground();
+      }
+      setAppState(nextAppState);
+    },
+    [onBackground, onForeground, appState],
+  );
 
   useEffect(() => {
-    AppState.addEventListener('change', handleAppStateChange);
+    const subscription = AppState.addEventListener('change', handleAppStateChange);
 
-    return () => AppState.removeEventListener('change', handleAppStateChange);
+    return () => {
+      // Following if-else logic is to support RN >= 0.65 and RN < 0.65 versions.
+      // https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#:~:text=EventEmitter%23removeSubscription%20is%20now%20deprecated.%20(cb6cbd12f8%20by%20%40yungsters)
+      if (subscription?.remove) {
+        subscription.remove();
+      } else {
+        AppState.removeEventListener('change', handleAppStateChange);
+      }
+    };
   }, [handleAppStateChange]);
 };

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -1954,10 +1954,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
-"@types/react-native@0.64.5":
-  version "0.64.5"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.64.5.tgz#219738b52b2e372ec057d3c8f20fbd6c37b245cd"
-  integrity sha512-k0r8MnQX7UFboZDvMKLov26gFLXKrNgLhCfSVhjaZ6wMUofKijxvee7/wgfAqtT2zS5FR4an4+qn0r72SCbw3g==
+"@types/react-native@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.65.1.tgz#7342158e10ea5088c225bb669dd4ef15aad0a2f7"
+  integrity sha512-pyRmTnvjYORIXuL8+ZhoI8gqamTE/8Lo9bU/1Ife3VOTgeFzY9rHnx3Tna7OOixBW5Exh2PcHSkJXma4FENC0g==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

React Native 0.65 deprecated a support for `AppState.removeEventListener()`. This involves the internal subscription model changes which is affecting our `useAppStateListener` in which we tried to keep away from `useCallback()` hook. Exact reason why removeEventListener fails to remove the listener is still a bit of a mystery, causing exponential increase in these listeners. But replacing `removeEventLister` with `subscription.remove()` seems to do the job.