### PR TITLE
fix: Add multiple mentions

### DIFF
--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -401,7 +401,7 @@ const AutoCompleteInputWithContext = <
     } else if (giphyEnabled && !(await handleCommand(text))) {
       const mentionTokenMatch = text
         .slice(0, selectionEnd.current)
-        .match(/(?!^|\W)?@[^\s]*\s?[^\s]*$/g);
+        .match(/(?!^|\W)?@[^\s@]*\s?[^\s@]*$/g);
       if (mentionTokenMatch) {
         handleMentions({ tokenMatch: mentionTokenMatch });
       } else {

--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -335,7 +335,7 @@ const AutoCompleteInputWithContext = <
   };
 
   const handleMentions = ({ tokenMatch }: { tokenMatch: RegExpMatchArray | null }) => {
-    const lastToken = tokenMatch?.[tokenMatch.length - 1].trim();
+    const lastToken = tokenMatch?.[tokenMatch.length - 1];
     const handleMentionsTrigger =
       (lastToken && Object.keys(triggerSettings).find((trigger) => trigger === lastToken[0])) ||
       null;

--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -288,12 +288,7 @@ const AutoCompleteInputWithContext = <
 
     const textToModify = text.slice(0, selectionEnd.current);
 
-    const startOfTokenPosition = textToModify.search(
-      /**
-       * It's important to escape the trigger char for chars like [, (,...
-       */
-      new RegExp(`\\${trigger}[^\\${trigger}${'\\s'}]*$`),
-    );
+    const startOfTokenPosition = textToModify.lastIndexOf(trigger, selectionEnd.current);
 
     const newCaretPosition = computeCaretPosition(newTokenString, startOfTokenPosition);
 

--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -292,7 +292,7 @@ const AutoCompleteInputWithContext = <
       /**
        * It's important to escape the trigger char for chars like [, (,...
        */
-      new RegExp(`\\${trigger}${`[^\\${trigger}${'\\s'}]`}*$`),
+      new RegExp(`\\${trigger}[^\\${trigger}${'\\s'}]*$`),
     );
 
     const newCaretPosition = computeCaretPosition(newTokenString, startOfTokenPosition);


### PR DESCRIPTION
## 🎯 Goal

As mentioned in #934, there are bugs in selecting multiple users, and certain inputs end up overwriting the content of the input field. This PR provides a fix for the issues I have been able to reproduce and isolate.

## 🛠 Implementation details

![Okay, so..](https://media.giphy.com/media/U8B56gfwLRqUboONZi/giphy.gif)

This has both been pretty tricky to make sense of and I might have redefined what it means to be code blind[^1], but at the same time pretty obvious in hindsight, so I'm compiling the notes I've taken looking through this sort of as documentation for any future work on suggestions. Forgive me if there are any gaps or unclear parts of my explanation, but I'm happy to elaborate/clarify if anybody asks. 

After testing things out on both SDK version [3.8.3]() and [3.9.0](), reproducing the issue with both versions[^2] I realized after more testing that things started acting weird once I selected a suggested user with only one name. Meaning that selecting users like `@John Doe` and `@Jan Jansen` after one another seemed to work fine, but as soon as you select a user with a single name like `@Ola` it would give the same experience as shown in #934.

This has ended up as three pretty tiny changes, but I'll do my best to explain each of them in case it could help in future work on simplifying and/or improving the suggestions/mentions logic. 

### fix: Stop matching mentions at next @ (6e7ba24)

When text in the child `TextInput` of AutoCompleteInput changes, `handleSuggestions` is called to handle either a Command, a matching emoji token (`:emoji`) or a mention token (`@User Name`). When a mention token is matched, we call `handleMention`.

The regex used to match a user here matches in order:
1. Optionally not the start of a line, or any non-word character
2. The `@` character
3. Any non-whitespace character, zero to infinity times
4. An optional whitespace
5. Same as 3, optional

This causes some trouble as it can determine that `@John Doe ` should not be handled as a suggestion any more since the suggestion adds the trailing whitespace, but it does not work for any cases where user names aren't `FirstName LastName`. As we don't have a good way at the moment to definitely know what a complete user name looks like for all inputs, I've kept the check for two names for now, but adding `@` to the list of characters that won't match with a user name.

### fix: Avoid trim when checking for tokens ()

I had a hard time figuring out a good way to ensure that we don't show suggestions when a suggestion has been selected for a particular cursor position in the input field. This is a workaround that isn't elegant, but seems to work. 

In `handleMentions`, we take the last match returned by the regex in the step above, and trim it before getting the match without the `@` symbol to pass on to the dataProvider that looks up suggestions. 

I realized that trimming the string doesn't make a difference for the function it's done in, but the effect of passing a trailing whitespace to the dataProvider is that the lookup with fail if the full user name is `John` and no other users are named `John SomethingOrOther`.

I haven't yet found a better way to reliably stop suggestions from popping up for single-name user names without rewriting large parts of how the whole setup works. Suggestions are very <sup>very very</sup> welcome if anybody has any ideas. (@ vishalnarkhede?)

### fix: Get start of new token based on cursor placement ()

If you already have more than one mention in the AutoCompleteInput, enter parts of a suggestion with a 2-word user name (`John D` for `John Doe` for example), and then select the suggestion the whole input field is cleared out. This was caused by the search for the specified regex failing, and I've replaced it by looking for the nearest token to the left of the cursor. 

### Other observations/notes

* ❓ Emoji have to be selected from the Suggestion list to render, so writing `:custard:` for example will stay the same literal string before and after sending the message
* ❓ We stop tracking suggestions entirely if the character directly behind the cursor is a space and `isTrackingStarted` is true: This seems like a hotfix or similar from the past, so I assume it's there for a good reason. But I think we should at least make it clear what that reason is, as it's a bit confusing.
* 



1. Matching a mention 'token'
2. Not trimming matches, so the query will fail
3. Improving the token lookup for updating the text when a user has been selected

## 🎨 UI Changes

_ Add relevant screenshots_

<details>
    <summary>iOS</summary>

| Before | After |
| --- | --- |
| img | img |
</details>


<details>
    <summary>Android</summary>

| Before | After |
| --- | --- |
| img | img |
</details>
## 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

[^1]: https://www.urbandictionary.com/define.php?term=codeblind
[^2]: Probably because of the test data in the initial repro I did, I at first couldn't reproduce it on 3.9.0. The two separate repros are a result of that.