### PR TITLE
refactor: re-organized message types to avoid deep-nesting typescript warning

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -111,8 +111,7 @@ import {
 import { FlatList as FlatListDefault } from '../../native';
 import { generateRandomId, ReactionData } from '../../utils/utils';
 
-import type { MessageType } from '../MessageList/hooks/useMessageList';
-
+import type { MessageType } from '../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -26,10 +26,7 @@ import { useCreateMessageContext } from './hooks/useCreateMessageContext';
 import { messageActions as defaultMessageActions } from './utils/messageActions';
 import { removeReservedFields } from './utils/removeReservedFields';
 
-import {
-  isMessageWithStylesReadByAndDateSeparator,
-  MessageType,
-} from '../MessageList/hooks/useMessageList';
+import { isMessageWithStylesReadByAndDateSeparator } from '../MessageList/hooks/useMessageList';
 
 import {
   ChannelContextValue,
@@ -81,6 +78,7 @@ import { emojiRegex } from '../../utils/utils';
 
 import type { Attachment, MessageResponse, Reaction } from 'stream-chat';
 
+import type { MessageType } from '../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/components/Message/MessageSimple/MessageDeleted.tsx
+++ b/package/src/components/Message/MessageSimple/MessageDeleted.tsx
@@ -21,8 +21,7 @@ import {
 
 import type { MessageFooterProps } from './MessageFooter';
 
-import type { MessageType } from '../../MessageList/hooks/useMessageList';
-
+import type { MessageType } from '../../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/components/Message/MessageSimple/MessageFooter.tsx
+++ b/package/src/components/Message/MessageSimple/MessageFooter.tsx
@@ -19,9 +19,8 @@ import type { Attachment } from 'stream-chat';
 
 import type { MessageStatusProps } from './MessageStatus';
 
-import type { MessageType } from '../../MessageList/hooks/useMessageList';
-
 import type { ChannelContextValue } from '../../../contexts/channelContext/ChannelContext';
+import type { MessageType } from '../../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -13,8 +13,7 @@ import {
   ReactNodeOutput,
 } from 'simple-markdown';
 
-import type { MessageType } from '../../../MessageList/hooks/useMessageList';
-
+import type { MessageType } from '../../../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/components/Message/utils/messageActions.ts
+++ b/package/src/components/Message/utils/messageActions.ts
@@ -1,6 +1,5 @@
-import type { MessageType } from '../../MessageList/hooks/useMessageList';
-
 import type { MessageAction } from '../../../contexts/messageOverlayContext/MessageOverlayContext';
+import type { MessageType } from '../../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/components/Message/utils/removeReservedFields.ts
+++ b/package/src/components/Message/utils/removeReservedFields.ts
@@ -1,4 +1,4 @@
-import type { MessageType } from '../../MessageList/hooks/useMessageList';
+import type { MessageType } from '../../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -8,11 +8,7 @@ import {
   ViewToken,
 } from 'react-native';
 
-import {
-  isMessageWithStylesReadByAndDateSeparator,
-  MessageType,
-  useMessageList,
-} from './hooks/useMessageList';
+import { isMessageWithStylesReadByAndDateSeparator, useMessageList } from './hooks/useMessageList';
 import { InlineLoadingMoreIndicator } from './InlineLoadingMoreIndicator';
 import { InlineLoadingMoreRecentIndicator } from './InlineLoadingMoreRecentIndicator';
 import { InlineLoadingMoreThreadIndicator } from './InlineLoadingMoreThreadIndicator';
@@ -53,6 +49,7 @@ import {
 
 import type { Channel as StreamChannel } from 'stream-chat';
 
+import type { MessageType } from '../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/components/MessageList/MessageSystem.tsx
+++ b/package/src/components/MessageList/MessageSystem.tsx
@@ -8,8 +8,7 @@ import {
   useTranslationContext,
 } from '../../contexts/translationContext/TranslationContext';
 
-import type { MessageType } from './hooks/useMessageList';
-
+import type { MessageType } from '../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/components/MessageList/hooks/useMessageList.ts
+++ b/package/src/components/MessageList/hooks/useMessageList.ts
@@ -10,8 +10,10 @@ import {
 import { usePaginatedMessageListContext } from '../../../contexts/paginatedMessageListContext/PaginatedMessageListContext';
 import { useThreadContext } from '../../../contexts/threadContext/ThreadContext';
 
-import type { ChannelState, MessageResponse } from 'stream-chat';
-
+import type {
+  MessagesWithStylesReadByAndDateSeparator,
+  MessageType,
+} from '../../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,
@@ -28,34 +30,6 @@ export type UseMessageListParams = {
   noGroupByUser?: boolean;
   threadList?: boolean;
 };
-
-export type GroupType = 'bottom' | 'middle' | 'single' | 'top';
-
-export type MessagesWithStylesReadByAndDateSeparator<
-  At extends UnknownType = DefaultAttachmentType,
-  Ch extends UnknownType = DefaultChannelType,
-  Co extends string = DefaultCommandType,
-  Me extends UnknownType = DefaultMessageType,
-  Re extends UnknownType = DefaultReactionType,
-  Us extends UnknownType = DefaultUserType,
-> = MessageResponse<At, Ch, Co, Me, Re, Us> & {
-  groupStyles: GroupType[];
-  readBy: boolean | number;
-  dateSeparator?: Date;
-};
-
-export type MessageType<
-  At extends UnknownType = DefaultAttachmentType,
-  Ch extends UnknownType = DefaultChannelType,
-  Co extends string = DefaultCommandType,
-  Ev extends UnknownType = DefaultEventType,
-  Me extends UnknownType = DefaultMessageType,
-  Re extends UnknownType = DefaultReactionType,
-  Us extends UnknownType = DefaultUserType,
-> =
-  | ReturnType<ChannelState<At, Ch, Co, Ev, Me, Re, Us>['formatMessage']>
-  | MessagesWithStylesReadByAndDateSeparator<At, Ch, Co, Me, Re, Us>;
-
 // Type guards to check MessageType
 export const isMessageWithStylesReadByAndDateSeparator = <
   At extends UnknownType = DefaultAttachmentType,

--- a/package/src/components/MessageList/utils/getGroupStyles.ts
+++ b/package/src/components/MessageList/utils/getGroupStyles.ts
@@ -1,9 +1,8 @@
 import type { DateSeparators } from './getDateSeparators';
 
-import type { GroupType } from '../hooks/useMessageList';
-
 import type { PaginatedMessageListContextValue } from '../../../contexts/paginatedMessageListContext/PaginatedMessageListContext';
 import type { ThreadContextValue } from '../../../contexts/threadContext/ThreadContext';
+import type { GroupType } from '../../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/components/MessageList/utils/getLastReceivedMessage.ts
+++ b/package/src/components/MessageList/utils/getLastReceivedMessage.ts
@@ -1,3 +1,4 @@
+import type { MessageType } from '../../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,
@@ -8,7 +9,6 @@ import type {
   DefaultUserType,
   UnknownType,
 } from '../../../types/types';
-import type { MessageType } from '../hooks/useMessageList';
 
 export const getLastReceivedMessage = <
   At extends UnknownType = DefaultAttachmentType,

--- a/package/src/contexts/imageGalleryContext/ImageGalleryContext.tsx
+++ b/package/src/contexts/imageGalleryContext/ImageGalleryContext.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren, useContext, useState } from 'react';
 
 import { getDisplayName } from '../utils/getDisplayName';
 
-import type { MessageType } from '../../components/MessageList/hooks/useMessageList';
+import type { MessageType } from '../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/contexts/messageContext/MessageContext.tsx
+++ b/package/src/contexts/messageContext/MessageContext.tsx
@@ -6,9 +6,9 @@ import type { Attachment } from 'stream-chat';
 
 import type { ActionHandler } from '../../components/Attachment/Attachment';
 import type { TouchableHandlerPayload } from '../../components/Message/Message';
-import type { GroupType, MessageType } from '../../components/MessageList/hooks/useMessageList';
 import type { ChannelContextValue } from '../../contexts/channelContext/ChannelContext';
 import type { MessageContentType } from '../../contexts/messagesContext/MessagesContext';
+import type { GroupType, MessageType } from '../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -43,7 +43,7 @@ import type { MessageInputProps } from '../../components/MessageInput/MessageInp
 import type { MoreOptionsButtonProps } from '../../components/MessageInput/MoreOptionsButton';
 import type { SendButtonProps } from '../../components/MessageInput/SendButton';
 import type { UploadProgressIndicatorProps } from '../../components/MessageInput/UploadProgressIndicator';
-import type { MessageType } from '../../components/MessageList/hooks/useMessageList';
+import type { MessageType } from '../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/contexts/messageOverlayContext/MessageOverlayContext.tsx
+++ b/package/src/contexts/messageOverlayContext/MessageOverlayContext.tsx
@@ -8,10 +8,10 @@ import type { Attachment } from 'stream-chat';
 import type { Alignment, MessageContextValue } from '../messageContext/MessageContext';
 import type { MessagesContextValue } from '../messagesContext/MessagesContext';
 
-import type { GroupType, MessageType } from '../../components/MessageList/hooks/useMessageList';
 import type { MessageActionsProps } from '../../components/MessageOverlay/MessageActions';
 import type { OverlayReactionListProps } from '../../components/MessageOverlay/OverlayReactionList';
 import type { OverlayReactionsProps } from '../../components/MessageOverlay/OverlayReactions';
+import type { GroupType, MessageType } from '../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/contexts/messagesContext/MessagesContext.tsx
+++ b/package/src/contexts/messagesContext/MessagesContext.tsx
@@ -36,7 +36,6 @@ import type { MessageSimpleProps } from '../../components/Message/MessageSimple/
 import type { MessageTextProps } from '../../components/Message/MessageSimple/MessageTextContainer';
 import type { MarkdownRules } from '../../components/Message/MessageSimple/utils/renderText';
 import type { DateHeaderProps } from '../../components/MessageList/DateHeader';
-import type { MessageType } from '../../components/MessageList/hooks/useMessageList';
 import type { InlineDateSeparatorProps } from '../../components/MessageList/InlineDateSeparator';
 import type { MessageListProps } from '../../components/MessageList/MessageList';
 import type { ScrollToBottomButtonProps } from '../../components/MessageList/ScrollToBottomButton';
@@ -45,6 +44,7 @@ import type { OverlayReactionListProps } from '../../components/MessageOverlay/O
 import type { ReactionListProps } from '../../components/Message/MessageSimple/ReactionList';
 import type { ReplyProps } from '../../components/Reply/Reply';
 import type { FlatList } from '../../native';
+import type { MessageType } from '../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/contexts/threadContext/ThreadContext.tsx
+++ b/package/src/contexts/threadContext/ThreadContext.tsx
@@ -3,8 +3,7 @@ import React, { PropsWithChildren, useContext } from 'react';
 import { getDisplayName } from '../utils/getDisplayName';
 
 import type { ChannelState } from 'stream-chat';
-
-import type { MessageType } from '../../components/MessageList/hooks/useMessageList';
+import type { MessageType } from '../../types/messageTypes';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -6,6 +6,7 @@ export * from './emoji-data/compiled';
 
 export * from './icons';
 
+export * from './types/messageTypes';
 export * from './types/types';
 
 export * from './utils/Streami18n';

--- a/package/src/types/messageTypes.ts
+++ b/package/src/types/messageTypes.ts
@@ -1,0 +1,38 @@
+import type { ChannelState, MessageResponse } from 'stream-chat';
+import type {
+  DefaultAttachmentType,
+  DefaultChannelType,
+  DefaultCommandType,
+  DefaultEventType,
+  DefaultMessageType,
+  DefaultReactionType,
+  DefaultUserType,
+  UnknownType,
+} from './types';
+
+export type GroupType = 'bottom' | 'middle' | 'single' | 'top';
+
+export type MessagesWithStylesReadByAndDateSeparator<
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+> = MessageResponse<At, Ch, Co, Me, Re, Us> & {
+  groupStyles: GroupType[];
+  readBy: boolean | number;
+  dateSeparator?: Date;
+};
+
+export type MessageType<
+  At extends UnknownType = DefaultAttachmentType,
+  Ch extends UnknownType = DefaultChannelType,
+  Co extends string = DefaultCommandType,
+  Ev extends UnknownType = DefaultEventType,
+  Me extends UnknownType = DefaultMessageType,
+  Re extends UnknownType = DefaultReactionType,
+  Us extends UnknownType = DefaultUserType,
+> =
+  | ReturnType<ChannelState<At, Ch, Co, Ev, Me, Re, Us>['formatMessage']>
+  | MessagesWithStylesReadByAndDateSeparator<At, Ch, Co, Me, Re, Us>;


### PR DESCRIPTION
## Description of the pull request

Resolves this typescript warning about Excessively deep instantiation on develop branch

![Screenshot 2021-09-28 at 00 18 59](https://user-images.githubusercontent.com/11586388/134992990-cb52a2d0-8589-44f3-ad3c-8c41521d7a97.png)

## Cause of the issue

This issue was introduced recently in this commit - https://github.com/GetStream/stream-chat-react-native/commit/95d15e08f9d6f43f1d9e314fc200d60e1ce04413#diff-e7d0e211073121199347eedf392123d964951dbd5ebbda17d1f86c921ec39782

In this commit we consumed `message` value from `MessageContext`, which caused recursive imports for typescript.

## Fix

- Moved following typescript types from `useMessageList.ts` to `types/messageTypes.ts`
  - `GroupType`
  - `MessagesWithStylesReadByAndDateSeparator`
  - `MessageType`
- Updated the references of above types in all the files
- Export `types/messageTypes.ts` from the package