### PR TITLE
feat: Add theming to the cooldown timer

### DIFF
--- a/package/src/components/MessageInput/CooldownTimer.tsx
+++ b/package/src/components/MessageInput/CooldownTimer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Text } from 'react-native';
+import { useTheme } from '../../contexts/themeContext/ThemeContext';
 
 export type CooldownTimerProps = {
   seconds: number;
@@ -13,6 +14,16 @@ export type CooldownTimerProps = {
  **/
 export const CooldownTimer = (props: CooldownTimerProps) => {
   const { seconds } = props;
+  const {
+    theme: {
+      colors: { black },
+      messageInput: { cooldownTimer },
+    },
+  } = useTheme();
 
-  return <Text testID='cooldown-seconds'>{seconds}</Text>;
+  return (
+    <Text style={[{ color: black }, cooldownTimer]} testID='cooldown-seconds'>
+      {seconds}
+    </Text>
+  );
 };

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -219,6 +219,7 @@ export type Theme = {
     commandsButtonContainer: ViewStyle;
     composerContainer: ViewStyle;
     container: ViewStyle;
+    cooldownTimer: TextStyle;
     editingBoxContainer: ViewStyle;
     editingBoxHeader: ViewStyle;
     editingBoxHeaderTitle: TextStyle;
@@ -665,6 +666,7 @@ export const defaultTheme: Theme = {
     commandsButtonContainer: {},
     composerContainer: {},
     container: {},
+    cooldownTimer: {},
     editingBoxContainer: {},
     editingBoxHeader: {},
     editingBoxHeaderTitle: {},


### PR DESCRIPTION
## 🎯 Goal

Currently the CooldownTimer cannot be styled through the theme at all, this adds that possibility

## 🛠 Implementation details

Straight-up just a key in the theme :) Also defaults color to theme.colors.black, which is the same as other text in messages etc.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

