### PR TITLE
refactor: Move resettable state to a new custom hook

### DIFF
--- a/package/src/contexts/messageOverlayContext/MessageOverlayContext.tsx
+++ b/package/src/contexts/messageOverlayContext/MessageOverlayContext.tsx
@@ -25,6 +25,7 @@ import type { Alignment, MessageContextValue } from '../messageContext/MessageCo
 import type { MessagesContextValue } from '../messagesContext/MessagesContext';
 import type { OwnCapabilitiesContextValue } from '../ownCapabilitiesContext/OwnCapabilitiesContext';
 import { getDisplayName } from '../utils/getDisplayName';
+import { useResettableState } from './hooks/useResettableState';
 
 export type MessageOverlayData<
   At extends UnknownType = DefaultAttachmentType,
@@ -103,18 +104,7 @@ export const MessageOverlayProvider = <
 }: PropsWithChildren<{
   value?: MessageOverlayContextValue<At, Ch, Co, Ev, Me, Re, Us>;
 }>) => {
-  const [data, setData] = useState(value?.data);
-
-  const reset = () => {
-    // TODO: Add the isMounted check here.
-    setData(value?.data);
-  };
-
-  const messageOverlayContext = {
-    data,
-    reset,
-    setData,
-  };
+  const messageOverlayContext = useResettableState(value);
   return (
     <MessageOverlayContext.Provider value={messageOverlayContext as MessageOverlayContextValue}>
       {children}

--- a/package/src/contexts/messageOverlayContext/MessageOverlayContext.tsx
+++ b/package/src/contexts/messageOverlayContext/MessageOverlayContext.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useContext, useState } from 'react';
+import React, { PropsWithChildren, useContext } from 'react';
 
 import type { Attachment } from 'stream-chat';
 

--- a/package/src/contexts/messageOverlayContext/MessageOverlayContext.tsx
+++ b/package/src/contexts/messageOverlayContext/MessageOverlayContext.tsx
@@ -2,6 +2,8 @@ import React, { PropsWithChildren, useContext } from 'react';
 
 import type { Attachment } from 'stream-chat';
 
+import { useResettableState } from './hooks/useResettableState';
+
 import type { GroupType, MessageType } from '../../components/MessageList/hooks/useMessageList';
 import type { MessageActionListProps } from '../../components/MessageOverlay/MessageActionList';
 import type {
@@ -25,7 +27,6 @@ import type { Alignment, MessageContextValue } from '../messageContext/MessageCo
 import type { MessagesContextValue } from '../messagesContext/MessagesContext';
 import type { OwnCapabilitiesContextValue } from '../ownCapabilitiesContext/OwnCapabilitiesContext';
 import { getDisplayName } from '../utils/getDisplayName';
-import { useResettableState } from './hooks/useResettableState';
 
 export type MessageOverlayData<
   At extends UnknownType = DefaultAttachmentType,

--- a/package/src/contexts/messageOverlayContext/hooks/useResettableState.test.tsx
+++ b/package/src/contexts/messageOverlayContext/hooks/useResettableState.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Button, Text } from 'react-native';
+
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
 import { useResettableState } from './useResettableState';
 
 const TestComponent = () => {

--- a/package/src/contexts/messageOverlayContext/hooks/useResettableState.test.tsx
+++ b/package/src/contexts/messageOverlayContext/hooks/useResettableState.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Button, Text } from 'react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { useResettableState } from './useResettableState';
+
+const TestComponent = () => {
+  const { data, reset, setData } = useResettableState(0);
+
+  return (
+    <>
+      <Text testID='value'>{`${data}`}</Text>
+      <Button
+        onPress={() => {
+          setData(data + 1);
+        }}
+        testID='increment'
+        title='Super useful incrementer'
+      />
+      <Button
+        onPress={() => {
+          reset();
+        }}
+        testID='reset'
+        title='Oh no, go back!'
+      />
+    </>
+  );
+};
+
+const waitForOptions = {
+  timeout: 1000,
+};
+
+test('useResettableState can be reset to its initial state', async () => {
+  const { getByTestId } = render(<TestComponent />);
+
+  await waitFor(() => expect(getByTestId('value').children[0]).toBe('0'), waitForOptions);
+
+  fireEvent.press(getByTestId('increment'));
+  await waitFor(() => expect(getByTestId('value').children[0]).toBe('1'), waitForOptions);
+
+  fireEvent.press(getByTestId('reset'));
+  await waitFor(() => expect(getByTestId('value').children[0]).toBe('0'), waitForOptions);
+});

--- a/package/src/contexts/messageOverlayContext/hooks/useResettableState.ts
+++ b/package/src/contexts/messageOverlayContext/hooks/useResettableState.ts
@@ -1,0 +1,21 @@
+import { useState } from "react";
+import { useIsMountedRef } from "../../../hooks/useIsMountedRef";
+
+/**
+ * Wrapper around useState that provides a `reset`
+ * function to reset the state to its initial value.
+ *
+ * Will not set state after being unmounted.
+ * */
+export const useResettableState = <T>(values: T)  => {
+  const [data, setData] = useState(values);
+  const isMounted = useIsMountedRef();
+
+  const reset = () => {
+    if (isMounted.current) {
+      setData(values);
+    }
+  }
+
+  return { data, reset, setData };
+}

--- a/package/src/contexts/messageOverlayContext/hooks/useResettableState.ts
+++ b/package/src/contexts/messageOverlayContext/hooks/useResettableState.ts
@@ -1,5 +1,6 @@
-import { useState } from "react";
-import { useIsMountedRef } from "../../../hooks/useIsMountedRef";
+import { useState } from 'react';
+
+import { useIsMountedRef } from '../../../hooks/useIsMountedRef';
 
 /**
  * Wrapper around useState that provides a `reset`
@@ -7,7 +8,7 @@ import { useIsMountedRef } from "../../../hooks/useIsMountedRef";
  *
  * Will not set state after being unmounted.
  * */
-export const useResettableState = <T>(values: T)  => {
+export const useResettableState = <T>(values: T) => {
   const [data, setData] = useState(values);
   const isMounted = useIsMountedRef();
 
@@ -15,7 +16,7 @@ export const useResettableState = <T>(values: T)  => {
     if (isMounted.current) {
       setData(values);
     }
-  }
+  };
 
   return { data, reset, setData };
-}
+};


### PR DESCRIPTION
## 🎯 Goal

This fixes #1065, and adds a test to check that the reset of state works as expected. Moved to a custom hook for simplicity.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [x] New code is covered by tests


