### PR TITLE
fix: crash on parsing urls [CRNS-498]

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -70,6 +70,19 @@ const parse: ParseFunction = (capture, parse, state) => ({
   content: parseInline(parse, capture[0], state),
 });
 
+const parseUrlsFromText = (text: string) => {
+  try {
+    return anchorme(text, {
+      list: true,
+    });
+  } catch (e) {
+    console.warn(`failure at parseUrlsFromText: ${e}`);
+    // In case of failures its not worth crashing the app,
+    // and instead simply to have un-parsed urls in message text.
+    return [];
+  }
+};
+
 export type MarkdownRules = Partial<DefaultRules>;
 
 export type RenderTextParams<
@@ -125,9 +138,7 @@ export const renderText = <
   if (!text) return null;
 
   let newText = text.trim();
-  const urls = anchorme(newText, {
-    list: true,
-  });
+  const urls = parseUrlsFromText(newText);
 
   for (const urlInfo of urls) {
     const displayLink = truncate(urlInfo.encoded.replace(/^(www\.)/, ''), {


### PR DESCRIPTION
## 🎯 Goal

URL parsing using `anachrome` library seems to break in case text contains some special character or so. Its not worth breaking the app when url parsing fails, and thus we should simply fallback to plain text when this happens.

## 🛠 Implementation details

Add `try ... catch` around url parsing using `anachrome.js` and ignore in case of failure.

## 🧪 Testing

- Open a channel
- Send following message: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa🤡`
- Long press on this message
- Select "Reply" message action.
- Notice the error on screen.
