### PR TITLE
fix: add missing own_capabilities field after channel.updated event [CRNS-537]

### DIFF
--- a/package/src/components/ChannelList/hooks/listeners/__tests__/useChannelUpdated.test.tsx
+++ b/package/src/components/ChannelList/hooks/listeners/__tests__/useChannelUpdated.test.tsx
@@ -18,7 +18,7 @@ describe('useChannelUpdated', () => {
           send_messages: true,
         },
       },
-    } as Channel;
+    } as unknown as Channel;
 
     const mockEvent = {
       channel: {

--- a/package/src/components/ChannelList/hooks/listeners/__tests__/useChannelUpdated.test.tsx
+++ b/package/src/components/ChannelList/hooks/listeners/__tests__/useChannelUpdated.test.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { Text } from 'react-native';
+import { render, waitFor } from '@testing-library/react-native';
+import type { Channel, ChannelResponse, Event, StreamChat } from 'stream-chat';
+import { ChatContext, useChannelUpdated } from '../../../../../index';
+import { act } from 'react-test-renderer';
+
+describe('useChannelUpdated', () => {
+  it("defaults to the channels own_capabilities if the event doesn't include it", async () => {
+    let eventHanler: (event: Event) => any;
+    const mockChannel = {
+      cid: 'channeltype:123abc',
+      data: {
+        own_capabilities: {
+          send_messages: true,
+        },
+      },
+    } as Channel;
+
+    const mockEvent = {
+      channel: {
+        cid: mockChannel.cid,
+      } as ChannelResponse,
+      type: 'channel.updated' as Event['type'],
+    };
+
+    const mockClient = {
+      on: jest.fn().mockImplementation((_eventName: string, handler: (event: Event) => any) => {
+        eventHanler = handler;
+      }),
+      off: jest.fn(),
+    } as unknown as StreamChat;
+
+    const TestComponent = () => {
+      const [channels, setChannels] = useState<Channel[]>([mockChannel]);
+
+      useChannelUpdated({ setChannels });
+
+      if (
+        channels[0].data?.own_capabilities &&
+        Object.keys(channels[0].data?.own_capabilities as any).includes('send_messages')
+      ) {
+        return <Text>Send messages enabled</Text>;
+      }
+
+      return <Text>Send messages NOT enabled</Text>;
+    };
+
+    const { getByText } = await waitFor(() =>
+      render(
+        <ChatContext.Provider
+          value={{
+            client: mockClient,
+            connectionRecovering: false,
+            isOnline: true,
+            mutedUsers: [],
+            setActiveChannel: () => null,
+          }}
+        >
+          <TestComponent />
+        </ChatContext.Provider>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(getByText('Send messages enabled')).toBeTruthy();
+    });
+
+    act(() => {
+      eventHanler(mockEvent);
+    });
+
+    await waitFor(() => {
+      expect(getByText('Send messages enabled')).toBeTruthy();
+    });
+  });
+});

--- a/package/src/components/ChannelList/hooks/listeners/__tests__/useChannelUpdated.test.tsx
+++ b/package/src/components/ChannelList/hooks/listeners/__tests__/useChannelUpdated.test.tsx
@@ -1,13 +1,16 @@
 import React, { useState } from 'react';
 import { Text } from 'react-native';
+
+import { act } from 'react-test-renderer';
+
 import { render, waitFor } from '@testing-library/react-native';
 import type { Channel, ChannelResponse, Event, StreamChat } from 'stream-chat';
+
 import { ChatContext, useChannelUpdated } from '../../../../../index';
-import { act } from 'react-test-renderer';
 
 describe('useChannelUpdated', () => {
   it("defaults to the channels own_capabilities if the event doesn't include it", async () => {
-    let eventHanler: (event: Event) => any;
+    let eventHanler: (event: Event) => void;
     const mockChannel = {
       cid: 'channeltype:123abc',
       data: {
@@ -25,10 +28,10 @@ describe('useChannelUpdated', () => {
     };
 
     const mockClient = {
-      on: jest.fn().mockImplementation((_eventName: string, handler: (event: Event) => any) => {
+      off: jest.fn(),
+      on: jest.fn().mockImplementation((_eventName: string, handler: (event: Event) => void) => {
         eventHanler = handler;
       }),
-      off: jest.fn(),
     } as unknown as StreamChat;
 
     const TestComponent = () => {
@@ -38,7 +41,9 @@ describe('useChannelUpdated', () => {
 
       if (
         channels[0].data?.own_capabilities &&
-        Object.keys(channels[0].data?.own_capabilities as any).includes('send_messages')
+        Object.keys(channels[0].data?.own_capabilities as { [key: string]: boolean }).includes(
+          'send_messages',
+        )
       ) {
         return <Text>Send messages enabled</Text>;
       }

--- a/package/src/components/ChannelList/hooks/listeners/useChannelUpdated.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useChannelUpdated.ts
@@ -33,8 +33,14 @@ export const useChannelUpdated = <
             (channel) => channel.cid === (event.cid || event.channel?.cid),
           );
           if (index >= 0 && event.channel) {
-            channels[index].data = event.channel;
+            channels[index].data = {
+              ...event.channel,
+              hidden: event.channel?.hidden ?? channels[index].data?.hidden,
+              own_capabilities:
+                event.channel?.own_capabilities ?? channels[index].data?.own_capabilities,
+            };
           }
+
           return [...channels];
         });
       }


### PR DESCRIPTION
## 🎯 Goal

Fixes https://github.com/GetStream/stream-chat-react-native/issues/1193

