### PR TITLE
fix: avoid parsing a decimal number as a URL

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/parseLinks.test.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.test.ts
@@ -97,4 +97,11 @@ getstream.io
       scheme: 'https://',
     });
   });
+
+  it('does not parse a decimal number as a URL', () => {
+    const input = '123.456';
+    const result = parseLinksFromText(input);
+
+    expect(result).toHaveLength(0);
+  });
 });

--- a/package/src/components/Message/MessageSimple/utils/parseLinks.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.ts
@@ -8,7 +8,8 @@
  * */
 const emailUserName = '[\\w+\\.~$_-]+';
 const schema = `(\\w{2,15}:\\/\\/)`;
-const domain = `((?:\\w+\\.\\w+)+(?:[^:\\/\\s]+))`;
+// something.tld OR 123.123.123.123
+const domain = `((?:\\w+\\.[a-zA-Z]+)+(?:[^:\\/\\s]+)|(?:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}))`;
 const port = `(:[0-9]{1,5})`;
 const path = `((?:\\/)?[^?#\\s]+)`;
 const queryString = `(\\?[^#\\s]+)`;


### PR DESCRIPTION
## 🎯 Goal

Currently `123.456` would be parsed as a URL, this change makes sure to avoid that.

This assumes that any TLD comprises letters (`a-zA-Z`), and IPs are handled as a separate case with `123.123.123.123` or `1.2.3.4` or anything along those lines.

## 🛠 Implementation details

See above

## 🎨 UI Changes

none

## 🧪 Testing

Test case is added to the test suite. You can test it manually if you'd like by sending a message with something like "123.456" as part of the message, and see that it's not rendered as a URL

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [x] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

