### PR TITLE
feat: added support for `channelListSkeleton.maskFillColor` theme property [CRNS-471]

### DIFF
--- a/package/src/components/ChannelList/Skeleton.tsx
+++ b/package/src/components/ChannelList/Skeleton.tsx
@@ -41,6 +41,7 @@ export const Skeleton: React.FC = () => {
         gradientStart,
         gradientStop,
         height = 64,
+        maskFillColor,
       },
       colors: { border, grey_gainsboro, white_snow },
     },
@@ -138,7 +139,7 @@ export const Skeleton: React.FC = () => {
         </Svg>
       </Animated.View>
       <Svg height={height} width={width}>
-        <Path d={d.value} fill={white_snow} />
+        <Path d={d.value} fill={maskFillColor || white_snow} />
       </Svg>
     </View>
   );

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -1,7 +1,7 @@
 import { vh } from '../../../utils/utils';
 
 import type { ImageStyle, TextStyle, ViewStyle } from 'react-native';
-import type { CircleProps, StopProps } from 'react-native-svg';
+import type { CircleProps, Color, StopProps } from 'react-native-svg';
 
 import type { IconProps } from '../../../icons/utils/base';
 
@@ -124,6 +124,7 @@ export type Theme = {
     gradientStart: StopProps;
     gradientStop: StopProps;
     height: number;
+    maskFillColor?: Color;
   };
   channelPreview: {
     checkAllIcon: IconProps;


### PR DESCRIPTION
## 🎯 Goal

- Add customisability to background color for channel list loading indicator (skeleton).
- Will close the ticket - https://getstream.zendesk.com/agent/filters/360143141753

Technically you can still use `white_snow` theme color to change this color, but white_snow is used across the SDK and will affect plenty of components. So better to give explicit customization to change this color.

## 🛠 Implementation details

- Added a new theme key to override mask color for skeleton - `channelListSkeleton.maskFillColor`

## 🎨 UI Changes

Following table displays a customizable theme in channel list loading indicator:

```tsx
const theme = {
    channelListMessenger: {
      flatList: {
        backgroundColor: 'yellow',
      },
    },
    channelListLoadingIndicator: {
      container: {
        backgroundColor: 'blue',
      },
    },
    channelListSkeleton: {
      background: {
        backgroundColor: 'red',
      },
      maskFillColor: 'black', // <-- this is the new theme key
    },
}
```

<table>
    <thead>
        <tr>
            <td>OOTB design</td>
            <td>Customizable design (after above theme changes)</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/11586388/139723245-10089382-4de6-41fc-a71a-a94a9232adde.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/11586388/139723112-12d9723c-1a31-4da9-9df7-7371ded0fb5e.png" />
            </td>
        </tr>
    </tbody>
</table>
</details>
