### PR TITLE
fix: fixed react warnings - Can not perform a React state update on an unmounted component [CRNS-444]

### DIFF
--- a/package/src/hooks/useIsMountedRef.ts
+++ b/package/src/hooks/useIsMountedRef.ts
@@ -1,15 +1,18 @@
 import { useEffect, useRef } from 'react';
 
 export const useIsMountedRef = () => {
-  const isMounted = useRef<boolean | null>(null);
+  // Initial value has been set to true, since this hook exist only for sole purpose of
+  // avoiding any setState calls (within async operation) after component gets unmounted.
+  // Basically we don't need to know about state change from component being initialized -> mounted.
+  // We only need a state change from initialized or mounted state -> unmounted state.
+  const isMounted = useRef(true);
 
-  useEffect(() => {
-    isMounted.current = true;
-
-    return () => {
+  useEffect(
+    () => () => {
       isMounted.current = false;
-    };
-  }, []);
+    },
+    [],
+  );
 
   return isMounted;
 };

--- a/package/src/hooks/useIsMountedRef.ts
+++ b/package/src/hooks/useIsMountedRef.ts
@@ -1,5 +1,23 @@
 import { useEffect, useRef } from 'react';
 
+/**
+ * Returns mount status of component. This hook can be used for purpose of avoiding any
+ * setState calls (within async operation) after component gets unmounted.
+ *
+ * @example
+ * ```
+ * const isMounted = useIsMountedRef();
+ * const [dummyValue, setDummyValue] = useState(false);
+ *
+ * useEffect(() => {
+ *  someAsyncOperation().then(() => {
+ *    if (isMounted.current) setDummyValue(true);
+ *  })
+ * })
+ * ```
+ *
+ * @returns isMounted {Object} Mount status ref for the component.
+ */
 export const useIsMountedRef = () => {
   // Initial value has been set to true, since this hook exist only for sole purpose of
   // avoiding any setState calls (within async operation) after component gets unmounted.

--- a/package/src/hooks/useIsMountedRef.ts
+++ b/package/src/hooks/useIsMountedRef.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+
+export const useIsMountedRef = () => {
+  const isMounted = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    isMounted.current = true;
+
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  return isMounted;
+};

--- a/package/src/hooks/useStreami18n.ts
+++ b/package/src/hooks/useStreami18n.ts
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 
-import type { TranslationContextValue } from '../contexts/translationContext/TranslationContext';
+import { useIsMountedRef } from './useIsMountedRef';
 import { Streami18n } from '../utils/Streami18n';
+
+import type { TranslationContextValue } from '../contexts/translationContext/TranslationContext';
 
 export const useStreami18n = ({
   i18nInstance,
@@ -11,7 +13,7 @@ export const useStreami18n = ({
   i18nInstance?: Streami18n;
 }) => {
   const [loadingTranslators, setLoadingTranslators] = useState(true);
-
+  const isMounted = useIsMountedRef();
   const i18nInstanceExists = !!i18nInstance;
   useEffect(() => {
     let streami18n: Streami18n;
@@ -26,7 +28,7 @@ export const useStreami18n = ({
       setTranslators((prevTranslator) => ({ ...prevTranslator, t })),
     );
     streami18n.getTranslators().then((translator) => {
-      if (translator) setTranslators(translator);
+      if (translator && isMounted.current) setTranslators(translator);
     });
 
     setLoadingTranslators(false);


### PR DESCRIPTION
## 🎯 Goal

Fixes https://github.com/GetStream/stream-chat-react-native/issues/693

## 🛠 Implementation details

- Introduced a hook - `useIsMountedRef`, which can be used to keep track of mount status of hook/component.
- Updated `useIsOnline`, `useStreami18n` and `usePaginatedChannels` to use mounted status and prevent setState calls in unmounted state.
- Updated useIsOnline component to use `unsubscribe` methods returned by `client.on(...)` method, instead of using `client.off()` to unsubscribe event listener

## 🎨 UI Changes

NA
