### PR TITLE
fix: change overlayOpacity prop type definition from OverlayContext to MessageOverlay

### DIFF
--- a/package/src/components/MessageOverlay/MessageOverlay.tsx
+++ b/package/src/components/MessageOverlay/MessageOverlay.tsx
@@ -100,8 +100,8 @@ export type MessageOverlayPropsWithContext<
     | 'message'
     | 'messageReactions'
     | 'messageTextNumberOfLines'
-    | 'overlayOpacity'
   > & {
+    overlayOpacity: Animated.SharedValue<number>;
     showScreen?: Animated.SharedValue<number>;
   };
 

--- a/package/src/contexts/overlayContext/OverlayContext.tsx
+++ b/package/src/contexts/overlayContext/OverlayContext.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import type Animated from 'react-native-reanimated';
 
 import type { BottomSheetMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 
@@ -53,7 +52,6 @@ export type OverlayProviderProps<
     >
   > &
   Pick<OverlayContextValue, 'translucentStatusBar'> & {
-    overlayOpacity: Animated.SharedValue<number>;
     closePicker?: (ref: React.RefObject<BottomSheetMethods>) => void;
     error?: boolean | Error;
     /** https://github.com/GetStream/stream-chat-react-native/wiki/Internationalization-(i18n) */


### PR DESCRIPTION
## 🎯 Goal

Move `overlayOpacity` from OverlayProvider to MessageOverlay.


<!-- Describe why we are making this change -->

## 🛠 Implementation details

The `OverlayProvider` had `overlayOpacity` as a compulsory prop which might be a problem for the users to add a value. This prop is only used by `MessageOverlay` so we can simply confine the prop to the component itself rather than using it from `OverlayProvider`.

Thanks, @santhoshvai for pointing this out.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

