### PR TITLE
fix: Add the correct styling for CooldownTimer

### DIFF
--- a/docusaurus/docs/reactnative/guides/message_input_customization.mdx
+++ b/docusaurus/docs/reactnative/guides/message_input_customization.mdx
@@ -288,9 +288,31 @@ const additionalTextInputProps = useMemo(() => {
 
 ## Customizing the slow mode CooldownTimer
 
+### Modifying styles through the theme
+
+The default CooldownTimer can have it's styles altered through the theme, using the following keys:
+
+```jsx
+    <ThemeProvider style={{
+      {/* ... your other styles */}
+      messageInput: {
+        cooldownTimer: {
+          container: {
+            {/* ViewStyle values */}
+          },
+          text: {
+            {/* TextStyle values */}
+          }
+        }
+      }
+    }}>
+```
+
+### Creating a custom CooldownTimer
+
 If a channel has slow mode enabled, the send button will be disabled when a user has sent a message, and a countdown will be displayed in its place. The built-in CooldownTimer component is styled to look like the disabled variant of the built-in send button, but you can replace the CooldownTimer to fit it to your needs.
 
-To do so, first create your custom CooldownTimer component, which `{ seconds: number }` as a prop, which is the current amount of seconds left until the cooldown finishes.
+To do so, first create your custom CooldownTimer component that accepts `{ seconds: number }` as a prop, which is the current amount of seconds left until the cooldown finishes.
 
 ```jsx
 import { CooldownTimerProps } from 'stream-chat-react-native';
@@ -307,7 +329,7 @@ const CustomCooldownTimer = ({ seconds }: CooldownTimerProps) => {
 You will then have to add your CustomCooldownTimer component as a prop to the Channel component in your application.
 
 ```jsx
-<Channel CooldownTimer={additionalTextInputProps}>...</Channel>
+<Channel CooldownTimer={CustomCooldownTimer}>...</Channel>
 ```
 
 ## Replacing AttachmentPicker With Native Image Picker

--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -85,7 +85,13 @@ type AutoCompleteInputPropsWithContext<
     SuggestionsContextValue<Co, Us>,
     'closeSuggestions' | 'openSuggestions' | 'updateSuggestions'
   > &
-  Pick<TranslationContextValue, 't'>;
+  Pick<TranslationContextValue, 't'> & {
+    /**
+     * This is currently passed in from MessageInput to avoid rerenders
+     * that would happen if we put this in the MessageInputContext
+     */
+    cooldownActive?: boolean;
+  };
 
 export type AutoCompleteInputProps<
   At extends UnknownType = DefaultAttachmentType,
@@ -112,6 +118,7 @@ const AutoCompleteInputWithContext = <
     additionalTextInputProps,
     autoCompleteSuggestionsLimit,
     closeSuggestions,
+    cooldownActive = false,
     giphyActive,
     giphyEnabled,
     maxMessageLength,
@@ -396,6 +403,12 @@ const AutoCompleteInputWithContext = <
     }
   };
 
+  const placeholderText = giphyActive
+    ? t('Search GIFs')
+    : cooldownActive
+    ? t('Slow mode ON')
+    : t('Send a message');
+
   const handleSuggestionsThrottled = throttle(handleSuggestions, 100, {
     leading: false,
   });
@@ -422,7 +435,7 @@ const AutoCompleteInputWithContext = <
         }
       }}
       onSelectionChange={handleSelectionChange}
-      placeholder={giphyActive ? t('Search GIFs') : t('Send a message')}
+      placeholder={placeholderText}
       placeholderTextColor={grey}
       ref={setInputBoxRef}
       style={[
@@ -458,8 +471,18 @@ const areEqual = <
   prevProps: AutoCompleteInputPropsWithContext<At, Ch, Co, Ev, Me, Re, Us>,
   nextProps: AutoCompleteInputPropsWithContext<At, Ch, Co, Ev, Me, Re, Us>,
 ) => {
-  const { giphyActive: prevGiphyActive, t: prevT, text: prevText } = prevProps;
-  const { giphyActive: nextGiphyActive, t: nextT, text: nextText } = nextProps;
+  const {
+    cooldownActive: prevCooldownActive,
+    giphyActive: prevGiphyActive,
+    t: prevT,
+    text: prevText,
+  } = prevProps;
+  const {
+    cooldownActive: nextCooldownActive,
+    giphyActive: nextGiphyActive,
+    t: nextT,
+    text: nextText,
+  } = nextProps;
 
   const giphyActiveEqual = prevGiphyActive === nextGiphyActive;
   if (!giphyActiveEqual) return false;
@@ -469,6 +492,9 @@ const areEqual = <
 
   const textEqual = prevText === nextText;
   if (!textEqual) return false;
+
+  const cooldownActiveEqual = prevCooldownActive === nextCooldownActive;
+  if (!cooldownActiveEqual) return false;
 
   return true;
 };

--- a/package/src/components/MessageInput/CooldownTimer.tsx
+++ b/package/src/components/MessageInput/CooldownTimer.tsx
@@ -1,10 +1,22 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 
 export type CooldownTimerProps = {
   seconds: number;
 };
+
+const CONTAINER_SIZE = 24;
+const CONTAINER_HORIZONTAL_PADDING = 6;
+const EXTRA_CHARACTER_PADDING = CONTAINER_SIZE - CONTAINER_HORIZONTAL_PADDING * 2;
+
+/**
+ * To avoid the container jumping between sizes when there are more
+ * than one character in the width of the container since we aren't
+ * using a monospaced font.
+ */
+const normalizeWidth = (seconds: number) =>
+  CONTAINER_SIZE + EXTRA_CHARACTER_PADDING * (`${seconds}`.length - 1);
 
 /**
  * Renders an amount of seconds left for a cooldown to finish.
@@ -16,14 +28,39 @@ export const CooldownTimer = (props: CooldownTimerProps) => {
   const { seconds } = props;
   const {
     theme: {
-      colors: { black },
-      messageInput: { cooldownTimer },
+      colors: { black, grey_gainsboro },
+      messageInput: {
+        cooldownTimer: { container, text },
+      },
     },
   } = useTheme();
 
   return (
-    <Text style={[{ color: black }, cooldownTimer]} testID='cooldown-seconds'>
-      {seconds}
-    </Text>
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: grey_gainsboro,
+          width: normalizeWidth(seconds),
+        },
+        container,
+      ]}
+    >
+      <Text style={[styles.text, { color: black }, text]} testID='cooldown-seconds'>
+        {seconds}
+      </Text>
+    </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    borderRadius: CONTAINER_SIZE / 2,
+    height: CONTAINER_SIZE,
+    justifyContent: 'center',
+    minWidth: CONTAINER_SIZE,
+    paddingHorizontal: CONTAINER_HORIZONTAL_PADDING,
+  },
+  text: { fontSize: 16, fontWeight: '600' },
+});

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -546,6 +546,7 @@ const MessageInputWithContext = <
                   )}
                   <AutoCompleteInput<At, Ch, Co, Ev, Me, Re, Us>
                     additionalTextInputProps={additionalTextInputProps}
+                    cooldownActive={!!cooldownRemainingSeconds}
                   />
                   {giphyActive && (
                     <TouchableOpacity

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -219,7 +219,10 @@ export type Theme = {
     commandsButtonContainer: ViewStyle;
     composerContainer: ViewStyle;
     container: ViewStyle;
-    cooldownTimer: TextStyle;
+    cooldownTimer: {
+      container: ViewStyle;
+      text: TextStyle;
+    };
     editingBoxContainer: ViewStyle;
     editingBoxHeader: ViewStyle;
     editingBoxHeaderTitle: TextStyle;
@@ -669,7 +672,10 @@ export const defaultTheme: Theme = {
     commandsButtonContainer: {},
     composerContainer: {},
     container: {},
-    cooldownTimer: {},
+    cooldownTimer: {
+      container: {},
+      text: {},
+    },
     editingBoxContainer: {},
     editingBoxHeader: {},
     editingBoxHeaderTitle: {},

--- a/package/src/i18n/en.json
+++ b/package/src/i18n/en.json
@@ -46,6 +46,7 @@
   "Search GIFs": "Search GIFs",
   "Send a message": "Send a message",
   "Sending links is not allowed in this conversation": "Sending links is not allowed in this conversation",
+  "Slow mode ON": "Slow mode ON",
   "The message has been reported to a moderator.": "The message has been reported to a moderator.",
   "Thread Reply": "Thread Reply",
   "Unblock User": "Unblock User",

--- a/package/src/i18n/fr.json
+++ b/package/src/i18n/fr.json
@@ -46,6 +46,7 @@
   "Search GIFs": "Rechercher des GIF",
   "Send a message": "Envoyer un message",
   "Sending links is not allowed in this conversation": "Sending links is not allowed in this conversation",
+  "Slow mode ON": "Mode lent activé",
   "The message has been reported to a moderator.": "Le message a été signalé à un modérateur.",
   "Thread Reply": "Réponse à la discussion",
   "Unblock User": "Débloquer Utilisateur",

--- a/package/src/i18n/hi.json
+++ b/package/src/i18n/hi.json
@@ -46,6 +46,7 @@
   "Search GIFs": "GIF खोजें",
   "Send a message": "एक संदेश भेजें",
   "Sending links is not allowed in this conversation": "इस बातचीत में लिंक भेजने की अनुमति नहीं है",
+  "Slow mode ON": "स्लो मोड चालू",
   "The message has been reported to a moderator.": "संदेश एक मॉडरेटर को सूचित किया गया है।",
   "Thread Reply": "धागा जवाब",
   "Unblock User": "उपयोगकर्ता को अनब्लॉक करें",

--- a/package/src/i18n/it.json
+++ b/package/src/i18n/it.json
@@ -46,6 +46,7 @@
   "Search GIFs": "Cerca GIF",
   "Send a message": "Mandare un messaggio",
   "Sending links is not allowed in this conversation": "L'invio di link non è consentito in questa conversazione",
+  "Slow mode ON": "Slowmode attiva",
   "The message has been reported to a moderator.": "Il messaggio è stato segnalato a un moderatore.",
   "Thread Reply": "Rispondi alla Discussione",
   "Unblock User": "Sblocca utente",

--- a/package/src/i18n/ja.json
+++ b/package/src/i18n/ja.json
@@ -37,6 +37,7 @@
   "Search GIFs": "GIFの探索",
   "Send a message": "メッセージを送る",
   "Something went wrong": "問題が発生しました。",
+  "Slow mode ON": "スローモードオン",
   "The message has been reported to a moderator.": "メッセージはモデレーターに報告されました。",
   "The operation couldn't be completed.": "操作を完了できませんでした。",
   "Thread Reply": "スレッドの返信",

--- a/package/src/i18n/ko.json
+++ b/package/src/i18n/ko.json
@@ -37,6 +37,7 @@
   "Search GIFs": "GIF의 검색",
   "Send a message": "메세지를 보내다",
   "Something went wrong": "문제가 발생했습니다.",
+  "Slow mode ON": "슬로모드 켜짐",
   "The message has been reported to a moderator.": "메시지는 운영자에보고되었습니다.",
   "The operation couldn't be completed.": "작업을 완료할 수 없습니다.",
   "Thread Reply": "스레드　답장",

--- a/package/src/i18n/nl.json
+++ b/package/src/i18n/nl.json
@@ -46,6 +46,7 @@
   "Search GIFs": "Zoek GIF's",
   "Send a message": "Stuur een bericht",
   "Sending links is not allowed in this conversation": "In dit gesprek is het niet toegestaan links te versturen",
+  "Slow mode ON": "Langzame modus aan",
   "The message has been reported to a moderator.": "Het bericht is gerapporteerd aan een moderator.",
   "Thread Reply": "Discussie beantwoorden",
   "Unblock User": "Deblokkeer gebruiker",

--- a/package/src/i18n/ru.json
+++ b/package/src/i18n/ru.json
@@ -46,6 +46,7 @@
   "Search GIFs": "Поиск GIF",
   "Send a message": "Отправить сообщение",
   "Sending links is not allowed in this conversation": "Отправка ссылок недоступна в этом чате",
+  "Slow mode ON": "Медленный режим включен",
   "The message has been reported to a moderator.": "Сообщение отправлено модератору.",
   "Thread Reply": "Тема Ответить",
   "Unblock User": "Разблокировать пользователя",

--- a/package/src/i18n/tr.json
+++ b/package/src/i18n/tr.json
@@ -46,6 +46,7 @@
   "Search GIFs": "GIF ara",
   "Send a message": "Bir mesaj göndermek",
   "Sending links is not allowed in this conversation": "Bağlantı göndermek bu konuşmada desteklenmiyor",
+  "Slow mode ON": "Yavaş Mod Açık",
   "The message has been reported to a moderator.": "Mesaj bir moderatöre bildirildi.",
   "Thread Reply": "Konu Yanıtı",
   "Unblock User": "Kullanıcının engelini kaldır",


### PR DESCRIPTION
## 🎯 Goal

Changing the styling of the CooldownTimer to match the [figma designs](https://www.figma.com/file/ekifwChR9tR7zRJg1QEzSM/Chat-Design-Kit---Current-version?node-id=12254%3A953)

## 🛠 Implementation details

One quirk I'm doing is to check for the amount of characters are displayed as the remaining seconds, as without it, going through 13, 12, 11, 10 the countdown jumped in width from character to character. As seen in the supplied video, this works around that.

I don't think this makes a difference of significance/that can be noticed since the component rerenders every second anyways, and it's a cheap calculation to make, so I haven't optimized it at all. If anybody thinks we should, I'm all ears.

## 🎨 UI Changes

https://user-images.githubusercontent.com/1548276/143273889-c7e3e290-33eb-4bd1-98f6-cfa0e7d3556e.mp4

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [ ] Documentation is updated

