### PR TITLE
fix: update message text when theme changes [CRNS-467]

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -262,7 +262,7 @@ export const renderText = <
     <Markdown
       key={`${JSON.stringify(mentioned_users)}-${onlyEmojis}-${
         messageOverlay ? JSON.stringify(markdownStyles) : undefined
-      }`}
+      }-${JSON.stringify(colors)}`}
       onLink={onLink}
       rules={{
         ...customRules,


### PR DESCRIPTION
## 🎯 Goal

Fix the issue: https://github.com/GetStream/stream-chat-react-native/issues/924

## 🛠 Implementation details

Force the markdown component to update when theme changes.

## 🎨 UI Changes

NA

## 🧪 Testing

- Open the example app on simulator
- Open any channel
- Press `cmd + shift + A` to toggle the dark/light mode.

Notice that text color doesn't update before this change.

