### PR TITLE
fix: render attachment type video in FileAttachment view [CRNS-480]

### DIFF
--- a/package/src/components/Attachment/Attachment.tsx
+++ b/package/src/components/Attachment/Attachment.tsx
@@ -84,10 +84,10 @@ const AttachmentWithContext = <
     return <FileAttachment attachment={attachment} />;
   }
 
-  if (attachment.type === 'video' && attachment.asset_url && attachment.image_url) {
+  if (attachment.type === 'video' && attachment.asset_url) {
     return (
       // TODO: Put in video component
-      <Card {...attachment} />
+      <FileAttachment attachment={attachment} />
     );
   }
 

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -468,7 +468,7 @@ const MessageWithContext = <
     !message.deleted_at && Array.isArray(message.attachments)
       ? message.attachments.reduce(
           (acc, cur) => {
-            if (cur.type === 'file') {
+            if (cur.type === 'file' || cur.type === 'video') {
               acc.files.push(cur);
               acc.other = []; // remove other attachments if a file exists
             } else if (cur.type === 'image' && !cur.title_link && !cur.og_scrape_url) {


### PR DESCRIPTION
## 🎯 Goal

RN SDK currently doesn't support video rendering. And thus when user uploads a video, it gets sent as `attachment.type === 'file'`. But when file gets uploaded from other SDKs, it gets sent as type `video`, and handling of this case was wrong within the SDK. It used to get rendered as `Card` component instead of FileAttachment.

https://getstream.slack.com/archives/C02888QAYG0/p1636955394060400

## 🛠 Implementation details

Render type `video` attachment as file attachment.

## 🎨 UI Changes

| BEFORE | AFTER |
| - | - |
| ![Screenshot 2021-11-15 at 09 02 55](https://user-images.githubusercontent.com/11586388/141744315-8dd514ee-aa54-4efc-ab74-66b1b0c9c249.png) | ![Screenshot 2021-11-15 at 09 03 15](https://user-images.githubusercontent.com/11586388/141744307-c4981188-44f6-4bf1-ac11-bde513a1a907.png) |

## 🧪 Testing

Upload video file from react application and check it on react-native example app.

**P.S.** We currently have a task to ensure attachment consistency across SDKs, so automated tests will be taken care of as part of that story.