### PR TITLE
fix: fixed touchable area for reaction list

### DIFF
--- a/package/src/components/Message/MessageSimple/ReactionList.tsx
+++ b/package/src/components/Message/MessageSimple/ReactionList.tsx
@@ -198,34 +198,7 @@ const ReactionListWithContext = <
       : x2 - (reactionSize * reactions.length) / 2 - strokeSize;
 
   return (
-    <TouchableOpacity
-      disabled={preventPress}
-      onLongPress={(event) => {
-        if (onLongPress) {
-          onLongPress({
-            emitter: 'reactionList',
-            event,
-          });
-        }
-      }}
-      onPress={(event) => {
-        if (onPress) {
-          onPress({
-            defaultHandler: () => showMessageOverlay(true),
-            emitter: 'reactionList',
-            event,
-          });
-        }
-      }}
-      onPressIn={(event) => {
-        if (onPressIn) {
-          onPressIn({
-            defaultHandler: () => showMessageOverlay(true),
-            emitter: 'reactionList',
-            event,
-          });
-        }
-      }}
+    <View
       style={[
         styles.container,
         {
@@ -266,7 +239,34 @@ const ReactionListWithContext = <
               <Circle cx={x2} cy={y2} fill={alignmentLeft ? fill : white} r={radius * 2} />
             </Svg>
           </View>
-          <View
+          <TouchableOpacity
+            disabled={preventPress}
+            onLongPress={(event) => {
+              if (onLongPress) {
+                onLongPress({
+                  emitter: 'reactionList',
+                  event,
+                });
+              }
+            }}
+            onPress={(event) => {
+              if (onPress) {
+                onPress({
+                  defaultHandler: () => showMessageOverlay(true),
+                  emitter: 'reactionList',
+                  event,
+                });
+              }
+            }}
+            onPressIn={(event) => {
+              if (onPressIn) {
+                onPressIn({
+                  defaultHandler: () => showMessageOverlay(true),
+                  emitter: 'reactionList',
+                  event,
+                });
+              }
+            }}
             style={[
               styles.reactionBubble,
               {
@@ -290,10 +290,10 @@ const ReactionListWithContext = <
                 type={reaction.type}
               />
             ))}
-          </View>
+          </TouchableOpacity>
         </View>
       ) : null}
-    </TouchableOpacity>
+    </View>
   );
 };
 


### PR DESCRIPTION
## 🎯 Goal

When you touch the reactions, it opens overlay. Currently touchable area for reactions is full width of the screen. Since reaction list kinda overlaps with the message content part, it creates a bit of wierd user experiece for end user e.g., user presses on upper half of message content (which is the overlapping part with reactions) and it opens overlay. But bottom half doesn't behave the same.

Also it creates confusion when you try to customize MessageContent. So its better if touchable area is only the reaction icons part. We have a ZD ticket for this - https://getstream.zendesk.com/agent/tickets/18105

## Screenshots

Following screenshots display touchable area (black bordered) before and after the change:

<table>
    <thead>
        <tr>
            <td><strong>Before</strong></td>
            <td><strong>After</strong></td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/11586388/152331470-ae4784c0-63ac-422d-a2f4-7992c5c54cbf.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/11586388/152331541-622d7cf4-a3a8-4660-b4ea-20142aca450a.png" /> 
            </td>
        </tr>
    </tbody>
</table>
