### PR TITLE
fix: Check network state separately from cache [CRNS-457]

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -128,7 +128,7 @@ import type {
   DefaultUserType,
   UnknownType,
 } from '../../types/types';
-import { useNetworkState } from 'src/hooks/useNetworkState';
+import { useNetworkState } from '../../hooks/useNetworkState';
 
 const styles = StyleSheet.create({
   selectChannel: { fontWeight: 'bold', padding: 16 },

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -1333,7 +1333,7 @@ const ChannelWithContext = <
 
     try {
       if (!isConnected) {
-        console.log(t('Something went wrong'));
+        console.log(`Could not send message: Network is disconnected.`);
         toast.show(t('Something went wrong'), 2000);
         throw new Error('No network connection');
       }

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -113,7 +113,6 @@ import {
   WutReaction,
 } from '../../icons';
 import { FlatList as FlatListDefault } from '../../native';
-import { StreamCache } from '../../StreamCache';
 import { generateRandomId, ReactionData } from '../../utils/utils';
 
 import type { MessageType } from '../MessageList/hooks/useMessageList';
@@ -129,6 +128,7 @@ import type {
   DefaultUserType,
   UnknownType,
 } from '../../types/types';
+import { useNetworkState } from 'src/hooks/useNetworkState';
 
 const styles = StyleSheet.create({
   selectChannel: { fontWeight: 'bold', padding: 16 },
@@ -583,6 +583,8 @@ const ChannelWithContext = <
   const [syncingChannel, setSyncingChannel] = useState(false);
 
   const { setTargetedMessage, targetedMessage } = useTargetedMessage(messageId);
+
+  const { isConnected } = useNetworkState();
 
   const toast = useToastContext();
 
@@ -1330,7 +1332,7 @@ const ChannelWithContext = <
     } as StreamMessage<At, Me, Us>;
 
     try {
-      if (!StreamCache.getInstance().currentNetworkState) {
+      if (!isConnected) {
         console.log(t('Something went wrong'));
         toast.show(t('Something went wrong'), 2000);
         throw new Error('No network connection');

--- a/package/src/components/Message/hooks/useMessageActions.tsx
+++ b/package/src/components/Message/hooks/useMessageActions.tsx
@@ -38,7 +38,7 @@ import type {
   UnknownType,
 } from '../../../types/types';
 import { useMessageActionHandlers } from './useMessageActionHandlers';
-import { useNetworkState } from 'src/hooks/useNetworkState';
+import { useNetworkState } from '../../../hooks/useNetworkState';
 
 export const useMessageActions = <
   At extends UnknownType = DefaultAttachmentType,

--- a/package/src/components/Message/hooks/useMessageActions.tsx
+++ b/package/src/components/Message/hooks/useMessageActions.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Alert, Clipboard } from 'react-native';
 
-import { StreamCache } from '../../../StreamCache';
 import type { ChannelContextValue } from '../../../contexts/channelContext/ChannelContext';
 import type { ChatContextValue } from '../../../contexts/chatContext/ChatContext';
 import type { MessageActionType } from '../../MessageOverlay/MessageActionListItem';
@@ -39,6 +38,7 @@ import type {
   UnknownType,
 } from '../../../types/types';
 import { useMessageActionHandlers } from './useMessageActionHandlers';
+import { useNetworkState } from 'src/hooks/useNetworkState';
 
 export const useMessageActions = <
   At extends UnknownType = DefaultAttachmentType,
@@ -132,6 +132,8 @@ export const useMessageActions = <
     updateMessage,
   });
 
+  const { isConnected } = useNetworkState();
+
   const error = message.type === 'error' || message.status === 'failed';
 
   const onOpenThread = () => {
@@ -149,7 +151,7 @@ export const useMessageActions = <
 
   const blockUser: MessageActionType = {
     action: () => async () => {
-      if (!StreamCache.getInstance().currentNetworkState) {
+      if (!isConnected) {
         toast.show(t('Something went wrong'), 2000);
       } else {
         setOverlay('none');
@@ -170,7 +172,7 @@ export const useMessageActions = <
   const copyMessage: MessageActionType = {
     // using depreciated Clipboard from react-native until expo supports the community version or their own
     action: () => {
-      if (!StreamCache.getInstance().currentNetworkState) {
+      if (!isConnected) {
         toast.show(t('Something went wrong'), 2000);
       } else {
         setOverlay('none');
@@ -187,7 +189,7 @@ export const useMessageActions = <
 
   const deleteMessage: MessageActionType = {
     action: () => {
-      if (!StreamCache.getInstance().currentNetworkState) {
+      if (!isConnected) {
         toast.show(t('Something went wrong'), 2000);
       } else {
         setOverlay('alert');
@@ -223,7 +225,7 @@ export const useMessageActions = <
 
   const editMessage: MessageActionType = {
     action: () => {
-      if (!StreamCache.getInstance().currentNetworkState) {
+      if (!isConnected) {
         toast.show(t('Something went wrong'), 2000);
       } else {
         setOverlay('none');
@@ -266,7 +268,7 @@ export const useMessageActions = <
 
   const flagMessage: MessageActionType = {
     action: () => {
-      if (!StreamCache.getInstance().currentNetworkState) {
+      if (!isConnected) {
         toast.show(t('Something went wrong'), 2000);
       } else {
         setOverlay('alert');
@@ -327,7 +329,7 @@ export const useMessageActions = <
     ? selectReaction
       ? selectReaction(message)
       : async (reactionType: string) => {
-          if (!StreamCache.getInstance().currentNetworkState) {
+          if (!isConnected) {
             toast.show(t('Something went wrong'), 2000);
           } else {
             if (handleReactionProp) {
@@ -341,7 +343,7 @@ export const useMessageActions = <
 
   const muteUser: MessageActionType = {
     action: async () => {
-      if (!StreamCache.getInstance().currentNetworkState) {
+      if (!isConnected) {
         toast.show(t('Something went wrong'), 2000);
       } else {
         setOverlay('none');
@@ -361,7 +363,7 @@ export const useMessageActions = <
 
   const quotedReply: MessageActionType = {
     action: () => {
-      if (!StreamCache.getInstance().currentNetworkState) {
+      if (!isConnected) {
         toast.show(t('Something went wrong'), 2000);
       } else {
         setOverlay('none');
@@ -378,7 +380,7 @@ export const useMessageActions = <
 
   const retry: MessageActionType = {
     action: async () => {
-      if (!StreamCache.getInstance().currentNetworkState) {
+      if (!isConnected) {
         toast.show(t('Something went wrong'), 2000);
       } else {
         setOverlay('none');
@@ -397,7 +399,7 @@ export const useMessageActions = <
 
   const threadReply: MessageActionType = {
     action: () => {
-      if (!StreamCache.getInstance().currentNetworkState) {
+      if (!isConnected) {
         toast.show(t('Something went wrong'), 2000);
       } else {
         setOverlay('none');

--- a/package/src/hooks/useNetworkState.tsx
+++ b/package/src/hooks/useNetworkState.tsx
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+import NetInfo from '@react-native-community/netinfo';
+
+export const useNetworkState = () => {
+  const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      setIsConnected(state.isConnected || false);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  return { isConnected };
+};


### PR DESCRIPTION
## 🎯 Goal

This checks network state before doing message actions without involving StreamCache, as not all customers will use StreamCache at all - our current implementation will give an error if there hasn't been set up a StreamCache instance

## 🛠 Implementation details

I've set up a simple hook using NetInfo to check network state, and expose a boolean value based on that.

## 🎨 UI Changes

N/A

## 🧪 Testing

Remove cache from the SampleApp, see that it won't give an error for missing StreamCache instance

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [-] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [-] New code is covered by tests
- [-] Screenshots added for visual changes
- [-] Documentation is updated

