### PR TITLE
fix: support external link for targetSdkVersion >=30

### DIFF
--- a/docusaurus/docs/reactnative/basics/troubleshooting.mdx
+++ b/docusaurus/docs/reactnative/basics/troubleshooting.mdx
@@ -209,6 +209,16 @@ android {
 }
 ```
 
+## External Link not opening
+
+### Android
+
+Opening an external link doesn't work without permissions on `targetSdkVersion` >= 30. So, the following permission must be included int the `AndroidManifest.xml` file.
+
+```xml
+<uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+```
+
 ## GIF and WebP not displaying
 
 ### Android

--- a/docusaurus/docs/reactnative/basics/troubleshooting.mdx
+++ b/docusaurus/docs/reactnative/basics/troubleshooting.mdx
@@ -219,6 +219,10 @@ Opening an external link doesn't work without permissions on `targetSdkVersion` 
 <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 ```
 
+:::caution
+**Note:** Make sure you are aware of [upcoming policies](https://support.google.com/googleplay/android-developer/answer/10158779) that this change will be subjected to.
+:::
+
 ## GIF and WebP not displaying
 
 ### Android

--- a/examples/NativeMessaging/android/app/src/main/AndroidManifest.xml
+++ b/examples/NativeMessaging/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application

--- a/examples/SampleApp/android/app/src/main/AndroidManifest.xml
+++ b/examples/SampleApp/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application

--- a/examples/TypeScriptMessaging/android/app/src/main/AndroidManifest.xml
+++ b/examples/TypeScriptMessaging/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This PR introduces support and adds documentation for the issue: No support for opening the external links on applications having targetSdkVersion >=30 on android. This is also done for our example applications.

Reference JIRA issue - https://stream-io.atlassian.net/browse/CRNS-441
