### PR TITLE
fix: fixing deprecated warning around AppState for RN 0.65 compatibility

### DIFF
--- a/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
+++ b/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
@@ -11,6 +11,7 @@ import {
   LayoutAnimation,
   LayoutChangeEvent,
   LayoutRectangle,
+  NativeEventSubscription,
   Platform,
   ScreenRect,
   StatusBar,
@@ -42,6 +43,7 @@ export class KeyboardCompatibleView extends React.Component<
   _frame: LayoutRectangle | null = null;
   _keyboardEvent: KeyboardEvent | null = null;
   _subscriptions: EmitterSubscription[] = [];
+  _appStateSubscription: NativeEventSubscription | null = null;
   viewRef: React.RefObject<View>;
   _initialFrameHeight = 0;
   constructor(props: KeyboardAvoidingViewProps) {
@@ -178,12 +180,17 @@ export class KeyboardCompatibleView extends React.Component<
   };
 
   componentDidMount() {
-    AppState.addEventListener('change', this._handleAppStateChange);
+    this._appStateSubscription = AppState.addEventListener('change', this._handleAppStateChange);
     this.setKeyboardListeners();
   }
 
   componentWillUnmount() {
-    AppState.removeEventListener('change', this._handleAppStateChange);
+    // Following if-else condition to avoid deprecated warning coming RN 0.65
+    if (this._appStateSubscription?.remove) {
+      this._appStateSubscription?.remove();
+    } else {
+      AppState.removeEventListener('change', this._handleAppStateChange);
+    }
     this.unsetKeyboardListeners();
   }
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
