### PR TITLE
fix: Make countdown timer actually count down

### DIFF
--- a/package/src/components/MessageInput/hooks/useCooldown.ts
+++ b/package/src/components/MessageInput/hooks/useCooldown.ts
@@ -1,8 +1,7 @@
-import dayjs from 'dayjs';
 import { useState } from 'react';
+import { BuiltinRoles, ChannelResponse, Role } from 'stream-chat';
 import { useChannelContext } from '../../../contexts/channelContext/ChannelContext';
 import { useChatContext } from '../../../contexts/chatContext/ChatContext';
-import { BuiltinRoles, ChannelResponse, Role } from 'stream-chat';
 import type {
   DefaultAttachmentType,
   DefaultChannelType,
@@ -12,6 +11,7 @@ import type {
   DefaultReactionType,
   DefaultUserType,
 } from '../../../types/types';
+import { ONE_SECOND_IN_MS } from '../../../utils/date';
 
 type Roles = Array<Role>;
 
@@ -28,12 +28,12 @@ export const useCooldown = <
   Re extends DefaultReactionType = DefaultReactionType,
   Us extends DefaultUserType = DefaultUserType,
 >() => {
-  const [endsAt, setEndsAt] = useState<Date>(new Date());
+  const [endsAt, setEndsAt] = useState(new Date());
 
   const { client } = useChatContext<At, Ch, Co, Ev, Me, Re, Us>();
   const { channel } = useChannelContext<At, Ch, Co, Ev, Me, Re, Us>();
   const { cooldown } = (channel?.data || {}) as ChannelResponse<Ch, Co, Us>;
-  const interval = (cooldown as number) ?? 0;
+  const interval: number = cooldown ?? 0;
 
   /**
    * We get the roles a user has globally set on the Client, and the role
@@ -51,10 +51,8 @@ export const useCooldown = <
   const enabled = interval > 0 && !disabledFor([userClientRole, userChannelRole]);
 
   const start = () => {
-    const now = dayjs();
-
     if (enabled) {
-      setEndsAt(now.add(interval, 'seconds').toDate());
+      setEndsAt(new Date(Date.now() + interval * ONE_SECOND_IN_MS));
     }
   };
 

--- a/package/src/components/MessageInput/hooks/useCountdown.ts
+++ b/package/src/components/MessageInput/hooks/useCountdown.ts
@@ -45,7 +45,7 @@ export const useCountdown = (endsAt: Date) => {
     return () => {
       clearInterval(counter.current);
     };
-  }, []);
+  });
 
   return { seconds };
 };

--- a/package/src/utils/date.ts
+++ b/package/src/utils/date.ts
@@ -1,0 +1,4 @@
+export const ONE_SECOND_IN_MS = 1000;
+
+export const secondsUntil = (date: Date) =>
+  Math.trunc((date.getTime() - Date.now()) / ONE_SECOND_IN_MS);


### PR DESCRIPTION
## 🎯 Goal

In v4.0.0, the countdown timer is stuck, and isn't actually counting down. This PR aims to fix that.

## 🛠 Implementation details

From feedback when talking about the original PR for the countdown timer, an empty dependency array was added to the useEffect wrapping the actual `setInterval`. This PR removes this, as an empty dependency array makes it so the effect is triggered at mount, and cleaned up at unmount.

Like this, the useEffect will be called on a rerender of MessageInput, and at each tick of the setInterval call that's being set up. It also cleans up the interval each time it's ran, making it so it will be cleaned up even if you dismount the component before the cooldown has completed.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

