### PR TITLE
build: Android fresco version bump

### DIFF
--- a/examples/SampleApp/android/app/build.gradle
+++ b/examples/SampleApp/android/app/build.gradle
@@ -197,11 +197,11 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:25.12.0')
 
     // For animated GIF support
-    implementation 'com.facebook.fresco:animated-gif:2.0.0'
+    implementation 'com.facebook.fresco:animated-gif:2.6.0'
 
     // For WebP support, including animated WebP
-    implementation 'com.facebook.fresco:animated-webp:2.1.0'
-    implementation 'com.facebook.fresco:webpsupport:2.0.0'
+    implementation 'com.facebook.fresco:animated-webp:2.6.0'
+    implementation 'com.facebook.fresco:webpsupport:2.6.0'
 
     implementation 'com.google.firebase:firebase-crashlytics'
     implementation 'com.google.firebase:firebase-analytics'

--- a/examples/TypeScriptMessaging/android/app/build.gradle
+++ b/examples/TypeScriptMessaging/android/app/build.gradle
@@ -189,11 +189,11 @@ dependencies {
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 
     // For animated GIF support
-    implementation 'com.facebook.fresco:animated-gif:2.0.0'
+    implementation 'com.facebook.fresco:animated-gif:2.6.0'
 
     // For WebP support, including animated WebP
-    implementation 'com.facebook.fresco:animated-webp:2.1.0'
-    implementation 'com.facebook.fresco:webpsupport:2.0.0'
+    implementation 'com.facebook.fresco:animated-webp:2.6.0'
+    implementation 'com.facebook.fresco:webpsupport:2.6.0'
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'


### PR DESCRIPTION
## 🎯 Goal

This pulls inn the changes from @khushal87 to fix fresco in the sample apps that the e2e tests use.

This is merged to v4.0.0, but not to develop. This branch has cherry-picked the commits so we can have them in develop as well.

(See for example that checks on #965 breaks cause of this)