### PR TITLE
feat: open giphy in image viewer when pressed [CRNS - 540]

### DIFF
--- a/docusaurus/docs/reactnative/common-content/contexts/image-gallery-context/set_image.mdx
+++ b/docusaurus/docs/reactnative/common-content/contexts/image-gallery-context/set_image.mdx
@@ -1,4 +1,4 @@
-Setter for value [`image`](../../../contexts/message_input_context.mdx#image).
+Setter for value [`image`](../../../contexts/image_gallery_context.mdx#image).
 
 | Type                                                   |
 | ------------------------------------------------------ |

--- a/docusaurus/docs/reactnative/common-content/contexts/image-gallery-context/set_images.mdx
+++ b/docusaurus/docs/reactnative/common-content/contexts/image-gallery-context/set_images.mdx
@@ -1,0 +1,5 @@
+Setter for value [`images`](../../../contexts/image_gallery_context.mdx#images).
+
+| Type                                                                                                                                                                         |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `(messageWithImages: [MessageType](https://github.com/GetStream/stream-chat-react-native/blob/master/package/src/components/MessageList/hooks/useMessageList.ts)[]) => void` |

--- a/docusaurus/docs/reactnative/common-content/core-components/overlay-provider/props/giphy_version.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/overlay-provider/props/giphy_version.mdx
@@ -1,0 +1,6 @@
+The giphy version to render when viewing a Giphy in the Image Gallery.
+Check the keys of the [Image Object](https://developers.giphy.com/docs/api/schema#image-object) for possible values.
+
+| Type   | Default        |
+| ------ | -------------- |
+| string | 'fixed_height' |

--- a/docusaurus/docs/reactnative/core-components/overlay_provider.mdx
+++ b/docusaurus/docs/reactnative/core-components/overlay_provider.mdx
@@ -12,6 +12,7 @@ import AttachmentPickerBottomSheetHeight from '../common-content/core-components
 import AttachmentPickerErrorButtonText from '../common-content/core-components/overlay-provider/props/attachment_picker_error_button_text.mdx';
 import AttachmentPickerErrorText from '../common-content/core-components/overlay-provider/props/attachment_picker_error_text.mdx';
 import AttachmentSelectionBarHeight from '../common-content/core-components/overlay-provider/props/attachment_selection_bar_height.mdx';
+import GiphyVersion from '../common-content/core-components/overlay-provider/props/giphy_version.mdx';
 import I18nInstance from '../common-content/core-components/overlay-provider/props/i18n_instance.mdx';
 import ImageGalleryCustomComponents from '../common-content/core-components/overlay-provider/props/image_gallery_custom_components.mdx';
 import ImageGalleryGridHandleHeight from '../common-content/core-components/overlay-provider/props/image_gallery_grid_handle_height.mdx';
@@ -152,6 +153,10 @@ This can also be set via the `setBottomInset` function provided by the `useAttac
 | Type   | Default |
 | ------ | ------- |
 | number | 0       |
+
+### giphyVersion
+
+<GiphyVersion />
 
 ### i18nInstance
 

--- a/docusaurus/docs/reactnative/ui-components/gallery.mdx
+++ b/docusaurus/docs/reactnative/ui-components/gallery.mdx
@@ -4,6 +4,7 @@ title: Gallery
 ---
 
 import SetImage from '../common-content/contexts/image-gallery-context/set_image.mdx';
+import SetImages from '../common-content/contexts/image-gallery-context/set_images.mdx';
 
 import Alignment from '../common-content/contexts/message-context/alignment.mdx';
 import GroupStyles from '../common-content/contexts/message-context/group_styles.mdx';
@@ -111,6 +112,10 @@ If true, onPress handler will be disabled.
 ### <div class="label description">_overrides the value from [ImageGalleryContext](../contexts/image_gallery_context.mdx#setimage)_</div> setImage {#setimage}
 
 <SetImage />
+
+### <div class="label description">_overrides the value from [ImageGalleryContext](../contexts/image_gallery_context.mdx#setimages)_</div> setImages {#setimages}
+
+<SetImages />
 
 ### <div class="label description">_overrides the value from [OverlayContext](../contexts/overlay_context.mdx#setoverlay)_</div> setOverlay {#setoverlay}
 

--- a/docusaurus/docs/reactnative/ui-components/giphy.mdx
+++ b/docusaurus/docs/reactnative/ui-components/giphy.mdx
@@ -7,8 +7,11 @@ import HandleAction from '../common-content/contexts/message-context/handle_acti
 import OnLongPress from '../common-content/contexts/message-context/on_long_press.mdx';
 import OnPress from '../common-content/contexts/message-context/on_press.mdx';
 import OnPressIn from '../common-content/contexts/message-context/on_press_in.mdx';
+import SetImage from '../common-content/contexts/image-gallery-context/set_image.mdx';
+import SetImages from '../common-content/contexts/image-gallery-context/set_images.mdx';
 
 import AdditionalTouchableProps from '../common-content/core-components/channel/props/additional_touchable_props.mdx';
+import SetOverlay from '../common-content/contexts/overlay-context/set_overlay.mdx';
 
 Component to render giphy attachments within the [`MessageList`](./message_list.mdx).
 
@@ -43,3 +46,15 @@ Attachment object for `giphy` type attachment.
 ### <div class="label description">_overrides the value from [MessageContext](../contexts/message_context.mdx#onpressin)_</div> onPressIn {#onpressin}
 
 <OnPressIn />
+
+### <div class="label description">_overrides the value from [ImageGalleryContext](../contexts/image_gallery_context.mdx#setimage)_</div> setImage {#setimage}
+
+<SetImage />
+
+### <div class="label description">_overrides the value from [ImageGalleryContext](../contexts/image_gallery_context.mdx#setimages)_</div> setImages {#setimages}
+
+<SetImages />
+
+### <div class="label description">_overrides the value from [OverlayContext](../contexts/overlay_context.mdx#setoverlay)_</div> setOverlay {#setoverlay}
+
+<SetOverlay />

--- a/package/src/components/Attachment/Giphy.tsx
+++ b/package/src/components/Attachment/Giphy.tsx
@@ -4,6 +4,10 @@ import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import type { Attachment } from 'stream-chat';
 
 import {
+  ImageGalleryContextValue,
+  useImageGalleryContext,
+} from '../../contexts/imageGalleryContext/ImageGalleryContext';
+import {
   MessageContextValue,
   useMessageContext,
 } from '../../contexts/messageContext/MessageContext';
@@ -11,6 +15,10 @@ import {
   MessagesContextValue,
   useMessagesContext,
 } from '../../contexts/messagesContext/MessagesContext';
+import {
+  OverlayContextValue,
+  useOverlayContext,
+} from '../../contexts/overlayContext/OverlayContext';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { GiphyIcon } from '../../icons';
 import { Lightning } from '../../icons/Lightning';
@@ -107,13 +115,20 @@ const styles = StyleSheet.create({
 
 export type GiphyPropsWithContext<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
-> = Pick<
-  MessageContextValue<StreamChatGenerics>,
-  'handleAction' | 'isMyMessage' | 'onLongPress' | 'onPress' | 'onPressIn' | 'preventPress'
-> &
+> = Pick<ImageGalleryContextValue<StreamChatGenerics>, 'setImage' | 'setImages'> &
+  Pick<
+    MessageContextValue<StreamChatGenerics>,
+    | 'handleAction'
+    | 'isMyMessage'
+    | 'message'
+    | 'onLongPress'
+    | 'onPress'
+    | 'onPressIn'
+    | 'preventPress'
+  > &
   Pick<MessagesContextValue<StreamChatGenerics>, 'giphyVersion' | 'additionalTouchableProps'> & {
     attachment: Attachment<StreamChatGenerics>;
-  };
+  } & Pick<OverlayContextValue, 'setOverlay'>;
 
 const GiphyWithContext = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -123,12 +138,17 @@ const GiphyWithContext = <
   const {
     additionalTouchableProps,
     attachment,
+    giphyVersion = 'fixed_width_downsampled',
     handleAction,
     isMyMessage,
+    message,
     onLongPress,
     onPress,
     onPressIn,
     preventPress,
+    setImage,
+    setImages,
+    setOverlay,
   } = props;
 
   const { actions, giphy: giphyData, image_url, thumb_url, title, type } = attachment;
@@ -159,8 +179,14 @@ const GiphyWithContext = <
   let uri = image_url || thumb_url;
   const giphyDimensions: { height?: number; width?: number } = {};
 
+  const defaultOnPress = () => {
+    setImages([message]);
+    setImage({ messageId: message.id, url: uri });
+    setOverlay('gallery');
+  };
+
   if (type === 'giphy' && giphyData) {
-    const giphyVersionInfo = giphyData[props.giphyVersion];
+    const giphyVersionInfo = giphyData[giphyVersion];
     uri = giphyVersionInfo.url;
     giphyDimensions.height = parseFloat(giphyVersionInfo.height);
     giphyDimensions.width = parseFloat(giphyVersionInfo.width);
@@ -247,6 +273,7 @@ const GiphyWithContext = <
       onPress={(event) => {
         if (onPress) {
           onPress({
+            defaultHandler: defaultOnPress,
             emitter: 'giphy',
             event,
           });
@@ -337,10 +364,7 @@ const MemoizedGiphy = React.memo(GiphyWithContext, areEqual) as typeof GiphyWith
 
 export type GiphyProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
-> = Partial<
-  Pick<MessageContextValue<StreamChatGenerics>, 'isMyMessage' | 'onLongPress' | 'onPressIn'> &
-    Pick<MessagesContextValue<StreamChatGenerics>, 'giphyVersion' | 'additionalTouchableProps'>
-> & {
+> = Partial<GiphyPropsWithContext<StreamChatGenerics>> & {
   attachment: Attachment<StreamChatGenerics>;
 };
 
@@ -352,10 +376,11 @@ export const Giphy = <
 >(
   props: GiphyProps<StreamChatGenerics>,
 ) => {
-  const { handleAction, isMyMessage, onLongPress, onPress, onPressIn, preventPress } =
+  const { handleAction, isMyMessage, message, onLongPress, onPress, onPressIn, preventPress } =
     useMessageContext<StreamChatGenerics>();
   const { additionalTouchableProps, giphyVersion } = useMessagesContext<StreamChatGenerics>();
-
+  const { setImage, setImages } = useImageGalleryContext<StreamChatGenerics>();
+  const { setOverlay } = useOverlayContext();
   return (
     <MemoizedGiphy
       {...{
@@ -363,10 +388,14 @@ export const Giphy = <
         giphyVersion,
         handleAction,
         isMyMessage,
+        message,
         onLongPress,
         onPress,
         onPressIn,
         preventPress,
+        setImage,
+        setImages,
+        setOverlay,
       }}
       {...props}
     />

--- a/package/src/components/Attachment/Giphy.tsx
+++ b/package/src/components/Attachment/Giphy.tsx
@@ -138,7 +138,7 @@ const GiphyWithContext = <
   const {
     additionalTouchableProps,
     attachment,
-    giphyVersion = 'fixed_width_downsampled',
+    giphyVersion,
     handleAction,
     isMyMessage,
     message,

--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -308,10 +308,11 @@ export const ImageGallery = <
     const attachmentImages =
       cur.attachments?.filter(
         (attachment) =>
-          attachment.type === 'image' &&
-          !attachment.title_link &&
-          !attachment.og_scrape_url &&
-          getUrlOfImageAttachment(attachment),
+          (attachment.type === 'giphy' && attachment.thumb_url) ||
+          (attachment.type === 'image' &&
+            !attachment.title_link &&
+            !attachment.og_scrape_url &&
+            getUrlOfImageAttachment(attachment)),
       ) || [];
 
     const attachmentPhotos = attachmentImages.map((a) => {

--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -53,7 +53,10 @@ import {
 } from './components/ImageGridHandle';
 
 import { useImageGalleryContext } from '../../contexts/imageGalleryContext/ImageGalleryContext';
-import { useOverlayContext } from '../../contexts/overlayContext/OverlayContext';
+import {
+  OverlayProviderProps,
+  useOverlayContext,
+} from '../../contexts/overlayContext/OverlayContext';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { triggerHaptic } from '../../native';
 import type { DefaultStreamChatGenerics } from '../../types/types';
@@ -130,7 +133,7 @@ type Props<StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamC
      */
     imageGalleryGridSnapPoints?: [string | number, string | number];
     numberOfImageGalleryGridColumns?: number;
-  };
+  } & Pick<OverlayProviderProps<StreamChatGenerics>, 'giphyVersion'>;
 
 export const ImageGallery = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -138,6 +141,7 @@ export const ImageGallery = <
   props: Props<StreamChatGenerics>,
 ) => {
   const {
+    giphyVersion,
     imageGalleryCustomComponents,
     imageGalleryGridHandleHeight,
     imageGalleryGridSnapPoints,
@@ -308,7 +312,7 @@ export const ImageGallery = <
     const attachmentImages =
       cur.attachments?.filter(
         (attachment) =>
-          (attachment.type === 'giphy' && attachment.thumb_url) ||
+          (attachment.type === 'giphy' && attachment.giphy?.[giphyVersion]?.url) ||
           (attachment.type === 'image' &&
             !attachment.title_link &&
             !attachment.og_scrape_url &&

--- a/package/src/contexts/overlayContext/OverlayContext.tsx
+++ b/package/src/contexts/overlayContext/OverlayContext.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 
 import type { BottomSheetMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
+import type { Attachment } from 'stream-chat';
 
 import type { AttachmentPickerProps } from '../../components/AttachmentPicker/AttachmentPicker';
 import type { ImageGalleryCustomComponents } from '../../components/ImageGallery/ImageGallery';
@@ -52,6 +53,10 @@ export type OverlayProviderProps<
     >
   > &
   Pick<OverlayContextValue, 'translucentStatusBar'> & {
+    /**
+     * The giphy version to render - check the keys of the [Image Object](https://developers.giphy.com/docs/api/schema#image-object) for possible values. Uses 'fixed_height' by default
+     * */
+    giphyVersion: keyof NonNullable<Attachment['giphy']>;
     closePicker?: (ref: React.RefObject<BottomSheetMethods>) => void;
     error?: boolean | Error;
     /** https://github.com/GetStream/stream-chat-react-native/wiki/Internationalization-(i18n) */

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -81,6 +81,7 @@ export const OverlayProvider = <
       }
     },
     FileSelectorIcon = DefaultFileSelectorIcon,
+    giphyVersion = 'fixed_height',
     i18nInstance,
     imageGalleryCustomComponents,
     imageGalleryGridHandleHeight,
@@ -222,6 +223,7 @@ export const OverlayProvider = <
                 )}
                 {overlay === 'gallery' && (
                   <ImageGallery<StreamChatGenerics>
+                    giphyVersion={giphyVersion}
                     imageGalleryCustomComponents={imageGalleryCustomComponents}
                     imageGalleryGridHandleHeight={imageGalleryGridHandleHeight}
                     imageGalleryGridSnapPoints={imageGalleryGridSnapPoints}


### PR DESCRIPTION
## 🎯 Goal

This PR involves adding a feature that allows opening a giphy in the image viewer when it's pressed.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

This is done by setting the state of `setImage`, `setImages` and `setOverlay` to `gallery`.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Image</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/158992290-3c0d1425-41cf-4eae-ac0d-11f8983ce6f9.png" />
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Image</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/158992279-871f7076-462d-4dd7-833e-1be805afa4f2.png" />
            </td>
        </tr>
    </tbody>
</table>
</details>


## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [x] Documentation is updated

