### PR TITLE
fix: reenable exhaustive deps lint rule

### DIFF
--- a/package/.eslintrc.json
+++ b/package/.eslintrc.json
@@ -148,7 +148,7 @@
         "@typescript-eslint/ban-ts-comment": 0,
         "@typescript-eslint/no-unused-vars": 1,
         "@typescript-eslint/no-var-requires": 0,
-        "react-hooks/exhaustive-deps": 0,
+        "react-hooks/exhaustive-deps": 1,
         "react-native/no-inline-styles": 0,
         "array-callback-return": 2,
         "arrow-body-style": 2,


### PR DESCRIPTION
## 🎯 Goal

Our eslint rc has disabled the exhaustive deps rule!. It caused by this commit https://github.com/GetStream/stream-chat-react-native/commit/560cac685e1febc0a1061ebd847edac60ef19b2d . This was probably done to get something out urgently. 

In this PR, we enable it and set it to warn. There are two reasons why this is important,

1. Having a lint warn to put all needed dependencies in `useEffect` reduces a lot of sources of bugs.
2. A lint will warn about a dependency and we could figure out if this will cause a performance issue easily and then refactor that code if possible.

## 🛠 Implementation details

NA

## 🎨 UI Changes

NA

## 🧪 Testing

NA

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

