### PR TITLE
Fix: remove long message text and scrollview from message overlay [CRNS - 278]

### DIFF
--- a/docusaurus/docs/reactnative/common-content/core-components/overlay-provider/props/message_text_number_of_lines.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/overlay-provider/props/message_text_number_of_lines.mdx
@@ -1,0 +1,5 @@
+Number of lines for the message text in the Message Overlay.
+
+| Type | Default |
+| - | - |
+| number | 5 |

--- a/docusaurus/docs/reactnative/core-components/overlay_provider.mdx
+++ b/docusaurus/docs/reactnative/core-components/overlay_provider.mdx
@@ -15,6 +15,7 @@ import I18nInstance from '../common-content/core-components/overlay-provider/pro
 import ImageGalleryCustomComponents from '../common-content/core-components/overlay-provider/props/image_gallery_custom_components.mdx';
 import ImageGalleryGridHandleHeight from '../common-content/core-components/overlay-provider/props/image_gallery_grid_handle_height.mdx';
 import ImageGalleryGridSnapPoints from '../common-content/core-components/overlay-provider/props/image_gallery_grid_snap_points.mdx';
+import MessageTextNumberOfLines from '../common-content/core-components/overlay-provider/props/message_text_number_of_lines.mdx';
 import NumberOfAttachmentImagesToLoadPerCall from '../common-content/core-components/overlay-provider/props/number_of_attachment_images_to_load_per_call.mdx';
 import NumberOfAttachmentPickerImageColumns from '../common-content/core-components/overlay-provider/props/number_of_attachment_picker_image_columns.mdx';
 import NumberOfImageGalleryGridColumns from '../common-content/core-components/overlay-provider/props/number_of_image_gallery_grid_columns.mdx';
@@ -161,6 +162,10 @@ This can also be set via the `setBottomInset` function provided by the `useAttac
 ### imageGalleryGridSnapPoints
 
 <ImageGalleryGridSnapPoints />
+
+### messageTextNumberOfLines
+
+<MessageTextNumberOfLines />
 
 ### numberOfAttachmentImagesToLoadPerCall
 

--- a/package/src/components/Message/MessageSimple/MessageTextContainer.tsx
+++ b/package/src/components/Message/MessageSimple/MessageTextContainer.tsx
@@ -57,6 +57,7 @@ export type MessageTextContainerPropsWithContext<
   Pick<MessagesContextValue<At, Ch, Co, Ev, Me, Re, Us>, 'markdownRules' | 'MessageText'> & {
     markdownStyles?: MarkdownStyle;
     messageOverlay?: boolean;
+    messageTextNumberOfLines?: number;
     styles?: Partial<{
       textContainer: StyleProp<ViewStyle>;
     }>;
@@ -81,6 +82,7 @@ const MessageTextContainerWithContext = <
     message,
     messageOverlay,
     MessageText,
+    messageTextNumberOfLines,
     onLongPress,
     onlyEmojis,
     onPress,
@@ -121,6 +123,7 @@ const MessageTextContainerWithContext = <
           },
           message,
           messageOverlay,
+          messageTextNumberOfLines,
           onLongPress,
           onlyEmojis,
           onPress,
@@ -192,6 +195,7 @@ export const MessageTextContainer = <
   const { message, onLongPress, onlyEmojis, onPress, preventPress } =
     useMessageContext<At, Ch, Co, Ev, Me, Re, Us>();
   const { markdownRules, MessageText } = useMessagesContext<At, Ch, Co, Ev, Me, Re, Us>();
+  const { messageTextNumberOfLines } = props;
 
   return (
     <MemoizedMessageTextContainer
@@ -199,6 +203,7 @@ export const MessageTextContainer = <
         markdownRules,
         message,
         MessageText,
+        messageTextNumberOfLines,
         onLongPress,
         onlyEmojis,
         onPress,

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -261,7 +261,7 @@ export const renderText = <
 
   const customRules = {
     link: { react },
-    // to deal with the long text  message in the message overlay text
+    // Truncate long text content in the message overlay
     paragraph: messageTextNumberOfLines ? { react: paragraphText } : {},
     // we have no react rendering support for reflinks
     reflink: { match: () => null },

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -186,34 +186,26 @@ export const renderText = <
     };
 
     state.withinLink = true;
-    const link = React.createElement(
-      Text,
-      {
-        key: state.key,
-        onLongPress,
-        onPress,
-        style: styles.autolink,
-        suppressHighlighting: true,
-      },
-      output(node.content, state),
+    const link = (
+      <Text
+        key={state.key}
+        onLongPress={onLongPress}
+        onPress={onPress}
+        style={styles.autolink}
+        suppressHighlighting={true}
+      >
+        {output(node.content, state)}
+      </Text>
     );
     state.withinLink = false;
     return link;
   };
 
-  const paragraphText: ReactNodeOutput = (node, output, { ...state }) => {
-    const paragraph = React.createElement(
-      Text,
-      {
-        key: state.key,
-        numberOfLines: messageTextNumberOfLines,
-        style: styles.paragraph,
-      },
-      output(node.content, state),
-    );
-
-    return paragraph;
-  };
+  const paragraphText: ReactNodeOutput = (node, output, { ...state }) => (
+    <Text key={state.key} numberOfLines={messageTextNumberOfLines} style={styles.paragraph}>
+      {output(node.content, state)}
+    </Text>
+  );
 
   const mentionedUsers = Array.isArray(mentioned_users)
     ? mentioned_users.reduce((acc, cur) => {
@@ -247,15 +239,10 @@ export const renderText = <
       }
     };
 
-    return React.createElement(
-      Text,
-      {
-        key: state.key,
-        onLongPress,
-        onPress,
-        style: styles.mentions,
-      },
-      Array.isArray(node.content) ? node.content[0]?.content || '' : output(node.content, state),
+    return (
+      <Text key={state.key} onLongPress={onLongPress} onPress={onPress} style={styles.mentions}>
+        {Array.isArray(node.content) ? node.content[0]?.content || '' : output(node.content, state)}
+      </Text>
     );
   };
 

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -81,6 +81,7 @@ export type RenderTextParams<
   markdownRules?: MarkdownRules;
   markdownStyles?: MarkdownStyle;
   messageOverlay?: boolean;
+  messageTextNumberOfLines?: number;
   onLink?: (url: string) => Promise<void>;
   onlyEmojis?: boolean;
 };
@@ -102,6 +103,7 @@ export const renderText = <
     markdownStyles,
     message,
     messageOverlay,
+    messageTextNumberOfLines,
     onLink: onLinkParams,
     onLongPress: onLongPressParam,
     onlyEmojis,
@@ -130,6 +132,7 @@ export const renderText = <
   }
 
   newText = newText.replace(/[<&"'>]/g, '\\$&');
+
   const styles: MarkdownStyle = {
     ...defaultMarkdownStyles,
     ...markdownStyles,
@@ -198,6 +201,20 @@ export const renderText = <
     return link;
   };
 
+  const paragraphText: ReactNodeOutput = (node, output, { ...state }) => {
+    const paragraph = React.createElement(
+      Text,
+      {
+        key: state.key,
+        numberOfLines: messageTextNumberOfLines,
+        style: styles.paragraph,
+      },
+      output(node.content, state),
+    );
+
+    return paragraph;
+  };
+
   const mentionedUsers = Array.isArray(mentioned_users)
     ? mentioned_users.reduce((acc, cur) => {
         const userName = cur.name || cur.id || '';
@@ -244,6 +261,8 @@ export const renderText = <
 
   const customRules = {
     link: { react },
+    // to deal with the long text  message in the message overlay text
+    paragraph: messageTextNumberOfLines ? { react: paragraphText } : {},
     // we have no react rendering support for reflinks
     reflink: { match: () => null },
     ...(mentionedUsers

--- a/package/src/components/MessageOverlay/MessageOverlay.tsx
+++ b/package/src/components/MessageOverlay/MessageOverlay.tsx
@@ -84,6 +84,7 @@ const styles = StyleSheet.create({
 
 const screenHeight = vh(100);
 const halfScreenHeight = vh(50);
+const DefaultMessageTextNumberOfLines = 5;
 
 export type MessageOverlayPropsWithContext<
   At extends UnknownType = DefaultAttachmentType,
@@ -146,7 +147,7 @@ const MessageOverlayWithContext = <
     MessageActionListItem,
     messageContext,
     messageReactionTitle,
-    messageTextNumberOfLines = 5,
+    messageTextNumberOfLines = DefaultMessageTextNumberOfLines,
     messagesContext,
     onlyEmojis,
     otherAttachments,

--- a/package/src/contexts/overlayContext/OverlayContext.tsx
+++ b/package/src/contexts/overlayContext/OverlayContext.tsx
@@ -82,6 +82,7 @@ export type OverlayProviderProps<
     isThreadMessage?: boolean;
     message?: MessageType<At, Ch, Co, Ev, Me, Re, Us>;
     messageReactions?: boolean;
+    messageTextNumberOfLines?: number;
     numberOfImageGalleryGridColumns?: number;
     openPicker?: (ref: React.RefObject<BottomSheetMethods>) => void;
     value?: Partial<OverlayContextValue>;

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -104,6 +104,7 @@ export const OverlayProvider = <
     ImageSelectorIcon = DefaultImageSelectorIcon,
     MessageActionList,
     MessageActionListItem,
+    messageTextNumberOfLines,
     numberOfAttachmentImagesToLoadPerCall,
     numberOfAttachmentPickerImageColumns,
     numberOfImageGalleryGridColumns,
@@ -228,6 +229,7 @@ export const OverlayProvider = <
                   <MessageOverlay<At, Ch, Co, Ev, Me, Re, Us>
                     MessageActionList={MessageActionList}
                     MessageActionListItem={MessageActionListItem}
+                    messageTextNumberOfLines={messageTextNumberOfLines}
                     overlayOpacity={overlayOpacity}
                     OverlayReactionList={OverlayReactionList}
                     OverlayReactions={OverlayReactions}


### PR DESCRIPTION
## 🎯 Goal
This PR introduces the fix for the long message scroll problem due to message overlay text and the related ScrollView problem.
<!-- Describe why we are making this change -->

## 🛠 Implementation details
Previously, opening the message overlay on long-press loaded a Scrollview which generated a warning/error of Virtualized list due to the presence of Reaction list within the view. To solve this the long text size is truncated and the underlying Scrollview is removed.

I have introduced a prop `messageTextNumberOfLines` to solve the issue which gives users flexibility to change the prop value later and render the number of lines according to their own purpose/use-case. By default, the value is 5.

Reference - https://stream-io.atlassian.net/browse/CRNS-278
<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
    <summary>iOS</summary>

<table>
    <thead>
        <tr><td>Before</td><td>After</td></tr>
    </thead>
    <body><tr><td><img src="https://user-images.githubusercontent.com/39884168/139698312-d09b1d41-6a27-49b7-b537-a51c8fbacee4.png" /> </td><td><img src="https://user-images.githubusercontent.com/39884168/139698347-82be4e30-96bf-4c9c-86c5-a69eb3c1b5e3.png" /></td></tr></tbody>
</table>





</details>


<details>
    <summary>Android</summary>

| Before | After |
| --- | --- |
| <img width="419" alt="Screenshot 2021-11-01 at 21 33 09" src="https://user-images.githubusercontent.com/39884168/139702599-2d493a32-089a-4fe7-a160-605a1bba22e1.png"> | <img width="419" alt="Screenshot 2021-11-01 at 21 33 27" src="https://user-images.githubusercontent.com/39884168/139702664-68c0a0ec-aba4-403f-b0ed-7e8333f65445.png"> |

</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [x] Documentation is updated

