### PR TITLE
refactor: make MessageReadStatus an enum and update docs

### DIFF
--- a/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
@@ -73,9 +73,15 @@ export type ChannelPreviewMessengerPropsWithContext<
      *    bold: true,
      *    text: 'This is the message preview text'
      *  },
-     *  status: 0 | 1 | 2 // read states of latest message.
+     *  status: 0 | 1 | 2 // read states of the latest message.
      * }
      * ```
+     *
+     * The read status is either of the following:
+     *
+     * 0: The message was not sent by the current user
+     * 1: The message was sent by the current user and is unread
+     * 2: The message was sent by the current user and is read
      *
      * @overrideType object
      */

--- a/package/src/components/ChannelPreview/ChannelPreviewStatus.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewStatus.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import type { ChannelPreviewProps } from './ChannelPreview';
-
 import type { ChannelPreviewMessengerPropsWithContext } from './ChannelPreviewMessenger';
+import { MessageReadStatus } from './hooks/useLatestMessagePreview';
 
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { Check, CheckAll } from '../../icons';
@@ -48,9 +48,9 @@ export const ChannelPreviewStatus = <
 
   return (
     <View style={styles.flexRow}>
-      {status === 2 ? (
+      {status === MessageReadStatus.READ ? (
         <CheckAll pathFill={accent_blue} {...checkAllIcon} />
-      ) : status === 1 ? (
+      ) : status === MessageReadStatus.UNREAD ? (
         <Check pathFill={grey} {...checkIcon} />
       ) : null}
       <Text style={[styles.date, { color: grey }, date]}>


### PR DESCRIPTION
## 🎯 Goal

To make it a bit more readable, I've made the message read status an enum and updated the docs with a description of the values.


## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [x] Documentation is updated

