### PR TITLE
ci: remove chonkbot

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -25,7 +25,3 @@ jobs:
         run: yarn lerna-workspaces run lint && cd docusaurus && npx prettier --check '**/*.mdx'
       - name: Test
         run: yarn test:unit
-      - name: Chonkbot
-        uses: tpbowden/chonkbot@v1.0.13
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The chonkbot action doesn't play well with PRs opened from contributors outside the organization, and it doesn't provide enough value to spend the time to look into and fix this, I believe.