### PR TITLE
build: change docs to use v4 by default

### DIFF
--- a/docusaurus/docs/reactnative/basics/stream_chat_with_navigation.mdx
+++ b/docusaurus/docs/reactnative/basics/stream_chat_with_navigation.mdx
@@ -45,7 +45,7 @@ You can choose whatever suits your needs best, theming, connection handling, and
 Having it higher in the _stack_ helps to ensure it is not unmounted at times when a connection is present.
 If `Chat` is unmounted with a connection present you may have to implement some connection handling functions yourself to ensure you reconnect when the app is, for instance, reopened from the background.
 The WebSocket connection closes on it's own approximately 15 seconds after the app is backgrounded.
-Not handling the connection on [`appState`](https://reactnative.dev/docs/appstate) changes will also effect [how Stream Chat handles Push Notifications](../guides/push_notifications.mdx).
+Not handling the connection on [`appState`](https://reactnative.dev/docs/appstate) changes will also effect [how Stream Chat handles Push Notifications](../guides/push_notifications_v2.mdx).
 
 :::
 

--- a/docusaurus/reactnative-docusaurus-dontent-docs.plugin.js
+++ b/docusaurus/reactnative-docusaurus-dontent-docs.plugin.js
@@ -3,15 +3,14 @@ module.exports = {
     [
       '@docusaurus/plugin-content-docs',
       {
-        lastVersion: '3.x.x',
+        lastVersion: 'current',
         versions: {
           current: {
-            label: '4.0.0-beta',
-            banner: 'unreleased',
-            path: '4.0.0'
+            label: '4.1.0',
           },
           '3.x.x': {
             label: '3.x.x',
+            path: '3.x.x'
           }
         }
       }

--- a/docusaurus/reactnative-docusaurus-dontent-docs.plugin.js
+++ b/docusaurus/reactnative-docusaurus-dontent-docs.plugin.js
@@ -6,11 +6,11 @@ module.exports = {
         lastVersion: 'current',
         versions: {
           current: {
-            label: '4.1.0',
+            label: 'v4',
           },
           '3.x.x': {
-            label: '3.x.x',
-            path: '3.x.x'
+            label: 'v3',
+            path: 'v4'
           }
         }
       }

--- a/docusaurus/reactnative-docusaurus-dontent-docs.plugin.js
+++ b/docusaurus/reactnative-docusaurus-dontent-docs.plugin.js
@@ -10,7 +10,7 @@ module.exports = {
           },
           '3.x.x': {
             label: 'v3',
-            path: 'v4'
+            path: 'v3'
           }
         }
       }

--- a/docusaurus/reactnative_versioned_docs/version-3.x.x/basics/getting_started.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-3.x.x/basics/getting_started.mdx
@@ -30,14 +30,14 @@ Install the required packages in your React Native project.
 <TabItem value='yarn'>
 
 ```bash
-  yarn add stream-chat-react-native
+  yarn add stream-chat-react-native@3.10.2
 ```
 
 </TabItem>
 <TabItem value='npm'>
 
 ```bash
-  npm install stream-chat-react-native
+  npm install stream-chat-react-native@3.10.2
 ```
 
 </TabItem>


### PR DESCRIPTION
## 🎯 Goal

Show v4 docs by default, adds notice to v3 as not actively maintained

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

