### PR TITLE
fix: Recover by clearing cache if cache is corrupt [CRNS-457]

### DIFF
--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert, LogBox, Platform, Text, useColorScheme, View } from 'react-native';
+import { LogBox, Platform, useColorScheme } from 'react-native';
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
@@ -42,9 +42,7 @@ import type {
 } from './src/types';
 
 LogBox.ignoreAllLogs(true);
-LogBox.ignoreLogs([
- 'Non-serializable values were found in the navigation state',
-]);
+LogBox.ignoreLogs(['Non-serializable values were found in the navigation state']);
 console.assert = () => null;
 
 const Drawer = createDrawerNavigator();

--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -42,6 +42,9 @@ import type {
 } from './src/types';
 
 LogBox.ignoreAllLogs(true);
+LogBox.ignoreLogs([
+ 'Non-serializable values were found in the navigation state',
+]);
 console.assert = () => null;
 
 const Drawer = createDrawerNavigator();

--- a/examples/SampleApp/src/hooks/usePaginatedPinnedMessages.ts
+++ b/examples/SampleApp/src/hooks/usePaginatedPinnedMessages.ts
@@ -83,8 +83,8 @@ export const usePaginatedPinnedMessages = (
       if (newMessages.length < DEFAULT_PAGINATION_LIMIT) {
         hasMoreResults.current = false;
       }
-    } catch (error) {
-      setError(error);
+    } catch (queryError) {
+      setError(queryError);
     }
     queryInProgress.current = false;
     setLoading(false);

--- a/examples/SampleApp/src/hooks/usePaginatedSearchedMessages.ts
+++ b/examples/SampleApp/src/hooks/usePaginatedSearchedMessages.ts
@@ -122,8 +122,8 @@ export const usePaginatedSearchedMessages = (
       }
 
       offset.current = offset.current + messagesLength;
-    } catch (error) {
-      setError(error);
+    } catch (queryError) {
+      setError(queryError);
     }
 
     done();

--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -7291,10 +7291,10 @@ stream-buffers@~2.2.0:
   resolved "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz"
   integrity sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=
 
-stream-chat-react-native-core@3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-3.9.0.tgz#819d139d40e593c11df400593475504a9b1d9ec2"
-  integrity sha512-1ciAIZUv5fbAMAktgdGytNgN+0RPvDDaANo677TfK+2Q2BVRYrZjQ+x1BtaKJpR4e12YB87yhL0RuxEx/TgKvQ==
+stream-chat-react-native-core@3.9.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-3.9.1.tgz#600a6b0fbb18eaf31c0cf7410d9c8ea3f6b17b55"
+  integrity sha512-4luqSFypBL0NSbvF1ioYrVSaVV8uIj6OaK3HyMzACfYfefEBApdgOIoMAn1oOPq+1QBvbC8IKdteGV/+QQnvGw==
   dependencies:
     "@babel/runtime" "7.13.10"
     "@gorhom/bottom-sheet" "3.6.4"

--- a/package/src/StreamCache.test.js
+++ b/package/src/StreamCache.test.js
@@ -445,7 +445,6 @@ describe('StreamCache instance', () => {
     await cacheInstance.rehydrate({ bogusKey: { bogusValueOne: 1, bogusValueTwo: 'two' } });
 
     expect(cacheInstance.clear).toHaveBeenCalled();
-
   });
 
   it('should set orderedChannels based on cachedChannelsOrder', async () => {

--- a/package/src/StreamCache.test.js
+++ b/package/src/StreamCache.test.js
@@ -425,7 +425,7 @@ describe('StreamCache instance', () => {
     });
   });
 
-  it('should not break if a wrong cache key is used while rehydrating', async () => {
+  it('should clear cache if a wrong cache key is used while rehydrating', async () => {
     const mockedCacheGet = (key) => Promise.resolve(cachedData[key]);
 
     const cacheInstance = StreamCache.getInstance(

--- a/package/src/StreamCache/index.ts
+++ b/package/src/StreamCache/index.ts
@@ -52,12 +52,12 @@ type CacheValuesDefault<
   Ch extends UnknownType = DefaultChannelType,
   Co extends string = DefaultCommandType,
   Us extends UnknownType = DefaultUserType,
-  > = {
-    STREAM_CHAT_CHANNELS_ORDER: ChannelsOrder;
-    STREAM_CHAT_CLIENT_DATA: ClientStateAndData<Ch, Co, Us>;
-    STREAM_CHAT_CLIENT_VERSION: string;
-    STREAM_CHAT_SDK_VERSION: string;
-  };
+> = {
+  STREAM_CHAT_CHANNELS_ORDER: ChannelsOrder;
+  STREAM_CHAT_CLIENT_DATA: ClientStateAndData<Ch, Co, Us>;
+  STREAM_CHAT_CLIENT_VERSION: string;
+  STREAM_CHAT_SDK_VERSION: string;
+};
 
 type CacheValues<
   At extends UnknownType = DefaultAttachmentType,
@@ -66,14 +66,14 @@ type CacheValues<
   Me extends UnknownType = DefaultMessageType,
   Re extends UnknownType = DefaultReactionType,
   Us extends UnknownType = DefaultUserType,
-  > = {
-    get: CacheValuesDefault<Ch, Co, Us> & {
-      STREAM_CHAT_CHANNELS_DATA: string[];
-    } & { [index: string]: ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us> };
-    set: CacheValuesDefault<Ch, Co, Us> & {
-      STREAM_CHAT_CHANNELS_DATA: string[];
-    } & { [index: string]: ChannelStateAndDataOutput<At, Ch, Co, Me, Re, Us> };
-  };
+> = {
+  get: CacheValuesDefault<Ch, Co, Us> & {
+    STREAM_CHAT_CHANNELS_DATA: string[];
+  } & { [index: string]: ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us> };
+  set: CacheValuesDefault<Ch, Co, Us> & {
+    STREAM_CHAT_CHANNELS_DATA: string[];
+  } & { [index: string]: ChannelStateAndDataOutput<At, Ch, Co, Me, Re, Us> };
+};
 
 export type CacheInterface<
   At extends UnknownType = DefaultAttachmentType,
@@ -82,16 +82,16 @@ export type CacheInterface<
   Me extends UnknownType = DefaultMessageType,
   Re extends UnknownType = DefaultReactionType,
   Us extends UnknownType = DefaultUserType,
-  > = {
-    getItem: <Key extends CacheKey>(
-      key: Key,
-    ) => Promise<CacheValues<At, Ch, Co, Me, Re, Us>['get'][Key] | null>;
-    removeItem: <Key extends CacheKey>(key: Key) => Promise<void>;
-    setItem: <Key extends CacheKey>(
-      key: Key,
-      value: CacheValues<At, Ch, Co, Me, Re, Us>['set'][Key] | null,
-    ) => Promise<void>;
-  };
+> = {
+  getItem: <Key extends CacheKey>(
+    key: Key,
+  ) => Promise<CacheValues<At, Ch, Co, Me, Re, Us>['get'][Key] | null>;
+  removeItem: <Key extends CacheKey>(key: Key) => Promise<void>;
+  setItem: <Key extends CacheKey>(
+    key: Key,
+    value: CacheValues<At, Ch, Co, Me, Re, Us>['set'][Key] | null,
+  ) => Promise<void>;
+};
 
 function extractChannelMessagesMap<
   At extends UnknownType = DefaultAttachmentType,
@@ -100,7 +100,9 @@ function extractChannelMessagesMap<
   Me extends UnknownType = DefaultMessageType,
   Re extends UnknownType = DefaultReactionType,
   Us extends UnknownType = DefaultUserType,
-  >(channelsData: ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us>[] | null): { [cid: string]: { [mid: string]: true; }; } {
+>(
+  channelsData: ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us>[] | null,
+): { [cid: string]: { [mid: string]: true } } {
   const oldChannelsMessagesMap =
     // for each channel...
     (channelsData || []).reduce((curr, next) => {
@@ -140,7 +142,7 @@ export class StreamCache<
   Me extends UnknownType = DefaultMessageType,
   Re extends UnknownType = DefaultReactionType,
   Us extends UnknownType = DefaultUserType,
-  > {
+> {
   public currentNetworkState: boolean | null;
   private static instance: StreamCache;
   private static cacheMedia: boolean;
@@ -183,11 +185,11 @@ export class StreamCache<
     Me extends UnknownType = DefaultMessageType,
     Re extends UnknownType = DefaultReactionType,
     Us extends UnknownType = DefaultUserType,
-    >(
-      client?: StreamChat<At, Ch, Co, Ev, Me, Re, Us>,
-      cacheInterface?: CacheInterface<At, Ch, Co, Me, Re, Us>,
-      tokenOrProvider?: TokenOrProvider,
-      cacheMedia = true,
+  >(
+    client?: StreamChat<At, Ch, Co, Ev, Me, Re, Us>,
+    cacheInterface?: CacheInterface<At, Ch, Co, Me, Re, Us>,
+    tokenOrProvider?: TokenOrProvider,
+    cacheMedia = true,
   ): StreamCache<At, Ch, Co, Ev, Me, Re, Us> {
     if (!StreamCache.instance) {
       if (!(client && cacheInterface)) {
@@ -223,13 +225,18 @@ export class StreamCache<
       this.cacheInterface.setItem(STREAM_CHAT_CHANNELS_DATA, channelsDataIds),
       Promise.all(
         filteredChannelsData.map((channelData) =>
-          this.cacheInterface.setItem(`STREAM_CHAT_CHANNEL_DATA_${channelData.id}` as CacheKey, channelData),
+          this.cacheInterface.setItem(
+            `STREAM_CHAT_CHANNEL_DATA_${channelData.id}` as CacheKey,
+            channelData,
+          ),
         ),
       ),
     ] as const;
   }
 
-  private async getNormalizedChannelsData(): Promise<ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us>[]> {
+  private async getNormalizedChannelsData(): Promise<
+    ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us>[]
+  > {
     const channelsDataIds = await this.cacheInterface.getItem(STREAM_CHAT_CHANNELS_DATA);
 
     if (!channelsDataIds) return [];
@@ -237,9 +244,9 @@ export class StreamCache<
     return Promise.all(
       channelsDataIds.map(
         (channelId) =>
-          this.cacheInterface.getItem(`STREAM_CHAT_CHANNEL_DATA_${channelId}` as CacheKey) as Promise<
-            ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us>
-          >,
+          this.cacheInterface.getItem(
+            `STREAM_CHAT_CHANNEL_DATA_${channelId}` as CacheKey,
+          ) as Promise<ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us>>,
       ),
     );
   }
@@ -294,13 +301,13 @@ export class StreamCache<
 
   private orderChannelsBasedOnCachedOrder<
     C extends
-    | Channel<At, Ch, Co, Ev, Me, Re, Us>[]
-    | ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us>[],
-    >(channels: C): ChannelSortOrder<C> {
+      | Channel<At, Ch, Co, Ev, Me, Re, Us>[]
+      | ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us>[],
+  >(channels: C): ChannelSortOrder<C> {
     const channelsOrder = {} as ChannelSortOrder<C>;
 
-     // Get current active channels
-      // get order from cache
+    // Get current active channels
+    // get order from cache
 
     // currentChannelsOrderKey = filter_and_sort_string
     // we may have two channel lists with different filter/sort
@@ -316,31 +323,36 @@ export class StreamCache<
       }, {} as { [index: string]: number });
 
       if (currentChannelsOrder) {
-        channels.sort((a: { id: string | number | undefined; }, b: { id: string | number | undefined; }) => {
-          // return value > 0, sort b before a
-          // return value < 0, sort a before b
+        channels.sort(
+          (a: { id: string | number | undefined }, b: { id: string | number | undefined }) => {
+            // return value > 0, sort b before a
+            // return value < 0, sort a before b
 
-          // if they both have undefined ids, sort a before b
-          if (a.id === undefined && b.id === undefined) return -1;
-          // if only a has undefined id, sort b before a
-          if (a.id === undefined) return 1;
-          // if only b has undefined id, sort a before b
-          if (b.id === undefined) return -1;
+            // if they both have undefined ids, sort a before b
+            if (a.id === undefined && b.id === undefined) return -1;
+            // if only a has undefined id, sort b before a
+            if (a.id === undefined) return 1;
+            // if only b has undefined id, sort a before b
+            if (b.id === undefined) return -1;
 
-          // If both a and b have no previous cached position on currentChannelsOrder,
-          // we use the original position from channelsIndicesMap, which is based on the
-          // original client channel list
-          if (currentChannelsOrder[a.id] === undefined && currentChannelsOrder[b.id] === undefined)
-            return channelsIndicesMap[a.id] - channelsIndicesMap[b.id];
+            // If both a and b have no previous cached position on currentChannelsOrder,
+            // we use the original position from channelsIndicesMap, which is based on the
+            // original client channel list
+            if (
+              currentChannelsOrder[a.id] === undefined &&
+              currentChannelsOrder[b.id] === undefined
+            )
+              return channelsIndicesMap[a.id] - channelsIndicesMap[b.id];
 
-          // If only a has no previous cached position, sort b before a
-          if (currentChannelsOrder[a.id] === undefined) return 1;
-          // If only b has no previous cached position, sort a before b
-          if (currentChannelsOrder[b.id] === undefined) return -1;
+            // If only a has no previous cached position, sort b before a
+            if (currentChannelsOrder[a.id] === undefined) return 1;
+            // If only b has no previous cached position, sort a before b
+            if (currentChannelsOrder[b.id] === undefined) return -1;
 
-          // Finally, calculate position based on cached channels order by substracting indices
-          return currentChannelsOrder[a.id] - currentChannelsOrder[b.id];
-        });
+            // Finally, calculate position based on cached channels order by substracting indices
+            return currentChannelsOrder[a.id] - currentChannelsOrder[b.id];
+          },
+        );
       }
 
       // Finally we set the ordered channels for that specific filter_and_sort_string key
@@ -459,8 +471,8 @@ export class StreamCache<
         );
       }
     } catch (error) {
-      console.warn(`Error while rehydrating cache: ${error}`)
-      console.warn(`Clearning cache.`)
+      console.warn(`Error while rehydrating cache: ${error}`);
+      console.warn(`Clearning cache.`);
       this.clear();
     }
   }
@@ -478,21 +490,39 @@ export class StreamCache<
         }
       }
     } catch (error) {
-      console.warn(`Error while initializing cache: ${error}`)
+      console.warn(`Error while initializing cache: ${error}`);
     }
   }
 
-  private getChannelsOrderKey({ filters, sort }: { filters: ChannelFilters<Ch, Co, Us>; sort: ChannelSort<Ch>; }): string {
+  private getChannelsOrderKey({
+    filters,
+    sort,
+  }: {
+    filters: ChannelFilters<Ch, Co, Us>;
+    sort: ChannelSort<Ch>;
+  }): string {
     return `${JSON.stringify(filters)}_${JSON.stringify(sort)}`;
   }
 
-  public getOrderedChannels({ filters, sort }: { filters: ChannelFilters<Ch, Co, Us>; sort: ChannelSort<Ch>; }): Channel<At, Ch, Co, Ev, Me, Re, Us>[] {
+  public getOrderedChannels({
+    filters,
+    sort,
+  }: {
+    filters: ChannelFilters<Ch, Co, Us>;
+    sort: ChannelSort<Ch>;
+  }): Channel<At, Ch, Co, Ev, Me, Re, Us>[] {
     return this.orderedChannels[this.getChannelsOrderKey({ filters, sort })] || [];
   }
 
-  public syncChannelsCachedOrder(
-{ channels, filters, sort }: { channels: Channel<At, Ch, Co, Ev, Me, Re, Us>[]; filters: ChannelFilters<Ch, Co, Us>; sort: ChannelSort<Ch>; },
-  ): void {
+  public syncChannelsCachedOrder({
+    channels,
+    filters,
+    sort,
+  }: {
+    channels: Channel<At, Ch, Co, Ev, Me, Re, Us>[];
+    filters: ChannelFilters<Ch, Co, Us>;
+    sort: ChannelSort<Ch>;
+  }): void {
     // We keep track of the channels order on every change so it can be used when
     // in offline mode
     this.cachedChannelsOrder[this.getChannelsOrderKey({ filters, sort })] = channels.reduce(

--- a/package/src/StreamCache/index.ts
+++ b/package/src/StreamCache/index.ts
@@ -220,7 +220,7 @@ export class StreamCache<
       this.cacheInterface.setItem(STREAM_CHAT_CHANNELS_DATA, channelsDataIds),
       Promise.all(
         filteredChannelsData.map((channelData) =>
-          this.cacheInterface.setItem(`${STREAM_CHAT_CHANNEL_DATA}_${channelData.id}`, channelData),
+          this.cacheInterface.setItem(`${STREAM_CHAT_CHANNEL_DATA}_${channelData.id}` as CacheKeys, channelData),
         ),
       ),
     ] as const;
@@ -234,7 +234,7 @@ export class StreamCache<
     return Promise.all(
       channelsDataIds.map(
         (channelId) =>
-          this.cacheInterface.getItem(`${STREAM_CHAT_CHANNEL_DATA}_${channelId}`) as Promise<
+          this.cacheInterface.getItem(`${STREAM_CHAT_CHANNEL_DATA}_${channelId}` as CacheKeys) as Promise<
             ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us>
           >,
       ),
@@ -309,7 +309,7 @@ export class StreamCache<
       }, {} as { [index: string]: number });
 
       if (currentChannelsOrder) {
-        channels.sort((a, b) => {
+        channels.sort((a: { id: string | number | undefined; }, b: { id: string | number | undefined; }) => {
           // return value > 0, sort b before a
           // return value < 0, sort a before b
 
@@ -495,7 +495,7 @@ export class StreamCache<
     const channelsIds = (await this.cacheInterface.getItem(STREAM_CHAT_CHANNELS_DATA)) || [];
     const removeAllChannelsItemsPromise = Promise.all(
       channelsIds.map((channelId) =>
-        this.cacheInterface.removeItem(`${STREAM_CHAT_CHANNEL_DATA}_${channelId}`),
+        this.cacheInterface.removeItem(`${STREAM_CHAT_CHANNEL_DATA}_${channelId}` as CacheKeys),
       ),
     );
 

--- a/package/src/StreamCache/index.ts
+++ b/package/src/StreamCache/index.ts
@@ -70,10 +70,10 @@ type CacheValues<
 > = {
   get: CacheValuesDefault<Ch, Co, Us> & {
     STREAM_CHAT_CHANNELS_DATA: string[];
-  } & { [index: STREAM_CHAT_CHANNEL_DATA_KEY]: ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us> };
+  } & { [index: string]: ChannelStateAndDataInput<At, Ch, Co, Me, Re, Us> };
   set: CacheValuesDefault<Ch, Co, Us> & {
     STREAM_CHAT_CHANNELS_DATA: string[];
-  } & { [index: STREAM_CHAT_CHANNEL_DATA_KEY]: ChannelStateAndDataOutput<At, Ch, Co, Me, Re, Us> };
+  } & { [index: string]: ChannelStateAndDataOutput<At, Ch, Co, Me, Re, Us> };
 };
 
 export type CacheInterface<

--- a/package/src/StreamMediaCache.ts
+++ b/package/src/StreamMediaCache.ts
@@ -31,7 +31,7 @@ async function saveAvatar(cid: string, fileId: string, filePathname: string) {
 
 async function removeChannelAvatars(cid: string) {
   try {
-    return RNFS.unlink(getStreamChannelAvatarsDir(cid));
+    return await RNFS.unlink(getStreamChannelAvatarsDir(cid));
   } catch (e) {
     return console.log('Skipping already deleted channel cached avatars...');
   }
@@ -69,7 +69,7 @@ async function saveAttachment(cid: string, mid: string, fileId: string, filePath
 
 async function removeChannelAttachments(cid: string) {
   try {
-    return RNFS.unlink(getStreamChannelAttachmentsDir(cid));
+    return await RNFS.unlink(getStreamChannelAttachmentsDir(cid));
   } catch (e) {
     return console.log('Skipping already deleted channel cached images...');
   }
@@ -77,7 +77,7 @@ async function removeChannelAttachments(cid: string) {
 
 async function removeMessageAttachments(cid: string, mid: string) {
   try {
-    return RNFS.unlink(getStreamChannelMessageAttachmentsDir(cid, mid));
+    return await RNFS.unlink(getStreamChannelMessageAttachmentsDir(cid, mid));
   } catch (e) {
     return console.log('Skipping already deleted cached image...');
   }
@@ -85,7 +85,7 @@ async function removeMessageAttachments(cid: string, mid: string) {
 
 async function clear() {
   try {
-    return RNFS.unlink(getStreamRootDir());
+    return await RNFS.unlink(getStreamRootDir());
   } catch (e) {
     return console.log('Skipping already cleared media cache');
   }

--- a/package/src/StreamMediaCache.ts
+++ b/package/src/StreamMediaCache.ts
@@ -29,10 +29,12 @@ async function saveAvatar(cid: string, fileId: string, filePathname: string) {
   }).promise;
 }
 
-function removeChannelAvatars(cid: string) {
-  return RNFS.unlink(getStreamChannelAvatarsDir(cid)).catch(() =>
-    console.log('Skipping already deleted channel cached avatars...'),
-  );
+async function removeChannelAvatars(cid: string) {
+  try {
+    return RNFS.unlink(getStreamChannelAvatarsDir(cid));
+  } catch (e) {
+    return console.log('Skipping already deleted channel cached avatars...');
+  }
 }
 
 /* 
@@ -65,22 +67,28 @@ async function saveAttachment(cid: string, mid: string, fileId: string, filePath
   }).promise;
 }
 
-function removeChannelAttachments(cid: string) {
-  return RNFS.unlink(getStreamChannelAttachmentsDir(cid)).catch(() =>
-    console.log('Skipping already deleted channel cached images...'),
-  );
+async function removeChannelAttachments(cid: string) {
+  try {
+    return RNFS.unlink(getStreamChannelAttachmentsDir(cid));
+  } catch (e) {
+    return console.log('Skipping already deleted channel cached images...');
+  }
 }
 
-function removeMessageAttachments(cid: string, mid: string) {
-  return RNFS.unlink(getStreamChannelMessageAttachmentsDir(cid, mid)).catch(() =>
-    console.log('Skipping already deleted cached image...'),
-  );
+async function removeMessageAttachments(cid: string, mid: string) {
+  try {
+    return RNFS.unlink(getStreamChannelMessageAttachmentsDir(cid, mid));
+  } catch (e) {
+    return console.log('Skipping already deleted cached image...');
+  }
 }
 
-function clear() {
-  return RNFS.unlink(getStreamRootDir()).catch(() =>
-    console.log('Skipping already cleared media cache'),
-  );
+async function clear() {
+  try {
+    return RNFS.unlink(getStreamRootDir());
+  } catch (e) {
+    return console.log('Skipping already cleared media cache');
+  }
 }
 
 export default {

--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -57,7 +57,7 @@ export const usePaginatedChannels = <
     : null;
   const { client } = useChatContext<At, Ch, Co, Ev, Me, Re, Us>();
   const [channels, setChannels] = useState<Channel<At, Ch, Co, Ev, Me, Re, Us>[]>(() =>
-    cacheInstance ? cacheInstance.getOrderedChannels(filters, sort) : [],
+    cacheInstance ? cacheInstance.getOrderedChannels({ filters, sort }) : [],
   );
   const activeChannels = useActiveChannelsRefContext();
 
@@ -72,7 +72,7 @@ export const usePaginatedChannels = <
 
   useEffect(() => {
     if (cacheInstance) {
-      cacheInstance.syncChannelsCachedOrder(channels, filters, sort);
+      cacheInstance.syncChannelsCachedOrder({ channels, filters, sort });
     }
   }, [channels]);
 


### PR DESCRIPTION
## 🎯 Goal

If the content of the offline cache is corrupt/incomplete/wrong, currently the rehydration of the cache will break, and an unhandled exception will be logged over and over in the console.

This catches these errors, and clears the cache if that were to happen.

## 🛠 Implementation details

Wrapping the rehydration in a try/catch, to give some information to the developer through the console, and clear cache when an error is caught.

## 🎨 UI Changes

None

## 🧪 Testing

Arbitrarily add a postfix or prefix to cache keys after the cache has been synced (so not on first build of the app), which should throw an error. Then apply these changes and do the same, which should give a warning, and then clear the cache, followed by the error disappearing.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [-] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [x] New code is covered by tests
- [-] Screenshots added for visual changes
- [-] Documentation is updated

