### PR TITLE
feat: Default to not renumbering lists

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -247,36 +247,46 @@ export const renderText = <
   };
 
   const listLevels = {
-    'top': 'top',
-    'sub': 'sub',
-  }
+    sub: 'sub',
+    top: 'top',
+  };
 
-  const customListAtLevel = (level: keyof typeof listLevels): ReactNodeOutput => (node, output, {...state}) => {
-        var numberIndex = node.start;
-        var items = node.items.map((item: Array<SingleASTNode>, i: number) => {
-          const withinList = item.length > 1 && item[1].type === 'list';
-          var content = output(item, { ...state, withinList });
+  const customListAtLevel =
+    (level: keyof typeof listLevels): ReactNodeOutput =>
+    (node, output, { ...state }) => {
+      const items = node.items.map((item: Array<SingleASTNode>, index: number) => {
+        const withinList = item.length > 1 && item[1].type === 'list';
+        const content = output(item, { ...state, withinList });
 
-          const isTopLevelText = ['text', 'paragraph', 'strong'].includes(item[0].type) && withinList == false
+        const isTopLevelText =
+          ['text', 'paragraph', 'strong'].includes(item[0].type) && withinList === false;
 
-          return (
-            <View key={i} style={styles.listRow}>
-              <Text style={styles.listItemNumber}>{node.ordered ? `${numberIndex++}. ` : `\u2022`}</Text>
-              <Text style={[styles.listItemText, isTopLevelText && {marginBottom: 0}]}>{content}</Text>
-            </View>
-          );
-        });
+        return (
+          <View key={index} style={styles.listRow}>
+            <Text style={styles.listItemNumber}>
+              {node.ordered ? `${node.start + index}. ` : `\u2022`}
+            </Text>
+            <Text style={[styles.listItemText, isTopLevelText && { marginBottom: 0 }]}>
+              {content}
+            </Text>
+          </View>
+        );
+      });
 
-    const isSublist = level === 'sub';
-    return (<View key={state.key} style={[isSublist ? styles.list : styles.sublist]}>{items}</View>);
-  }
+      const isSublist = level === 'sub';
+      return (
+        <View key={state.key} style={[isSublist ? styles.list : styles.sublist]}>
+          {items}
+        </View>
+      );
+    };
 
   const customRules = {
     link: { react },
     list: { react: customListAtLevel('top') },
-    sublist: { react: customListAtLevel('sub') },
     // we have no react rendering support for reflinks
     reflink: { match: () => null },
+    sublist: { react: customListAtLevel('sub') },
     ...(mentionedUsers
       ? {
           mentions: {

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -251,6 +251,13 @@ export const renderText = <
     top: 'top',
   };
 
+  /**
+   * For lists and sublists, the default behavior of the markdown library we use is
+   * to always renumber any list, so all ordered lists start from 1.
+   *
+   * This custom rule overrides this behavior both for top level lists and sublists,
+   * in order to start the numbering from the number of the first list item provided.
+   * */
   const customListAtLevel =
     (level: keyof typeof listLevels): ReactNodeOutput =>
     (node, output, { ...state }) => {

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -39,6 +39,9 @@ const defaultMarkdownStyles: MarkdownStyle = {
     marginBottom: 8,
     marginTop: 8,
   },
+  listItemNumber: {
+    fontWeight: 'bold',
+  },
   listItemText: {
     flex: 0,
   },

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -259,11 +259,9 @@ export const renderText = <
 
           const isTopLevelText = ['text', 'paragraph', 'strong'].includes(item[0].type) && withinList == false
 
-          numberIndex++;
-
           return (
             <View key={i} style={styles.listRow}>
-              <Text style={styles.listItemNumber}>{node.ordered ? `${numberIndex}. ` : `\u2022`}</Text>
+              <Text style={styles.listItemNumber}>{node.ordered ? `${numberIndex++}. ` : `\u2022`}</Text>
               <Text style={[styles.listItemText, isTopLevelText && {marginBottom: 0}]}>{content}</Text>
             </View>
           );


### PR DESCRIPTION
## 🎯 Goal

Currently, any ordered list in a message will have numbers reset to start from 1, but for consistency, this PR introduces a new default to start lists with the first number of the list, assigning incremental numbers from there.

## 🛠 Implementation details

I've taken the list rule from [react-native-markdown-package](https://github.com/andangrd/react-native-markdown-package), but simplified it a bit on top of using JSX rather than `React.createElement`.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

I've only included screenshots from the iOS emulator, but this renders the same on either OS

<details>
<summary>Screenshots</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>       
<img width="377" alt="image" src="https://user-images.githubusercontent.com/1548276/140965067-aa2e54df-8300-4f46-a564-bb1ecd699e13.png">
            </td>
            <td>
                <img width="370" alt="image" src="https://user-images.githubusercontent.com/1548276/140964934-fa042dbd-0bb8-44c0-b2c0-a2bb560653a2.png">
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

Send a message like this:

```
4. Four
5. Five
6. Six
```

The message should render with 4, 5, and 6 as bullets, not 1, 2, and 3 like it currently does in our prod build.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [-] New code is covered by tests
- [x] Screenshots added for visual changes
- [-] Documentation is updated

Don't need to update the documentation for this, I think.