### PR TITLE
build: Ignore test files in lib/

### DIFF
--- a/package/jest.config.js
+++ b/package/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
     './node_modules/react-native-gesture-handler/jestSetup.js',
   ],
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
-  testPathIgnorePatterns: ['/node_modules/', '/examples/', '__snapshots__'],
+  testPathIgnorePatterns: ['/node_modules/', '/examples/', '__snapshots__', '/lib/'],
   transformIgnorePatterns: ['node_modules/!(react-native-reanimated)'],
   testRegex: [
     /**


### PR DESCRIPTION
## 🎯 Goal

The current jest config makes it so it also looks for test files in lib/, making it so tests written in TypeScript will be ran twice - once in `src/` and once in `lib/`.

This PR makes it so jest ignores `/lib`

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

