### PR TITLE
docs: Channel delete blank screen troubleshooting docs [CRNS - 472]

### DIFF
--- a/docusaurus/docs/reactnative/basics/troubleshooting.mdx
+++ b/docusaurus/docs/reactnative/basics/troubleshooting.mdx
@@ -250,7 +250,7 @@ dependencies {
 
 When a channel is deleted, and if some user is active on that channel, a blank screen appears by default (as per the default logic) as we return `null` in this case. It might be confusing for end user to see a blank screen and appropriate UX would be to navigate back to channel list screen. You can implement such UX by listening to `channel.deleted` event on channel screen, and navigate to channel list screen with appropriate notification on app.
 
-```tsx
+````tsx
 client.on('channel.deleted', (event) => {
   if (event.cid === channel.cid) {
     // add your action here
@@ -266,7 +266,7 @@ This includes ensuring you import `react-native-gesture-handler` at the top of y
 
 ```tsx
 import 'react-native-gesture-handler';
-```
+````
 
 And for Android you additionally need to update `MainActivity.java` to override the method for creating the `ReactRootView`.
 

--- a/docusaurus/docs/reactnative/basics/troubleshooting.mdx
+++ b/docusaurus/docs/reactnative/basics/troubleshooting.mdx
@@ -246,12 +246,9 @@ dependencies {
 }
 ```
 
-## Blank screen on channel delete
+## Blank screen when channel gets delete
 
-When a channel is deleted, and you are active on that channel a blank screen appears by default in the SDK as we return `null` by checking the status of the event returned from the backend.
-A user can go back to the channel list and then the channel gets disappeared from the list. At the same time, an event is shared from the backend which could be listened to get the status of the deleted channel.
-
-Users can listen to the event and store the status of the deleted channel and thereby display the appropriate message in the UI.
+When a channel is deleted, and if some user is active on that channel, a blank screen appears by default (as per the default logic) as we return `null` in this case. It might be confusing for end user to see a blank screen and appropriate UX would be to navigate back to channel list screen. You can implement such UX by listening to `channel.deleted` event on channel screen, and navigate to channel list screen with appropriate notification on app.
 
 ```tsx
 client.on('channel.deleted', (event) => {
@@ -259,7 +256,6 @@ client.on('channel.deleted', (event) => {
     // add your action here
   }
 }),
-```
 
 ## Touchables not working
 

--- a/docusaurus/docs/reactnative/basics/troubleshooting.mdx
+++ b/docusaurus/docs/reactnative/basics/troubleshooting.mdx
@@ -248,7 +248,7 @@ dependencies {
 
 ## Blank screen on channel delete
 
-When a channel is deleted, and you are active on that channel a blank screen appears by default in the SDK as we return `null` by checking the status of the event returned from the backend. 
+When a channel is deleted, and you are active on that channel a blank screen appears by default in the SDK as we return `null` by checking the status of the event returned from the backend.
 A user can go back to the channel list and then the channel gets disappeared from the list. At the same time, an event is shared from the backend which could be listened to get the status of the deleted channel.
 
 Users can listen to the event and store the status of the deleted channel and thereby display the appropriate message in the UI.

--- a/docusaurus/docs/reactnative/basics/troubleshooting.mdx
+++ b/docusaurus/docs/reactnative/basics/troubleshooting.mdx
@@ -248,8 +248,10 @@ dependencies {
 
 ## Blank screen on channel delete
 
-When a channel is deleted, an event is shared from the backend which could be listened to get the status of the deleted channel.
-Users can listen to the event and store the status of the deleted channel and thereby display the appropriate messa
+When a channel is deleted, and you are active on that channel a blank screen appears by default in the SDK as we return `null` by checking the status of the event returned from the backend. 
+A user can go back to the channel list and then the channel gets disappeared from the list. At the same time, an event is shared from the backend which could be listened to get the status of the deleted channel.
+
+Users can listen to the event and store the status of the deleted channel and thereby display the appropriate message in the UI.
 
 ```tsx
 client.on('channel.deleted', (event) => {

--- a/docusaurus/docs/reactnative/basics/troubleshooting.mdx
+++ b/docusaurus/docs/reactnative/basics/troubleshooting.mdx
@@ -246,6 +246,19 @@ dependencies {
 }
 ```
 
+## Blank screen on channel delete
+
+When a channel is deleted, an event is shared from the backend which could be listened to get the status of the deleted channel.
+Users can listen to the event and store the status of the deleted channel and thereby display the appropriate messa
+
+```tsx
+client.on('channel.deleted', (event) => {
+  if (event.cid === channel.cid) {
+    // add your action here
+  }
+}),
+```
+
 ## Touchables not working
 
 If you are having trouble with pressing, swiping, or otherwise interacting with components it is likely the result of [React Native Gesture Handler](https://docs.swmansion.com/react-native-gesture-handler/docs/) not being properly setup.


### PR DESCRIPTION
## 🎯 Goal

This PR involves adding the troubleshooting docs for the channel delete blank screen which appears if the channel is deleted.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

Nothing as such. Only the troubleshooting docs are updated. 

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [x] Documentation is updated

