### PR TITLE
fix: Animated prop with fill crashing [CRNS-507]

### DIFF
--- a/package/src/components/MessageOverlay/OverlayReactionList.tsx
+++ b/package/src/components/MessageOverlay/OverlayReactionList.tsx
@@ -334,14 +334,12 @@ const OverlayReactionListWithContext = <
   const animatedBigCircleProps = useAnimatedProps<CircleProps>(() => ({
     cx: messageLayout.value.x - radius * 3,
     cy: messageLayout.value.y - radius * 3,
-    fill: fill || white_snow,
     r: radius * 2,
   }));
 
   const animateSmallCircleProps = useAnimatedProps<CircleProps>(() => ({
     cx: messageLayout.value.x - radius,
     cy: messageLayout.value.y,
-    fill: fill || white_snow,
     r: radius,
   }));
 
@@ -380,8 +378,8 @@ const OverlayReactionListWithContext = <
         style={showScreenStyle}
       >
         <Svg>
-          <AnimatedCircle animatedProps={animatedBigCircleProps} />
-          <AnimatedCircle animatedProps={animateSmallCircleProps} />
+          <AnimatedCircle animatedProps={animatedBigCircleProps} fill={fill || white_snow} />
+          <AnimatedCircle animatedProps={animateSmallCircleProps} fill={fill || white_snow} />
         </Svg>
         <Animated.View
           onLayout={({


### PR DESCRIPTION
When passing fill in useAnimatedProps, the value passed to
RenderableView in react-native-svg is the literal hex string
and isn't converted to the rgb value array expected.

This fixes #1054

@vishalnarkhede I think this is worth releasing as a hotfix for 3.x as well as including in v4.0.0-beta.2

## 🛠 Implementation details

This ligns up with how the [`hook is supposed to be used as per the reanimated docs`](https://docs.swmansion.com/react-native-reanimated/docs/2.2.0/api/useAnimatedProps/), and works with both reanimated v2.2.x and 2.3.x.

## 🎨 UI Changes

None

## 🧪 Testing

Haven't found a good way to automate this yet, but if you open an overlay on android with reanimated v2.3.1 with and without this diff, it should clearly break without and not break when the diff is applied.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec


