### PR TITLE
fix: preview message & channellist customization

### DIFF
--- a/package/src/components/ChannelList/ChannelListLoadingIndicator.tsx
+++ b/package/src/components/ChannelList/ChannelListLoadingIndicator.tsx
@@ -13,6 +13,7 @@ const styles = StyleSheet.create({
 export const ChannelListLoadingIndicator: React.FC = () => {
   const {
     theme: {
+      channelListLoadingIndicator: { container },
       colors: { white_snow },
     },
   } = useTheme();
@@ -20,7 +21,7 @@ export const ChannelListLoadingIndicator: React.FC = () => {
 
   return (
     <View
-      style={[styles.container, { backgroundColor: white_snow }]}
+      style={[styles.container, { backgroundColor: white_snow }, container]}
       testID='channel-list-loading-indicator'
     >
       {Array.from(Array(numberOfSkeletons)).map((_, index) => (

--- a/package/src/components/ChannelPreview/ChannelPreviewMessage.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewMessage.tsx
@@ -51,7 +51,7 @@ export const ChannelPreviewMessage: React.FC<ChannelPreviewMessageProps> = ({
         preview.text ? (
           <Text
             key={`${preview.text}_${index}`}
-            style={[{ color: grey }, preview.bold ? styles.bold : {}]}
+            style={[{ color: grey }, preview.bold ? styles.bold : {}, message]}
           >
             {preview.text}
           </Text>

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -110,6 +110,9 @@ export type Theme = {
     container: ViewStyle;
     errorText: TextStyle;
   };
+  channelListLoadingIndicator: {
+    container: ViewStyle;
+  };
   channelListMessenger: {
     flatList: ViewStyle;
     flatListContent: ViewStyle;
@@ -530,6 +533,9 @@ export const defaultTheme: Theme = {
   channelListHeaderErrorIndicator: {
     container: {},
     errorText: {},
+  },
+  channelListLoadingIndicator: {
+    container: {},
   },
   channelListMessenger: {
     flatList: {},


### PR DESCRIPTION
Currently, there is a bug where we cannot customize the preview message color. The parent text node consumes the message from context so we can apply it to style. But the child text node doesn't consume anything beyond the base styles which enforces the grey color. As seen in develop branch here

https://github.com/GetStream/stream-chat-react-native/blob/develop/package/src/components/ChannelPreview/ChannelPreviewMessage.tsx#L49-#L60


As a consumer, if I want to update the preview message color to a color other than the theme color `grey` I cannot. This solves that issue

ChannelListLoadingIndicator background can be updated based on` white_snow`, however if we want the background to be different from the color that is `white_snow` this is not currently possible. In this PR this is resolved by add the following to the theme context

```tsx
channelListLoadingIndicator: {
    container: {},
  },
  ```


## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
