### PR TITLE
fix: only allow image resizing when new CDN is deployed

### DIFF
--- a/package/src/components/Attachment/__tests__/buildGallery.test.js
+++ b/package/src/components/Attachment/__tests__/buildGallery.test.js
@@ -97,7 +97,7 @@ describe('buildGallery', () => {
   it('thumbnail size should be smaller than the limits set by sizeConfig', () => {
     const bigImage = generateImageAttachment({
       image_url:
-        'https://us-east.stream-io-cdn.com/23kn4k2j3n4k2n3k4n23?sig=34k23n4k23nk423&h=*&w=*&resize=*',
+        'https://us-east.stream-io-cdn.com/23kn4k2j3n4k2n3k4n23?sig=34k23n4k23nk423&oh=200&ow=300&h=*&w=*&resize=*',
       original_height: 1200,
       original_width: 900,
     });
@@ -113,7 +113,7 @@ describe('buildGallery', () => {
 
     const smallImage = generateImageAttachment({
       image_url:
-        'https://us-east.stream-io-cdn.com/23kn4k2j3n4k2n3k4n23?sig=34k23n4k23nk423&h=*&w=*&resize=*',
+        'https://us-east.stream-io-cdn.com/23kn4k2j3n4k2n3k4n23?sig=34k23n4k23nk423&h=*&w=*&resize=*&oh=200&ow=300',
       original_height: 30,
       original_width: 20,
     });

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -641,8 +641,6 @@ export const MessageInputProvider = <
         attachments.push({
           fallback: image.file.name,
           image_url: image.url,
-          original_height: image.height,
-          original_width: image.width,
           type: 'image',
         } as Attachment<StreamChatGenerics>);
       }

--- a/package/src/utils/__tests__/getResizedImageUrl.test.js
+++ b/package/src/utils/__tests__/getResizedImageUrl.test.js
@@ -11,7 +11,8 @@ describe('getResizedImageUrl', () => {
   });
 
   it('should append given height, width and resize mode to url', () => {
-    const testUrl = 'http://us-east.stream-io-cdn.com/blah';
+    const testUrl =
+      'http://us-east.stream-io-cdn.com/blah?sig=34k23n4k23nk423&oh=300&ow=200&h=*&w=*&resize=*';
 
     const testConfigs = [
       { height: 100, resize: 'scale', width: 100 },
@@ -33,7 +34,7 @@ describe('getResizedImageUrl', () => {
   });
 
   it('should replace wildcards with given height, width and resize mode within url', () => {
-    const testUrl = 'http://us-east.stream-io-cdn.com/blah?h=*&w=*&resize=*';
+    const testUrl = 'http://us-east.stream-io-cdn.com/blah?oh=300&ow=200&h=*&w=*&resize=*';
 
     const testConfigs = [
       { height: 100, resize: 'scale', width: 100 },

--- a/package/src/utils/getResizedImageUrl.ts
+++ b/package/src/utils/getResizedImageUrl.ts
@@ -25,9 +25,30 @@ export function getResizedImageUrl({
   url,
   width,
 }: GetResizedImageUrlParams) {
-  let parsedUrl;
   try {
-    parsedUrl = new URL(url);
+    const parsedUrl = new URL(url);
+
+    const originalHeight = parsedUrl.searchParams.get('oh');
+    const originalWidth = parsedUrl.searchParams.get('ow');
+
+    // If url is not from new cloudfront CDN (which offers fast image resizing), then return the url as it is.
+    // Check for oh and ow parameters in the url, is just to differentiate between old and new CDN.
+    // In case of old CDN we don't want to do any kind of resizing.
+    const isResizableUrl = url.includes('.stream-io-cdn.com') && originalHeight && originalWidth;
+
+    if (!isResizableUrl || (!height && !width)) return url;
+
+    if (height) {
+      parsedUrl.searchParams.set('h', `${PixelRatio.getPixelSizeForLayoutSize(Number(height))}`);
+    }
+
+    if (width) {
+      parsedUrl.searchParams.set('w', `${PixelRatio.getPixelSizeForLayoutSize(Number(width))}`);
+    }
+
+    parsedUrl.searchParams.set('resize', `${resize}`);
+
+    return parsedUrl.toString();
   } catch (error) {
     // There is some issue with the url.
     // Simply return the original url, there is no need to break the app for this.
@@ -35,26 +56,4 @@ export function getResizedImageUrl({
 
     return url;
   }
-
-  const originalHeight = parsedUrl.searchParams.get('oh');
-  const originalWidth = parsedUrl.searchParams.get('ow');
-
-  // If url is not from new cloudfront CDN (which offers fast image resizing), then return the url as it is.
-  // Check for oh and ow parameters in the url, is just to differentiate between old and new CDN.
-  // In case of old CDN we don't want to do any kind of resizing.
-  const isResizableUrl = url.includes('.stream-io-cdn.com') && originalHeight && originalWidth;
-
-  if (!isResizableUrl || (!height && !width)) return url;
-
-  if (height) {
-    parsedUrl.searchParams.set('h', `${PixelRatio.getPixelSizeForLayoutSize(Number(height))}`);
-  }
-
-  if (width) {
-    parsedUrl.searchParams.set('w', `${PixelRatio.getPixelSizeForLayoutSize(Number(width))}`);
-  }
-
-  parsedUrl.searchParams.set('resize', `${resize}`);
-
-  return parsedUrl.toString();
 }

--- a/package/src/utils/getResizedImageUrl.ts
+++ b/package/src/utils/getResizedImageUrl.ts
@@ -25,11 +25,26 @@ export function getResizedImageUrl({
   url,
   width,
 }: GetResizedImageUrlParams) {
-  // Check if url belongs to cloudfront CDN
-  const isResizableUrl = url.includes('.stream-io-cdn.com');
-  if (!isResizableUrl || (!height && !width)) return url;
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (error) {
+    // There is some issue with the url.
+    // Simply return the original url, there is no need to break the app for this.
+    console.warn(error);
 
-  const parsedUrl = new URL(url);
+    return url;
+  }
+
+  const originalHeight = parsedUrl.searchParams.get('oh');
+  const originalWidth = parsedUrl.searchParams.get('ow');
+
+  // If url is not from new cloudfront CDN (which offers fast image resizing), then return the url as it is.
+  // Check for oh and ow parameters in the url, is just to differentiate between old and new CDN.
+  // In case of old CDN we don't want to do any kind of resizing.
+  const isResizableUrl = url.includes('.stream-io-cdn.com') && originalHeight && originalWidth;
+
+  if (!isResizableUrl || (!height && !width)) return url;
 
   if (height) {
     parsedUrl.searchParams.set('h', `${PixelRatio.getPixelSizeForLayoutSize(Number(height))}`);


### PR DESCRIPTION
## 🎯 Goal

Start requesting resized version of images only when new CDN is deployed.

## 🛠 Implementation details

- Detect whether new CDN is deployed or not using existence of `oh` and `ow` params in url. If these params exist in url, then it means new CDN has been deployed and SDK can start requesting resized images.
- Otherwise use the original images

