### PR TITLE
chore: Ignore .log files in the project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 NEXT_RELEASE_CHANGELOG.md
+*.log


### PR DESCRIPTION
## 🎯 Goal

Thanks to @khushal87 for noticing in #932 that `.log` files seem not to be ignored by our `.gitignore` in the project root - adding it here by wildcard `*.log` as running detox tests from the root of the project produces emulator logs in the root. (`{deviceName}.log)

## 🛠 Implementation details
See above

## 🎨 UI Changes

N/A
## 🧪 Testing

N/A

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [-] New code is covered by tests
- [-] Screenshots added for visual changes
- [-] Documentation is updated

