### PR TITLE
refactor: remove unused import of useContext in SampleApp

### DIFF
--- a/examples/SampleApp/src/screens/GroupChannelDetailsScreen.tsx
+++ b/examples/SampleApp/src/screens/GroupChannelDetailsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   ScrollView,
   StyleSheet,


### PR DESCRIPTION
## 🎯 Goal

An unused import in the SampleApp was reported in the next-release workflow (however, doesn't stop the build. I'll make a separate PR with some changes to the workflows)

