### PR TITLE
Fix: Mentioned users removed after editing message [CRNS - 493]

### DIFF
--- a/package/src/contexts/messageInputContext/hooks/useMessageDetailsForState.ts
+++ b/package/src/contexts/messageInputContext/hooks/useMessageDetailsForState.ts
@@ -53,6 +53,9 @@ export const useMessageDetailsForState = <
     }
   }, [text]);
 
+  const messageValue =
+    typeof message === 'boolean' ? '' : `${message.id}${message.text}${message.updated_at}`;
+
   useEffect(() => {
     if (
       !isEditingBoolean<At, Ch, Co, Ev, Me, Re, Us>(message) &&
@@ -61,10 +64,8 @@ export const useMessageDetailsForState = <
       const mentionedUsers = message.mentioned_users.map((user) => user.id);
       setMentionedUsers(mentionedUsers);
     }
-  }, [message]);
+  }, [messageValue]);
 
-  const messageValue =
-    typeof message === 'boolean' ? '' : `${message.id}${message.text}${message.updated_at}`;
   useEffect(() => {
     if (message && !isEditingBoolean<At, Ch, Co, Ev, Me, Re, Us>(message)) {
       setText(message?.text || '');

--- a/package/src/contexts/messageInputContext/hooks/useMessageDetailsForState.ts
+++ b/package/src/contexts/messageInputContext/hooks/useMessageDetailsForState.ts
@@ -41,12 +41,7 @@ export const useMessageDetailsForState = <
 ) => {
   const [fileUploads, setFileUploads] = useState<FileUpload[]>([]);
   const [imageUploads, setImageUploads] = useState<ImageUpload[]>([]);
-  const [mentionedUsers, setMentionedUsers] = useState(
-    (!isEditingBoolean<At, Ch, Co, Ev, Me, Re, Us>(message) &&
-      Array.isArray(message?.mentioned_users) &&
-      message.mentioned_users.map((user) => user.id)) ||
-      [],
-  );
+  const [mentionedUsers, setMentionedUsers] = useState<string[]>([]);
   const [numberOfUploads, setNumberOfUploads] = useState(0);
   const [showMoreOptions, setShowMoreOptions] = useState(true);
   const initialTextValue = initialValue || '';
@@ -57,6 +52,16 @@ export const useMessageDetailsForState = <
       setShowMoreOptions(false);
     }
   }, [text]);
+
+  useEffect(() => {
+    if (
+      !isEditingBoolean<At, Ch, Co, Ev, Me, Re, Us>(message) &&
+      Array.isArray(message?.mentioned_users)
+    ) {
+      const mentionedUsers = message.mentioned_users.map((user) => user.id);
+      setMentionedUsers(mentionedUsers);
+    }
+  }, [message]);
 
   const messageValue =
     typeof message === 'boolean' ? '' : `${message.id}${message.text}${message.updated_at}`;


### PR DESCRIPTION
## 🎯 Goal
This PR fixes the empty mentioned users array issue when a message with a mentioned user is edited. 
Fixes: #1023 
Reference ticket: https://stream-io.atlassian.net/browse/CRNS-493
<!-- Describe why we are making this change -->

## 🛠 Implementation details
The solution is fixed in `useEffect` hook.
<!-- Provide a description of the implementation -->

## 📹  Video

https://user-images.githubusercontent.com/39884168/145537720-ea3738c2-e31b-4847-9ab3-0dfd0e8ff1fa.mov



## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

