### PR TITLE
docs: Fix broken link to reanimated docs

### DIFF
--- a/docusaurus/docs/reactnative/basics/getting_started.mdx
+++ b/docusaurus/docs/reactnative/basics/getting_started.mdx
@@ -100,7 +100,7 @@ To be able to use the Stream Chat React Native SDK, a few dependencies must meet
 ### Additional Steps
 
 - `react-native` - [additional installation steps](https://reactnative.dev/docs/image#gif-and-webp-support-on-android)
-- `react-native-reanimated` - [additional installation steps](https://docs.swmansion.com/react-native-reanimated/docs/installation).
+- `react-native-reanimated` - [additional installation steps](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation).
 - `react-native-image-crop-picker` - [additional installation steps](https://github.com/ivpusic/react-native-image-crop-picker#step-3)
 - `react-native-cameraroll` - [additional installation steps](https://github.com/react-native-cameraroll/react-native-cameraroll#permissions)
 - `react-native-gesture-handler` - [additional installation steps](https://docs.swmansion.com/react-native-gesture-handler/docs/#android)


### PR DESCRIPTION
## 🎯 Goal

To replace a broken link in our documentation

## 🛠 Implementation details

N/A

## 🎨 UI Changes

N/A

## 🧪 Testing

N/A

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
-  ~New code is covered by tests~
- ~Screenshots added for visual changes~
- [x] Documentation is updated

