### PR TITLE
refactor: change error response.

### DIFF
--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -1,14 +1,5 @@
 import React, { useState } from 'react';
-import {
-  ImageErrorEventData,
-  ImageProps,
-  NativeSyntheticEvent,
-  PixelRatio,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { ImageProps, PixelRatio, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { CachedAttachmentImage } from '../CachedImages/CachedAttachmentImage';
 
@@ -53,7 +44,7 @@ const GalleryImage: React.FC<
 > = (props) => {
   const { channelId, height, messageId, uri, ...rest } = props;
 
-  const [error, setError] = useState<NativeSyntheticEvent<ImageErrorEventData>>(false);
+  const [error, setError] = useState<unknown>(false);
 
   return (
     <CachedAttachmentImage

--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -1,5 +1,14 @@
 import React, { useState } from 'react';
-import { ImageProps, PixelRatio, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import {
+  ImageErrorEventData,
+  ImageProps,
+  NativeSyntheticEvent,
+  PixelRatio,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
 import { CachedAttachmentImage } from '../CachedImages/CachedAttachmentImage';
 
@@ -44,7 +53,7 @@ const GalleryImage: React.FC<
 > = (props) => {
   const { channelId, height, messageId, uri, ...rest } = props;
 
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<NativeSyntheticEvent<ImageErrorEventData>>(false);
 
   return (
     <CachedAttachmentImage
@@ -54,7 +63,7 @@ const GalleryImage: React.FC<
         channelId,
         messageId,
       }}
-      onError={() => setError(true)}
+      onError={(error) => setError(error)}
       source={{
         uri: uri.includes('&h=%2A')
           ? error

--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -195,7 +195,7 @@ export const AttachmentPicker = React.forwardRef(
 
     const [currentIndex, setCurrentIndex] = useState(-1);
     const [endCursor, setEndCursor] = useState<string>();
-    const [photoError, setPhotoError] = useState(false);
+    const [photoError, setPhotoError] = useState<unknown>(false);
     const [hasNextPage, setHasNextPage] = useState(true);
     const [loadingPhotos, setLoadingPhotos] = useState(false);
     const [photos, setPhotos] = useState<Asset[]>([]);
@@ -224,7 +224,7 @@ export const AttachmentPicker = React.forwardRef(
           setHasNextPage(results.hasNextPage || false);
         } catch (error) {
           console.log(error);
-          setPhotoError(true);
+          setPhotoError(error);
         }
         setLoadingPhotos(false);
       }

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -582,7 +582,7 @@ const ChannelWithContext = <
   } = useTheme();
 
   const [editing, setEditing] = useState<boolean | MessageType<At, Ch, Co, Ev, Me, Re, Us>>(false);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<unknown>(false);
   const [hasMore, setHasMore] = useState(true);
   const [lastRead, setLastRead] =
     useState<ChannelContextValue<At, Ch, Co, Ev, Me, Re, Us>['lastRead']>();
@@ -827,7 +827,7 @@ const ChannelWithContext = <
       setHasMore(true);
       copyChannelState();
     } catch (err) {
-      setError(true);
+      setError(err);
       setLoading(false);
       setLastRead(new Date());
     }
@@ -977,7 +977,7 @@ const ChannelWithContext = <
       }
     } catch (err) {
       console.warn('Thread loading request failed with error', err);
-      setError(true);
+      setError(err);
       setThreadLoadingMore(false);
       throw err;
     }
@@ -1080,7 +1080,7 @@ const ChannelWithContext = <
         setThreadMessages([...channel.state.threads[thread.id]]);
       }
     } catch (err) {
-      setError(true);
+      setError(err);
       setLoading(false);
     }
 
@@ -1447,7 +1447,7 @@ const ChannelWithContext = <
       }
     } catch (err) {
       console.warn('Message pagination request failed with error', err);
-      setError(true);
+      setError(err);
       setLoadingMore(false);
       throw err;
     }
@@ -1482,7 +1482,7 @@ const ChannelWithContext = <
       }
     } catch (err) {
       console.warn('Message pagination request failed with error', err);
-      setError(true);
+      setError(err);
       setLoadingMoreRecent(false);
       throw err;
     }
@@ -1621,7 +1621,7 @@ const ChannelWithContext = <
         }
       } catch (err) {
         console.warn('Message pagination request failed with error', err);
-        setError(true);
+        setError(err);
         setThreadLoadingMore(false);
         throw err;
       }

--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -60,7 +60,7 @@ export const usePaginatedChannels = <
   );
   const activeChannels = useActiveChannelsRefContext();
 
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<unknown>(false);
   const [hasNextPage, setHasNextPage] = useState(true);
   const lastRefresh = useRef(Date.now());
   const querying = useRef(false);

--- a/package/src/components/Indicators/LoadingErrorIndicator.tsx
+++ b/package/src/components/Indicators/LoadingErrorIndicator.tsx
@@ -48,7 +48,7 @@ const LoadingErrorWrapper: React.FC<LoadingErrorWrapperProps> = (props) => {
 };
 
 export type LoadingErrorProps = {
-  error?: boolean;
+  error?: unknown;
   listType?: 'channel' | 'message' | 'default';
   loadNextPage?: () => Promise<void>;
   retry?: () => void;

--- a/package/src/components/Message/utils/messageActions.ts
+++ b/package/src/components/Message/utils/messageActions.ts
@@ -48,7 +48,7 @@ export const messageActions = <
   copyMessage: MessageAction | null;
   deleteMessage: MessageAction | null;
   editMessage: MessageAction | null;
-  error: boolean;
+  error: unknown;
   flagMessage: MessageAction | null;
   isMyMessage: boolean;
   isThreadMessage: boolean;

--- a/package/src/components/Reply/Reply.tsx
+++ b/package/src/components/Reply/Reply.tsx
@@ -102,7 +102,7 @@ const ReplyWithContext = <
     t,
   } = props;
 
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<unknown>(false);
 
   const {
     theme: {

--- a/package/src/components/docs/ListProps.md
+++ b/package/src/components/docs/ListProps.md
@@ -1,6 +1,6 @@
 All props available in the [ChannelList](#channellist) component are passed along to the List component. Additionally, the following props are provided to the List component:
 
-- `error` {boolean} Error in channels query, if any
+- `error` {unknown} Error in channels query, if any
 - `channels` {array} List of channel objects
 - `forceUpdate` {number} Incremental number change to force update the FlatList
 - `hasNextPage` {boolean} Whether or not the FlatList has another page to render

--- a/package/src/contexts/channelContext/ChannelContext.tsx
+++ b/package/src/contexts/channelContext/ChannelContext.tsx
@@ -44,7 +44,7 @@ export type ChannelContextValue<
    * This is similar to reaction UX on [iMessage application](https://en.wikipedia.org/wiki/IMessage).
    */
   enforceUniqueReaction: boolean;
-  error: boolean;
+  error: unknown;
   /**
    * When set to false, it will disable giphy command on MessageInput component.
    */

--- a/package/src/contexts/channelsContext/ChannelsContext.tsx
+++ b/package/src/contexts/channelsContext/ChannelsContext.tsx
@@ -67,7 +67,7 @@ export type ChannelsContextValue<
   /**
    * Error in channels query, if any
    */
-  error: boolean;
+  error: unknown;
   /**
    * Custom loading indicator to display at bottom of the list, while loading further pages
    *

--- a/package/src/contexts/messagesContext/MessagesContext.tsx
+++ b/package/src/contexts/messagesContext/MessagesContext.tsx
@@ -428,7 +428,7 @@ export type MessagesContextValue<
         deleteMessage: MessageAction | null;
         dismissOverlay: () => void;
         editMessage: MessageAction | null;
-        error: boolean;
+        error: unknown;
         flagMessage: MessageAction | null;
         isMyMessage: boolean;
         isThreadMessage: boolean;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This PR introduces the change in Error response which was previously just a `boolean` value. This allows developers to get the error trace rather than just be aware that there's an error.

Reference JIRA ticket - https://stream-io.atlassian.net/browse/CRNS-434
Reference Slack Discussion - https://getstream.slack.com/archives/C021MF2V1CH/p1632127926136700?thread_ts=1632127534.136600&cid=C021MF2V1CH

Note - We don't have any error type which is defined in the stream-client API or anywhere else, I thought of using `Error` but that could behave weirdly in some cases and we don't know about the default value for state in that case. That is why I have used `unknown` after discussion. Any changes or suggestions to the same are welcomed. 