### PR TITLE
fix: overrideOwnCapabilities typescript issue

### DIFF
--- a/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
+++ b/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
@@ -323,6 +323,7 @@ export const NewDirectMessagingScreen: React.FC<NewDirectMessagingScreenProps> =
         enforceUniqueReaction
         keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : -300}
         onChangeText={setMessageInputText}
+        overrideOwnCapabilities={{ sendMessage: true }}
         SendButton={NewDirectMessagingSendButton}
         setInputRef={(ref) => (messageInputRef.current = ref)}
       >

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -366,7 +366,7 @@ export type ChannelPropsWithContext<
     maxMessageLength?: number;
     messageId?: string;
     newMessageStateUpdateThrottleInterval?: number;
-    overrideOwnCapabilities?: OwnCapabilitiesContextValue;
+    overrideOwnCapabilities?: Partial<OwnCapabilitiesContextValue>;
     stateUpdateThrottleInterval?: number;
     /**
      * Tells if channel is rendering a thread list


### PR DESCRIPTION
## 🎯 Goal

Fixes - #1191 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

- Fixes the above issue by adding the `overrideOwnCapabilities` prop with `sendMessage` capability.
- Since all the capabilities were compulsory previously, so making the type of it as `Partial<OwnCapabilitiesContextValue>` in SDk.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [x] Documentation is updated

