### PR TITLE
fix: cleanup of keyboard listeners

### DIFF
--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -248,13 +248,18 @@ export const AttachmentPicker = React.forwardRef(
     }, [selectedPicker]);
 
     useEffect(() => {
-      if (Platform.OS === 'ios') {
-        Keyboard.addListener('keyboardWillShow', hideAttachmentPicker);
-      } else {
-        Keyboard.addListener('keyboardDidShow', hideAttachmentPicker);
-      }
+      const keyboardListener =
+        Platform.OS === 'ios'
+          ? Keyboard.addListener('keyboardWillShow', hideAttachmentPicker)
+          : Keyboard.addListener('keyboardDidShow', hideAttachmentPicker);
 
       return () => {
+        if (keyboardListener?.remove) {
+          keyboardListener.remove();
+          return;
+        }
+
+        // To keep compatibility with older versions of React Native, where `remove()` is not available
         if (Platform.OS === 'ios') {
           Keyboard.removeListener('keyboardWillShow', hideAttachmentPicker);
         } else {

--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -248,14 +248,14 @@ export const AttachmentPicker = React.forwardRef(
     }, [selectedPicker]);
 
     useEffect(() => {
-      const keyboardListener =
+      const keyboardSubscription =
         Platform.OS === 'ios'
           ? Keyboard.addListener('keyboardWillShow', hideAttachmentPicker)
           : Keyboard.addListener('keyboardDidShow', hideAttachmentPicker);
 
       return () => {
-        if (keyboardListener?.remove) {
-          keyboardListener.remove();
+        if (keyboardSubscription?.remove) {
+          keyboardSubscription.remove();
           return;
         }
 


### PR DESCRIPTION
## 🎯 Goal

Fix the deprecated warning about `removeListener`