### PR TITLE
chore: Upgrade gradle kotlin plugin to 1.3.10

### DIFF
--- a/examples/NativeMessaging/android/build.gradle
+++ b/examples/NativeMessaging/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         targetSdkVersion = 30
         androidXCore = "1.0.2"
         ndkVersion = "20.1.5948944"
-        kotlinVersion = '1.3.0'
+        kotlinVersion = '1.3.10'
         // Put here other AndroidX dependencies
     }
     repositories {

--- a/examples/SampleApp/android/build.gradle
+++ b/examples/SampleApp/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         targetSdkVersion = 30
         androidXCore = "1.0.2"
         ndkVersion = "20.1.5948944"
-        kotlinVersion = '1.3.0'
+        kotlinVersion = '1.3.10'
     }
     repositories {
         google()


### PR DESCRIPTION
## 🎯 Goal

The e2e tests fail, reporting the version as wrong on develop. A [fix was merged](https://github.com/GetStream/stream-chat-react-native/pull/923) to v4.0.0, but not to develop, though this PR also updates the NativeMessaging app as that also is built by our tests.

## 🛠 Implementation details

Updated the version of the plugin in NativeMessaging and SampleApp

## 🎨 UI Changes

N/A

## 🧪 Testing

Covered by the e2e tests ran by our workflows

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [x] New code is covered by tests
- [-] Screenshots added for visual changes
- [-] Documentation is updated

