### PR TITLE
fix: show background for Giphy on long press

### DIFF
--- a/package/src/components/Attachment/Giphy.tsx
+++ b/package/src/components/Attachment/Giphy.tsx
@@ -109,7 +109,7 @@ export type GiphyPropsWithContext<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 > = Pick<
   MessageContextValue<StreamChatGenerics>,
-  'handleAction' | 'onLongPress' | 'onPress' | 'onPressIn' | 'preventPress'
+  'handleAction' | 'isMyMessage' | 'onLongPress' | 'onPress' | 'onPressIn' | 'preventPress'
 > &
   Pick<MessagesContextValue<StreamChatGenerics>, 'giphyVersion' | 'additionalTouchableProps'> & {
     attachment: Attachment<StreamChatGenerics>;
@@ -124,6 +124,7 @@ const GiphyWithContext = <
     additionalTouchableProps,
     attachment,
     handleAction,
+    isMyMessage,
     onLongPress,
     onPress,
     onPressIn,
@@ -262,7 +263,13 @@ const GiphyWithContext = <
       testID='giphy-attachment'
       {...additionalTouchableProps}
     >
-      <View style={[styles.container, container]}>
+      <View
+        style={[
+          styles.container,
+          { backgroundColor: isMyMessage ? grey_gainsboro : white },
+          container,
+        ]}
+      >
         <Image
           resizeMode='contain'
           source={{ uri: makeImageCompatibleUrl(uri) }}
@@ -295,10 +302,12 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
   const {
     attachment: { actions: prevActions, image_url: prevImageUrl, thumb_url: prevThumbUrl },
     giphyVersion: prevGiphyVersion,
+    isMyMessage: prevIsMyMessage,
   } = prevProps;
   const {
     attachment: { actions: nextActions, image_url: nextImageUrl, thumb_url: nextThumbUrl },
     giphyVersion: nextGiphyVersion,
+    isMyMessage: nextIsMyMessage,
   } = nextProps;
 
   const imageUrlEqual = prevImageUrl === nextImageUrl;
@@ -307,9 +316,6 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
   const thumbUrlEqual = prevThumbUrl === nextThumbUrl;
   if (!thumbUrlEqual) return false;
 
-  const giphyVersionEqual = prevGiphyVersion === nextGiphyVersion;
-  if (!giphyVersionEqual) return false;
-
   const actionsEqual =
     Array.isArray(prevActions) === Array.isArray(nextActions) &&
     ((Array.isArray(prevActions) &&
@@ -317,6 +323,12 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
       prevActions.length === nextActions.length) ||
       prevActions === nextActions);
   if (!actionsEqual) return false;
+
+  const giphyVersionEqual = prevGiphyVersion === nextGiphyVersion;
+  if (!giphyVersionEqual) return false;
+
+  const isMyMessageEqual = prevIsMyMessage === nextIsMyMessage;
+  if (!isMyMessageEqual) return false;
 
   return true;
 };
@@ -340,7 +352,7 @@ export const Giphy = <
 >(
   props: GiphyProps<StreamChatGenerics>,
 ) => {
-  const { handleAction, onLongPress, onPress, onPressIn, preventPress } =
+  const { handleAction, isMyMessage, onLongPress, onPress, onPressIn, preventPress } =
     useMessageContext<StreamChatGenerics>();
   const { additionalTouchableProps, giphyVersion } = useMessagesContext<StreamChatGenerics>();
 
@@ -350,6 +362,7 @@ export const Giphy = <
         additionalTouchableProps,
         giphyVersion,
         handleAction,
+        isMyMessage,
         onLongPress,
         onPress,
         onPressIn,

--- a/package/src/components/Message/MessageSimple/MessageContent.tsx
+++ b/package/src/components/Message/MessageSimple/MessageContent.tsx
@@ -212,7 +212,7 @@ const MessageContentWithContext = <
     backgroundColor = transparent;
   } else if (otherAttachments.length) {
     if (otherAttachments[0].type === 'giphy') {
-      backgroundColor = message.quoted_message || isMyMessage ? grey_gainsboro : white;
+      backgroundColor = message.quoted_message ? grey_gainsboro : transparent;
     } else {
       backgroundColor = blue_alice;
     }


### PR DESCRIPTION
## 🎯 Goal

The Giphy customization change in https://github.com/GetStream/stream-chat-react-native/pull/1201 caused a bug in the message overlay for Giphy. On the overlay, Giphy did not have any background, it should show the same background as in MessageSimple.

## 🛠 Implementation details

Moved the background color to Giphy component. Then the overlay picks it up.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/3846977/158614256-957e92a1-367c-4479-9bd6-5cb9c0e90f19.png" /> 
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/3846977/158614427-e216f382-9977-49d5-840f-19077cad15df.png" /> 
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

NA

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

