### PR TITLE
Fix: Sign-in advanced option focus UI fix [CRNS - 363]

### DIFF
--- a/examples/SampleApp/src/screens/AdvancedUserSelectorScreen.tsx
+++ b/examples/SampleApp/src/screens/AdvancedUserSelectorScreen.tsx
@@ -64,15 +64,29 @@ export const LabeledTextInput: React.FC<LabeledTextInputProps> = ({
 }) => {
   const {
     theme: {
-      colors: { accent_red, black, grey, white_smoke },
+      colors: { accent_blue, accent_red, black, grey, white_smoke },
     },
   } = useTheme();
+  const [borderColor, setBorderColor] = useState(white_smoke);
+
+  const onFocus = () => {
+    setBorderColor(accent_blue);
+  };
+
+  const onBlur = () => {
+    setBorderColor(white_smoke);
+  };
+
+  const isEmpty = value === undefined;
+
   return (
     <View
       style={[
         styles.labelTextContainer,
         {
           backgroundColor: white_smoke,
+          borderColor,
+          borderWidth: 1,
           paddingVertical: !!value || !!error ? 16 : 8,
         },
       ]}
@@ -102,13 +116,18 @@ export const LabeledTextInput: React.FC<LabeledTextInputProps> = ({
         </Text>
       )}
       <TextInput
+        onBlur={onBlur}
         onChangeText={onChangeText}
+        onFocus={onFocus}
         placeholder={label}
         placeholderTextColor={grey}
         returnKeyType='next'
         style={[
           styles.input,
-          { color: black, fontWeight: value ? undefined : '500' }, // design team wanted placeholder fontWeight of 500
+          {
+            color: black,
+            fontWeight: isEmpty ? '500' : 'normal',
+          }, // design team wanted placeholder fontWeight of 500
         ]}
         value={value}
       />


### PR DESCRIPTION
## 🎯 Goal

This PR fixes the sign-in advanced option UI in the SampleApp.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The input focus border color didn't work previously so now on focusing an input the border color of the text input is changed to `accent_blue`.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/149291224-66609705-18c0-4a30-9af5-24de198bf75b.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/149290618-f9573a9d-ef45-42c6-a314-628aeef36f29.png" /> 
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/149291292-12b28e66-80fd-4d56-800b-2ed20fe7dc22.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/149290486-0e4b450c-cf84-44f8-ae97-8f2db3bf8469.png" />
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [ ] Documentation is updated

