### PR TITLE
build: Run checks on semver-named branches

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - master
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     types: [opened, synchronize]
 
 jobs:

--- a/.github/workflows/e2e-native-android.yml
+++ b/.github/workflows/e2e-native-android.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - master
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     types: [opened, synchronize]
 
 jobs:

--- a/.github/workflows/e2e-native-ios.yml
+++ b/.github/workflows/e2e-native-ios.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - master
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     types: [opened, synchronize]
 
 jobs:

--- a/.github/workflows/e2e-sample-android.yml
+++ b/.github/workflows/e2e-sample-android.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - master
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     types: [opened, synchronize]
 
 jobs:

--- a/.github/workflows/e2e-sample-ios.yml
+++ b/.github/workflows/e2e-sample-ios.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - master
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     types: [opened, synchronize]
 
 jobs:

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - develop
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     types: [opened, edited, synchronize]
 
 jobs:


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

This intends to make it so our checks run for PRs targeting branches named by semver versions. For example `v4.0.0` should be valid.

I've verified the syntax should work with the [GitHub docs](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)