### PR TITLE
Fix: Rendering issues of ImageGallery on iOS [CRNS - 532]

### DIFF
--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -124,7 +124,6 @@ export type ImageGalleryCustomComponents<
 type Props<StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics> =
   ImageGalleryCustomComponents<StreamChatGenerics> & {
     overlayOpacity: Animated.SharedValue<number>;
-    visible: boolean;
     imageGalleryGridHandleHeight?: number;
     /**
      * This should be
@@ -144,7 +143,6 @@ export const ImageGallery = <
     imageGalleryGridSnapPoints,
     numberOfImageGalleryGridColumns,
     overlayOpacity,
-    visible,
   } = props;
   const {
     theme: {
@@ -190,10 +188,8 @@ export const ImageGallery = <
    * Run the fade animation on visible change
    */
   useEffect(() => {
-    if (visible) {
-      Keyboard.dismiss();
-    }
-  }, [visible]);
+    Keyboard.dismiss();
+  }, []);
 
   /**
    * Image height from URL or default to full screen height
@@ -307,10 +303,8 @@ export const ImageGallery = <
   };
 
   useEffect(() => {
-    if (!visible) {
-      resetVisibleValues();
-    }
-  }, [visible]);
+    resetVisibleValues();
+  }, []);
 
   /**
    * Photos array created from all currently available
@@ -1002,7 +996,7 @@ export const ImageGallery = <
         },
       ],
     }),
-    [visible],
+    [],
   );
 
   /**
@@ -1037,10 +1031,7 @@ export const ImageGallery = <
   };
 
   return (
-    <Animated.View
-      pointerEvents={visible ? 'auto' : 'none'}
-      style={[StyleSheet.absoluteFillObject]}
-    >
+    <Animated.View pointerEvents={'auto'} style={[StyleSheet.absoluteFillObject]}>
       <Animated.View style={[StyleSheet.absoluteFillObject, containerBackground]} />
       <TapGestureHandler
         minPointers={1}

--- a/package/src/components/MessageOverlay/MessageOverlay.tsx
+++ b/package/src/components/MessageOverlay/MessageOverlay.tsx
@@ -104,7 +104,6 @@ export type MessageOverlayPropsWithContext<
     | 'overlayOpacity'
   > & {
     showScreen?: Animated.SharedValue<number>;
-    visible?: boolean;
   };
 
 const MessageOverlayWithContext = <
@@ -138,7 +137,6 @@ const MessageOverlayWithContext = <
     reset,
     setOverlay,
     threadList,
-    visible,
     isMyMessage,
     messageReactions,
     error,
@@ -223,11 +221,9 @@ const MessageOverlayWithContext = <
   };
 
   useEffect(() => {
-    if (visible) {
-      Keyboard.dismiss();
-    }
-    fadeScreen(!!visible);
-  }, [visible]);
+    Keyboard.dismiss();
+    fadeScreen(true);
+  }, []);
 
   const onPan = useAnimatedGestureHandler<PanGestureHandlerGestureEvent>({
     onActive: (evt) => {
@@ -324,7 +320,7 @@ const MessageOverlayWithContext = <
       <MessageProvider value={messageContext}>
         <ThemeProvider mergedStyle={wrapMessageInTheme ? modifiedTheme : theme}>
           <Animated.View
-            pointerEvents={visible ? 'auto' : 'none'}
+            pointerEvents={'auto'}
             style={[StyleSheet.absoluteFillObject, containerStyle]}
           >
             <PanGestureHandler
@@ -542,17 +538,12 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
     alignment: prevAlignment,
     message: prevMessage,
     messageReactionTitle: prevMessageReactionTitle,
-    visible: prevVisible,
   } = prevProps;
   const {
     alignment: nextAlignment,
     message: nextMessage,
     messageReactionTitle: nextMessageReactionTitle,
-    visible: nextVisible,
   } = nextProps;
-
-  const visibleEqual = prevVisible === nextVisible;
-  if (!visibleEqual) return false;
 
   const alignmentEqual = prevAlignment === nextAlignment;
   if (!alignmentEqual) return false;

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -218,7 +218,6 @@ export const OverlayProvider = <
                     OverlayReactionList={OverlayReactionList}
                     OverlayReactions={OverlayReactions}
                     OverlayReactionsAvatar={OverlayReactionsAvatar}
-                    visible={overlay === 'message'}
                   />
                 )}
                 {overlay === 'gallery' && (
@@ -228,7 +227,6 @@ export const OverlayProvider = <
                     imageGalleryGridSnapPoints={imageGalleryGridSnapPoints}
                     numberOfImageGalleryGridColumns={numberOfImageGalleryGridColumns}
                     overlayOpacity={overlayOpacity}
-                    visible={overlay === 'gallery'}
                   />
                 )}
                 <AttachmentPicker ref={bottomSheetRef} {...attachmentPickerProps} />


### PR DESCRIPTION
## 🎯 Goal

This PR focuses on fixing the rendering issues with the ImageGallery when a message image attachment is opened.

Fixes #1148 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

Previously, the ImageGallery component was always open, and the rendering of the ImageGallery was handled conditionally using logic in the ImageGallery component. This PR focuses on clearing the logic and making sure that the ImageGallery works fine. 

The following are cleared:
- `showScreenStyle` is removed from the Animated.View in ImageGallery component.
- `showScreen` logic is removed.
- Removed `visible` prop from both the MessageOverlay and ImageGallery and its usage.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes



<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <video src="https://user-images.githubusercontent.com/39884168/156316238-05a06cff-5b19-463e-889a-a05978aa0ae7.mov" /> 
            </td>
            <td>
                <video src="https://user-images.githubusercontent.com/39884168/156316206-38709b30-c69b-4a43-80b3-fbadebeb9771.mov" />
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [ ] Documentation is updated

