### PR TITLE
Fix: lint warnings in the SDK and example apps

### DIFF
--- a/examples/SampleApp/.eslintrc.json
+++ b/examples/SampleApp/.eslintrc.json
@@ -140,7 +140,7 @@
         "no-mixed-spaces-and-tabs": 1,
         "no-self-compare": 2,
         "no-underscore-dangle": [2, { "allowAfterThis": true }],
-        "no-unused-vars": [1, { "ignoreRestSiblings": true }],
+        "no-unused-vars": [1, { "ignoreRestSiblings": true, "args":"none" }],
         "no-useless-concat": 2,
         "no-var": 2,
         "object-shorthand": 1,

--- a/examples/SampleApp/src/components/ChatScreenHeader.tsx
+++ b/examples/SampleApp/src/components/ChatScreenHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Image, StyleSheet, TouchableOpacity } from 'react-native';
 import { CompositeNavigationProp, useNavigation } from '@react-navigation/native';
 import { useChatContext, useTheme } from 'stream-chat-react-native';
 

--- a/examples/SampleApp/src/hooks/useChatClient.ts
+++ b/examples/SampleApp/src/hooks/useChatClient.ts
@@ -15,8 +15,6 @@ import type {
   LoginConfig,
 } from '../types';
 
-const getRandomInt = (min: number, max: number) => Math.floor(Math.random() * (max - min)) + min;
-
 export const useChatClient = () => {
   const [chatClient, setChatClient] = useState<StreamChat<
     LocalAttachmentType,
@@ -41,7 +39,6 @@ export const useChatClient = () => {
     >(config.apiKey, {
       timeout: 6000,
     });
-    const randomSeed = getRandomInt(1, 50);
     const user = {
       id: config.userId,
       image: config.userImage,

--- a/examples/SampleApp/src/icons/Close.tsx
+++ b/examples/SampleApp/src/icons/Close.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'stream-chat-react-native';
 
 import { IconProps } from '../utils/base';
 
-export const Close: React.FC<IconProps> = ({ active, height, width }) => {
+export const Close: React.FC<IconProps> = ({ height, width }) => {
   const {
     theme: {
       colors: { black },

--- a/examples/SampleApp/src/icons/RightArrow.tsx
+++ b/examples/SampleApp/src/icons/RightArrow.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'stream-chat-react-native';
 
 import { IconProps } from '../utils/base';
 
-export const RightArrow: React.FC<IconProps> = ({ active, height, width }) => {
+export const RightArrow: React.FC<IconProps> = ({ height, width }) => {
   const {
     theme: {
       colors: { accent_blue },

--- a/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
+++ b/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
@@ -161,7 +161,7 @@ export const NewDirectMessagingScreen: React.FC<NewDirectMessagingScreenProps> =
 
   const [focusOnMessageInput, setFocusOnMessageInput] = useState(false);
   const [focusOnSearchInput, setFocusOnSearchInput] = useState(true);
-  // As we dont use the first state variable we can simple not have it here and just separate with a comma within the array. Fix for no-usused-vars
+  // As we don't use the state value, we can omit it here and separate it with a comma within the array.
   const [, setMessageInputText] = useState('');
 
   // When selectedUsers are changed, initiate a channel with those users as members,

--- a/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
+++ b/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
@@ -1,13 +1,11 @@
-import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { Alert, Platform, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import { Platform, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   Channel,
   Group,
   MessageInput,
   MessageList,
-  SendButton,
-  SendButtonProps,
   User,
   UserAdd,
   useTheme,
@@ -163,7 +161,8 @@ export const NewDirectMessagingScreen: React.FC<NewDirectMessagingScreenProps> =
 
   const [focusOnMessageInput, setFocusOnMessageInput] = useState(false);
   const [focusOnSearchInput, setFocusOnSearchInput] = useState(true);
-  const [messageInputText, setMessageInputText] = useState('');
+  // As we dont use the first state variable we can simple not have it here and just separate with a comma within the array. Fix for no-usused-vars
+  const [, setMessageInputText] = useState('');
 
   // When selectedUsers are changed, initiate a channel with those users as members,
   // and set it as a channel on current screen.


### PR DESCRIPTION
## 🎯 Goal
Running the `yarn lint` command produces around 28-30 warnings across the SDK and the sample app. Most of them are related to unused vars. This PR intends to fix them all. 
<!-- Describe why we are making this change -->

## 🛠 Implementation details
The solution for no-used-vars are as follows:
- Using a `_` character and prepend it to the parameter. This would simply let the linter avoid checks on such parameters.
- Adding an `args` argument to the `no-unused-vars` and setting it to `none`. This avoids no-unused-vars checks from the parameters of the functions.

I personally preferred the 2nd solution because a function parameter could be used or unused and checking them or not doesn't make much difference. Moreover, usage 0f `_` might confuse others.

I will be happy to get suggestions on this and also feedback if the solution looks fine. 
<!-- Provide a description of the implementation -->

## 🎨 UI Changes
None
<!-- Add relevant screenshots -->

<details>
    <summary>iOS</summary>

| Before | After |
| --- | --- |
| img | img |
</details>


<details>
    <summary>Android</summary>

| Before | After |
| --- | --- |
| img | img |
</details>

## 🧪 Testing
NA
<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

