### PR TITLE
fix(Channel): Copy channel state on leading edge of throttling

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -165,7 +165,7 @@ const scrollToFirstUnreadThreshold = 4;
 const defaultThrottleInterval = 500;
 const defaultDebounceInterval = 500;
 const throttleOptions = {
-  leading: false,
+  leading: true,
   trailing: true,
 };
 const debounceOptions = {


### PR DESCRIPTION
This PR is meant to fix the problem where, after throttling the state updates inside of channel, it ended up kind of debouncing it instead because the leading parameter was set to false. Setting it to true should immediately copy the channel state and then start throttling