### PR TITLE
Fix: enable user panel submenu swipe gesture on Android in Sample App [CRNS - 295]

### DIFF
--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -82,23 +82,19 @@ const App = () => {
   );
 };
 
-const DrawerNavigator: React.FC = () => {
-  const { overlay } = useOverlayContext();
-
-  return (
-    <Drawer.Navigator
-      drawerContent={(props) => <MenuDrawer {...props} />}
-      drawerStyle={{
-        width: 300,
-      }}
-      screenOptions={{
-        gestureEnabled: Platform.OS === 'ios' && overlay === 'none',
-      }}
-    >
-      <Drawer.Screen component={HomeScreen} name='HomeScreen' options={{ headerShown: false }} />
-    </Drawer.Navigator>
-  );
-};
+const DrawerNavigator: React.FC = () => (
+  <Drawer.Navigator
+    drawerContent={(props) => <MenuDrawer {...props} />}
+    drawerStyle={{
+      width: 300,
+    }}
+    screenOptions={{
+      gestureEnabled: true,
+    }}
+  >
+    <Drawer.Screen component={HomeScreen} name='HomeScreen' options={{ headerShown: false }} />
+  </Drawer.Navigator>
+);
 
 const DrawerNavigatorWrapper: React.FC<{
   chatClient: StreamChat<


### PR DESCRIPTION
## 🎯 Goal

This PR focuses on solving the user panel swipe issue on android which was not swipeable previously. 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The changes are self-descriptive. Previously it was only for iOS and now it's enabled for Android too. 

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/39884168/149091986-1d82d600-57e9-402a-8ef6-03f8ff4120cb.mp4

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/39884168/149092010-acc0039f-fe6b-40df-8cc4-31de41948fb1.mov

</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [ ] Documentation is updated

