### PR TITLE
fix: export ownCapabilitiesContext from SDK

### DIFF
--- a/package/src/contexts/index.ts
+++ b/package/src/contexts/index.ts
@@ -13,6 +13,7 @@ export * from './messagesContext/MessagesContext';
 export * from './paginatedMessageListContext/PaginatedMessageListContext';
 export * from './overlayContext/OverlayContext';
 export * from './overlayContext/OverlayProvider';
+export * from './ownCapabilitiesContext/OwnCapabilitiesContext';
 export * from './suggestionsContext/SuggestionsContext';
 export * from './themeContext/ThemeContext';
 export * from './themeContext/utils/theme';


### PR DESCRIPTION
## 🎯 Goal

Fixes https://github.com/GetStream/stream-chat-react-native/issues/1186

## 🛠 Implementation details

Export `OwnCapabilitiesContext` from SDK

