### PR TITLE
refactor: Use JSX rather than React.createElement

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -182,20 +182,17 @@ export const renderText = <
       }
     };
 
-    state.withinLink = true;
-    const link = React.createElement(
-      Text,
-      {
-        key: state.key,
-        onLongPress,
-        onPress,
-        style: styles.autolink,
-        suppressHighlighting: true,
-      },
-      output(node.content, state),
+    return (
+      <Text
+        key={state.key}
+        onLongPress={onLongPress}
+        onPress={onPress}
+        style={styles.autolink}
+        suppressHighlighting={true}
+      >
+        {output(node.content, { ...state, withinLink: true })}
+      </Text>
     );
-    state.withinLink = false;
-    return link;
   };
 
   const mentionedUsers = Array.isArray(mentioned_users)
@@ -230,15 +227,10 @@ export const renderText = <
       }
     };
 
-    return React.createElement(
-      Text,
-      {
-        key: state.key,
-        onLongPress,
-        onPress,
-        style: styles.mentions,
-      },
-      Array.isArray(node.content) ? node.content[0]?.content || '' : output(node.content, state),
+    return (
+      <Text key={state.key} onLongPress={onLongPress} onPress={onPress} style={styles.mentions}>
+        {Array.isArray(node.content) ? node.content[0].content || '' : output(node.content, state)}
+      </Text>
     );
   };
 


### PR DESCRIPTION
## 🎯 Goal

Our markdown custom rules use `React.createElement`, but I don't think that's necessary for us, so this PR changes it to use JSX instead. :) Happy to be convinced otherwise, though.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [-] New code is covered by tests
- [-] Screenshots added for visual changes
- [-] Documentation is updated

