### PR TITLE
fix(perf): turn off legacy image swiping behaviour

### DIFF
--- a/docusaurus/docs/reactnative/common-content/core-components/channel/props/legacy_image_viewer_swipe_behaviour.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/channel/props/legacy_image_viewer_swipe_behaviour.mdx
@@ -2,13 +2,9 @@
 
 Enables/disables the legacy image viewer behavior.
 
-By default, when you open (press) an image attachment it opens the image in a full-screen image viewer.
-Within the viewer, you can keep swiping left to scroll through all the images that have been loaded within a channel so far.
-This creates quite a lot of extra work for the JS thread to keep track of image attachments loaded in a channel and pre-populating them in the viewer for smooth transitions.
-
-For performance reason, you can switch to an alternate UX for the image viewer where image attachments are only loaded for the selected messages in a viewer,
-by setting this prop to false.
+When true, within the image viewer you can keep swiping left to scroll through all the images that have been loaded within a channel so far.
+Beaware that this creates quite a lot of extra work for the JS thread to keep track of image attachments loaded in a channel and pre-populating them in the viewer for smooth transitions.
 
 | Type | Default |
 | - | - |
-| boolean | true |
+| boolean | false |

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -466,8 +466,7 @@ const ChannelWithContext = <
     keyboardBehavior,
     KeyboardCompatibleView = KeyboardCompatibleViewDefault,
     keyboardVerticalOffset,
-    // TODO[major]: switch to false.
-    legacyImageViewerSwipeBehaviour = true,
+    legacyImageViewerSwipeBehaviour = false,
     LoadingErrorIndicator = LoadingErrorIndicatorDefault,
     LoadingIndicator = LoadingIndicatorDefault,
     loadingMore: loadingMoreProp,


### PR DESCRIPTION
## 🎯 Goal

Switch off the legacy image swiping behavior

## 🛠 Implementation details

Switch the default value of [`legacyImageViewerSwipeBehaviour`](https://getstream.io/chat/docs/sdk/reactnative/core-components/channel/#legacyimageviewerswipebehaviour) prop to false

