### PR TITLE
fix: add missing key in markdown list

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -252,7 +252,7 @@ export const renderText = <
   };
 
   const list: ReactNodeOutput = (node, output, state) => (
-    <ListOutput node={node} output={output} state={state} styles={styles} />
+    <ListOutput key={0} node={node} output={output} state={state} styles={styles} />
   );
 
   const customRules = {


### PR DESCRIPTION
## 🎯 Goal

Would potentially have been an issue if a message contains more than one list.

## 🛠 Implementation details

Uses whatever key is passed by the markdown lib

## 🧪 Testing

send a message along the lines of 

```
1. One
2. Two
3. Three

Hello

1. One
2. Two
3. Three
```

Check that no warning about duplicated keys in the `Markdown` component is logged

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests

