### PR TITLE
fix: fixed offset-limit logic for channel list pagination

### DIFF
--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -57,7 +57,6 @@ export const usePaginatedChannels = <
   const lastRefresh = useRef(Date.now());
   const [loadingChannels, setLoadingChannels] = useState(false);
   const [loadingNextPage, setLoadingNextPage] = useState(false);
-  const [offset, setOffset] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
 
   const queryChannels = async (queryType = '', retryCount = 0): Promise<void> => {
@@ -73,7 +72,7 @@ export const usePaginatedChannels = <
 
     const newOptions = {
       limit: options?.limit ?? MAX_QUERY_CHANNELS_LIMIT,
-      offset: queryType === 'reload' || queryType === 'refresh' ? 0 : offset,
+      offset: queryType === 'reload' || queryType === 'refresh' ? 0 : channels.length,
       ...options,
     };
 
@@ -89,7 +88,6 @@ export const usePaginatedChannels = <
 
       setChannels(newChannels);
       setHasNextPage(channelQueryResponse.length >= newOptions.limit);
-      setOffset(newChannels.length);
       setError(false);
     } catch (err) {
       await wait(2000);


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

### Issue

With current logic, we used to set `offset` for next pagination request after the completion of previous request. But in case a length of `channels` changes between two pagination calls (new channel gets added/remove to list from event handlers), then the offset for next pagination api call will be wrong. This results in following error on channellist:

```
ERROR  Warning: Encountered two children with the same key, `messaging:channel-ex-example-apps-8`. Keys should be unique so that components maintain their identity across updates.
```

### Fix

We should decide the value of offset right before making the pagination api call, using length of channel list.