### PR TITLE
Fix: Error banner UI in channel list screen [CRNS - 436]

### DIFF
--- a/package/src/components/ChannelList/ChannelListHeaderErrorIndicator.tsx
+++ b/package/src/components/ChannelList/ChannelListHeaderErrorIndicator.tsx
@@ -13,7 +13,6 @@ const styles = StyleSheet.create({
   },
   errorText: {
     fontSize: 12,
-    fontWeight: 'bold',
     padding: 3,
   },
 });
@@ -28,7 +27,7 @@ export const ChannelListHeaderErrorIndicator: React.FC<HeaderErrorProps> = ({
   const {
     theme: {
       channelListHeaderErrorIndicator: { container, errorText },
-      colors: { accent_red, grey },
+      colors: { grey_dark, white },
     },
   } = useTheme();
   const { t } = useTranslationContext();
@@ -36,12 +35,9 @@ export const ChannelListHeaderErrorIndicator: React.FC<HeaderErrorProps> = ({
   return (
     <TouchableOpacity
       onPress={onPress}
-      style={[styles.container, { backgroundColor: `${grey}E6` }, container]}
+      style={[styles.container, { backgroundColor: `${grey_dark}E6` }, container]}
     >
-      <Text
-        style={[styles.errorText, { color: accent_red }, errorText]}
-        testID='channel-loading-error'
-      >
+      <Text style={[styles.errorText, { color: white }, errorText]} testID='channel-loading-error'>
         {t('Error while loading, please reload/refresh')}
       </Text>
     </TouchableOpacity>

--- a/package/src/components/ChannelList/ChannelListHeaderNetworkDownIndicator.tsx
+++ b/package/src/components/ChannelList/ChannelListHeaderNetworkDownIndicator.tsx
@@ -20,14 +20,14 @@ export const ChannelListHeaderNetworkDownIndicator: React.FC = () => {
   const {
     theme: {
       channelListHeaderErrorIndicator: { container, errorText },
-      colors: { grey, white },
+      colors: { grey_dark, white },
     },
   } = useTheme();
   const { t } = useTranslationContext();
 
   return (
     <View
-      style={[styles.container, { backgroundColor: `${grey}E6` }, container]}
+      style={[styles.container, { backgroundColor: `${grey_dark}E6` }, container]}
       testID='network-down-indicator'
     >
       <Text style={[styles.errorText, { color: white }, errorText]}>{t('Reconnecting...')}</Text>


### PR DESCRIPTION
## 🎯 Goal

The goal of this PR is to fix the error banner UI in the Channel list screen when there's a network error or the user isn't online.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The text color of the error text is changed to `white(#ffffff)`. The background color of the UI is also fixed. 

Note: These changes were specific to the SDK and not the SampleApp. Tested for Dark mode too.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/148924780-9d8cbb76-067e-43e0-a835-a551e6e6ac5e.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/148924264-079bb0ae-f68f-4ee8-9cf5-05eeec5d8be8.png" />
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/148924622-a797860d-3482-426a-bb49-744f59777d3f.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/148924374-e019943b-c3fa-4b15-a193-0b4b1791a46f.png" />
</td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [ ] Documentation is updated

