### PR TITLE
fix: isAttachmentEqual logic in MessageContent and MessageSimple

### DIFF
--- a/package/src/components/Attachment/Giphy.tsx
+++ b/package/src/components/Attachment/Giphy.tsx
@@ -201,6 +201,7 @@ const GiphyWithContext = <
         { backgroundColor: white, borderColor: `${black}0D` },
         selectionContainer,
       ]}
+      testID='giphy-action-attachment'
     >
       <View style={[styles.header, header]}>
         <GiphyIcon />
@@ -229,6 +230,7 @@ const GiphyWithContext = <
               { borderColor: grey_gainsboro, borderRightWidth: 1 },
               buttonContainer,
             ]}
+            testID={`${actions?.[2].value}-action-button`}
           >
             <Text style={[styles.cancel, { color: grey }, cancel]}>{actions?.[2].text}</Text>
           </TouchableOpacity>
@@ -243,6 +245,7 @@ const GiphyWithContext = <
               { borderColor: grey_gainsboro, borderRightWidth: 1 },
               buttonContainer,
             ]}
+            testID={`${actions?.[1].value}-action-button`}
           >
             <Text style={[styles.shuffle, { color: grey }, shuffle]}>{actions?.[1].text}</Text>
           </TouchableOpacity>
@@ -253,6 +256,7 @@ const GiphyWithContext = <
               }
             }}
             style={[styles.buttonContainer, { borderColor: grey_gainsboro }, buttonContainer]}
+            testID={`${actions?.[0].value}-action-button`}
           >
             <Text style={[styles.send, { color: accent_blue }, send]}>{actions?.[0].text}</Text>
           </TouchableOpacity>

--- a/package/src/components/Attachment/__tests__/Attachment.test.js
+++ b/package/src/components/Attachment/__tests__/Attachment.test.js
@@ -10,9 +10,7 @@ import {
   generateAudioAttachment,
   generateCardAttachment,
   generateFileAttachment,
-  generateGiphyAttachment,
   generateImageAttachment,
-  generateImgurAttachment,
 } from '../../../mock-builders/generator/attachment';
 import { generateMessage } from '../../../mock-builders/generator/message';
 import { Attachment } from '../Attachment';
@@ -50,65 +48,6 @@ describe('Attachment', () => {
 
     await waitFor(() => {
       expect(getByTestId('file-attachment')).toBeTruthy();
-    });
-  });
-
-  it('should render Card component for "imgur" type attachment', async () => {
-    const attachment = generateImgurAttachment();
-    const { getByTestId } = render(getAttachmentComponent({ attachment }));
-
-    await waitFor(() => {
-      expect(getByTestId('giphy-attachment')).toBeTruthy();
-    });
-  });
-
-  it('should render Card component for "giphy" type attachment', async () => {
-    const attachment = generateGiphyAttachment();
-    const { getByTestId } = render(getAttachmentComponent({ attachment }));
-
-    await waitFor(() => {
-      expect(getByTestId('giphy-attachment')).toBeTruthy();
-    });
-  });
-
-  it('"giphy" attachment size should be customisable', async () => {
-    const attachment = generateGiphyAttachment();
-    attachment.giphy = {
-      fixed_height: {
-        height: '200',
-        url: 'https://media1.giphy.com/media/test/fixed_height.gif',
-        width: '375',
-      },
-      original: {
-        height: '256',
-        url: 'https://media1.giphy.com/media/test/original.gif',
-        width: '480',
-      },
-    };
-    const { getByTestId: getByTestIdFixedHeight } = render(
-      getAttachmentComponent({ attachment, giphyVersion: 'fixed_height' }),
-    );
-    const { getByTestId: getByTestIdOriginal } = render(
-      getAttachmentComponent({ attachment, giphyVersion: 'original' }),
-    );
-    await waitFor(() => {
-      const checkImageProps = (imageProps, specificSizedGiphyData) => {
-        let imageStyle = imageProps.style;
-        if (Array.isArray(imageStyle)) {
-          imageStyle = Object.assign({}, ...imageStyle);
-        }
-        expect(imageStyle.height).toBe(parseFloat(specificSizedGiphyData.height));
-        expect(imageStyle.width).toBe(parseFloat(specificSizedGiphyData.width));
-        expect(imageProps.source.uri).toBe(specificSizedGiphyData.url);
-      };
-      checkImageProps(
-        getByTestIdFixedHeight('giphy-attachment-image').props,
-        attachment.giphy.fixed_height,
-      );
-      checkImageProps(
-        getByTestIdOriginal('giphy-attachment-image').props,
-        attachment.giphy.original,
-      );
     });
   });
 

--- a/package/src/components/Attachment/__tests__/Giphy.test.js
+++ b/package/src/components/Attachment/__tests__/Giphy.test.js
@@ -1,0 +1,290 @@
+import React from 'react';
+
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import { MessageProvider } from '../../../contexts/messageContext/MessageContext';
+import { OverlayProvider } from '../../../contexts/overlayContext/OverlayProvider';
+
+import { ThemeProvider } from '../../../contexts/themeContext/ThemeContext';
+import { getOrCreateChannelApi } from '../../../mock-builders/api/getOrCreateChannel';
+import { useMockedApis } from '../../../mock-builders/api/useMockedApis';
+import {
+  generateGiphyAttachment,
+  generateImgurAttachment,
+} from '../../../mock-builders/generator/attachment';
+import { generateChannelResponse } from '../../../mock-builders/generator/channel';
+import { generateMember } from '../../../mock-builders/generator/member';
+import { generateMessage } from '../../../mock-builders/generator/message';
+import { generateUser } from '../../../mock-builders/generator/user';
+import { getTestClientWithUser } from '../../../mock-builders/mock';
+import { Channel } from '../../Channel/Channel';
+import { Chat } from '../../Chat/Chat';
+import { MessageList } from '../../MessageList/MessageList';
+import { Giphy } from '../Giphy';
+
+describe('Giphy', () => {
+  const getAttachmentComponent = (props) => {
+    const message = generateMessage();
+    return (
+      <ThemeProvider>
+        <MessageProvider value={{ message }}>
+          <Giphy {...props} />
+        </MessageProvider>
+      </ThemeProvider>
+    );
+  };
+
+  it('should render Card component for "imgur" type attachment', async () => {
+    const attachment = generateImgurAttachment();
+    const { getByTestId } = render(getAttachmentComponent({ attachment }));
+
+    await waitFor(() => {
+      expect(getByTestId('giphy-attachment')).toBeTruthy();
+    });
+  });
+
+  it('should render Card component for "giphy" type attachment', async () => {
+    const attachment = generateGiphyAttachment();
+    const { getByTestId } = render(getAttachmentComponent({ attachment }));
+
+    await waitFor(() => {
+      expect(getByTestId('giphy-attachment')).toBeTruthy();
+    });
+  });
+
+  it('"giphy" attachment size should be customisable', async () => {
+    const attachment = generateGiphyAttachment();
+    attachment.giphy = {
+      fixed_height: {
+        height: '200',
+        url: 'https://media1.giphy.com/media/test/fixed_height.gif',
+        width: '375',
+      },
+      original: {
+        height: '256',
+        url: 'https://media1.giphy.com/media/test/original.gif',
+        width: '480',
+      },
+    };
+    const { getByTestId: getByTestIdFixedHeight } = render(
+      getAttachmentComponent({ attachment, giphyVersion: 'fixed_height' }),
+    );
+    const { getByTestId: getByTestIdOriginal } = render(
+      getAttachmentComponent({ attachment, giphyVersion: 'original' }),
+    );
+    await waitFor(() => {
+      const checkImageProps = (imageProps, specificSizedGiphyData) => {
+        let imageStyle = imageProps.style;
+        if (Array.isArray(imageStyle)) {
+          imageStyle = Object.assign({}, ...imageStyle);
+        }
+        expect(imageStyle.height).toBe(parseFloat(specificSizedGiphyData.height));
+        expect(imageStyle.width).toBe(parseFloat(specificSizedGiphyData.width));
+        expect(imageProps.source.uri).toBe(specificSizedGiphyData.url);
+      };
+      checkImageProps(
+        getByTestIdFixedHeight('giphy-attachment-image').props,
+        attachment.giphy.fixed_height,
+      );
+      checkImageProps(
+        getByTestIdOriginal('giphy-attachment-image').props,
+        attachment.giphy.original,
+      );
+    });
+  });
+
+  it('show render giphy action UI and all the 3 action buttons', async () => {
+    const attachment = generateGiphyAttachment();
+    attachment.actions = [
+      { name: 'image_action', text: 'Send', value: 'send' },
+      { name: 'image_action', text: 'Shuffle', value: 'shuffle' },
+      {
+        name: 'image_action',
+        text: 'Cancel',
+        value: 'cancel',
+      },
+    ];
+    const { getByTestId } = render(
+      getAttachmentComponent({ attachment, giphyVersion: 'fixed_height' }),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('giphy-action-attachment')).toBeTruthy();
+      expect(getByTestId('cancel-action-button')).toBeTruthy();
+      expect(getByTestId('shuffle-action-button')).toBeTruthy();
+      expect(getByTestId('send-action-button')).toBeTruthy();
+    });
+  });
+
+  it('should trigger the cancel giphy action', async () => {
+    const attachment = generateGiphyAttachment();
+    const handleAction = jest.fn();
+    attachment.actions = [
+      { name: 'image_action', text: 'Send', value: 'send' },
+      { name: 'image_action', text: 'Shuffle', value: 'shuffle' },
+      {
+        name: 'image_action',
+        text: 'Cancel',
+        value: 'cancel',
+      },
+    ];
+    const { getByTestId } = render(
+      getAttachmentComponent({
+        attachment,
+        giphyVersion: 'fixed_height',
+        handleAction,
+      }),
+    );
+
+    await waitFor(() => getByTestId(`${attachment.actions[2].value}-action-button`));
+
+    expect(getByTestId('giphy-action-attachment')).toContainElement(
+      getByTestId(`${attachment.actions[2].value}-action-button`),
+    );
+
+    fireEvent.press(getByTestId(`${attachment.actions[2].value}-action-button`));
+
+    await waitFor(() => {
+      expect(handleAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should trigger the shuffle giphy action', async () => {
+    const attachment = generateGiphyAttachment();
+    const handleAction = jest.fn();
+    attachment.actions = [
+      { name: 'image_action', text: 'Send', value: 'send' },
+      { name: 'image_action', text: 'Shuffle', value: 'shuffle' },
+      {
+        name: 'image_action',
+        text: 'Cancel',
+        value: 'cancel',
+      },
+    ];
+    const { getByTestId } = render(
+      getAttachmentComponent({
+        attachment,
+        giphyVersion: 'fixed_height',
+        handleAction,
+      }),
+    );
+
+    await waitFor(() => getByTestId(`${attachment.actions[1].value}-action-button`));
+
+    expect(getByTestId('giphy-action-attachment')).toContainElement(
+      getByTestId(`${attachment.actions[1].value}-action-button`),
+    );
+
+    fireEvent.press(getByTestId(`${attachment.actions[1].value}-action-button`));
+
+    await waitFor(() => {
+      expect(handleAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should trigger the send giphy action', async () => {
+    const attachment = generateGiphyAttachment();
+    const handleAction = jest.fn();
+    attachment.actions = [
+      { name: 'image_action', text: 'Send', value: 'send' },
+      { name: 'image_action', text: 'Shuffle', value: 'shuffle' },
+      {
+        name: 'image_action',
+        text: 'Cancel',
+        value: 'cancel',
+      },
+    ];
+    const { getByTestId } = render(
+      getAttachmentComponent({
+        attachment,
+        giphyVersion: 'fixed_height',
+        handleAction,
+      }),
+    );
+
+    await waitFor(() => getByTestId(`${attachment.actions[0].value}-action-button`));
+
+    expect(getByTestId('giphy-action-attachment')).toContainElement(
+      getByTestId(`${attachment.actions[0].value}-action-button`),
+    );
+
+    fireEvent.press(getByTestId(`${attachment.actions[0].value}-action-button`));
+
+    await waitFor(() => {
+      expect(handleAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('giphy attachment UI should render within the message list with actions', async () => {
+    const user1 = generateUser();
+    const attachment = generateGiphyAttachment();
+    attachment.actions = [
+      { name: 'image_action', text: 'Send', value: 'send' },
+      { name: 'image_action', text: 'Shuffle', value: 'shuffle' },
+      {
+        name: 'image_action',
+        text: 'Cancel',
+        value: 'cancel',
+      },
+    ];
+    const mockedChannel = generateChannelResponse({
+      members: [generateMember({ user: user1 })],
+      messages: [
+        generateMessage({ user: user1 }),
+        generateMessage({ type: 'system', user: undefined }),
+        generateMessage({ attachments: [{ ...attachment }], user: user1 }),
+      ],
+    });
+
+    const chatClient = await getTestClientWithUser({ id: 'testID' });
+    useMockedApis(chatClient, [getOrCreateChannelApi(mockedChannel)]);
+    const channel = chatClient.channel('messaging', mockedChannel.id);
+    await channel.watch();
+
+    const { getByTestId, queryByTestId } = render(
+      <OverlayProvider>
+        <Chat client={chatClient}>
+          <Channel channel={channel}>
+            <MessageList />
+          </Channel>
+        </Chat>
+      </OverlayProvider>,
+    );
+
+    expect(queryByTestId('giphy-action-attachment')).toBeTruthy();
+    expect(getByTestId('cancel-action-button')).toBeTruthy();
+    expect(getByTestId('shuffle-action-button')).toBeTruthy();
+    expect(getByTestId('send-action-button')).toBeTruthy();
+  });
+
+  it('giphy attachment UI should render within the message list', async () => {
+    const user1 = generateUser();
+    const attachment = generateGiphyAttachment();
+
+    const mockedChannel = generateChannelResponse({
+      members: [generateMember({ user: user1 })],
+      messages: [
+        generateMessage({ user: user1 }),
+        generateMessage({ type: 'system', user: undefined }),
+        generateMessage({ attachments: [{ ...attachment }], user: user1 }),
+      ],
+    });
+
+    const chatClient = await getTestClientWithUser({ id: 'testID' });
+    useMockedApis(chatClient, [getOrCreateChannelApi(mockedChannel)]);
+    const channel = chatClient.channel('messaging', mockedChannel.id);
+    await channel.watch();
+
+    const { queryByTestId } = render(
+      <OverlayProvider>
+        <Chat client={chatClient}>
+          <Channel channel={channel}>
+            <MessageList />
+          </Channel>
+        </Chat>
+      </OverlayProvider>,
+    );
+
+    expect(queryByTestId('giphy-attachment')).toBeTruthy();
+  });
+});

--- a/package/src/components/Channel/__tests__/isAttachmentEqualHandler.test.js
+++ b/package/src/components/Channel/__tests__/isAttachmentEqualHandler.test.js
@@ -18,7 +18,7 @@ import { Channel } from '../../Channel/Channel';
 import { Chat } from '../../Chat/Chat';
 import { MessageList } from '../../MessageList/MessageList';
 
-describe('Message', () => {
+describe('isAttachmentEqualHandler', () => {
   let channel;
   let chatClient;
 

--- a/package/src/components/Message/MessageSimple/MessageContent.tsx
+++ b/package/src/components/Message/MessageSimple/MessageContent.tsx
@@ -445,23 +445,22 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
   const prevMessageAttachments = prevMessage.attachments;
   const nextMessageAttachments = nextMessage.attachments;
   const attachmentsEqual =
-    Array.isArray(prevMessageAttachments) &&
-    Array.isArray(nextMessageAttachments) &&
-    prevMessageAttachments.length === nextMessageAttachments.length &&
-    prevMessageAttachments.every((attachment, index) => {
-      const attachmentKeysEqual =
-        attachment.type === 'image'
-          ? attachment.image_url === nextMessageAttachments[index].image_url &&
-            attachment.thumb_url === nextMessageAttachments[index].thumb_url
-          : attachment.type === nextMessageAttachments[index].type;
+    Array.isArray(prevMessageAttachments) && Array.isArray(nextMessageAttachments)
+      ? prevMessageAttachments.length === nextMessageAttachments.length &&
+        prevMessageAttachments.every((attachment, index) => {
+          const attachmentKeysEqual =
+            attachment.image_url === nextMessageAttachments[index].image_url &&
+            attachment.og_scrape_url === nextMessageAttachments[index].og_scrape_url &&
+            attachment.thumb_url === nextMessageAttachments[index].thumb_url;
 
-      if (isAttachmentEqual)
-        return (
-          attachmentKeysEqual && !!isAttachmentEqual(attachment, nextMessageAttachments[index])
-        );
+          if (isAttachmentEqual)
+            return (
+              attachmentKeysEqual && !!isAttachmentEqual(attachment, nextMessageAttachments[index])
+            );
 
-      return attachmentKeysEqual;
-    });
+          return attachmentKeysEqual;
+        })
+      : prevMessageAttachments === nextMessageAttachments;
   if (!attachmentsEqual) return false;
 
   const latestReactionsEqual =

--- a/package/src/components/Message/MessageSimple/MessageSimple.tsx
+++ b/package/src/components/Message/MessageSimple/MessageSimple.tsx
@@ -147,18 +147,17 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
   const prevMessageAttachments = prevMessage.attachments;
   const nextMessageAttachments = nextMessage.attachments;
   const attachmentsEqual =
-    Array.isArray(prevMessageAttachments) &&
-    Array.isArray(nextMessageAttachments) &&
-    prevMessageAttachments.length === nextMessageAttachments.length &&
-    prevMessageAttachments.every((attachment, index) => {
-      const attachmentKeysEqual =
-        attachment.type === 'image'
-          ? attachment.image_url === nextMessageAttachments[index].image_url &&
-            attachment.thumb_url === nextMessageAttachments[index].thumb_url
-          : attachment.type === nextMessageAttachments[index].type;
+    Array.isArray(prevMessageAttachments) && Array.isArray(nextMessageAttachments)
+      ? prevMessageAttachments.length === nextMessageAttachments.length &&
+        prevMessageAttachments.every((attachment, index) => {
+          const attachmentKeysEqual =
+            attachment.image_url === nextMessageAttachments[index].image_url &&
+            attachment.og_scrape_url === nextMessageAttachments[index].og_scrape_url &&
+            attachment.thumb_url === nextMessageAttachments[index].thumb_url;
 
-      return attachmentKeysEqual;
-    });
+          return attachmentKeysEqual;
+        })
+      : prevMessageAttachments === nextMessageAttachments;
   if (!attachmentsEqual) return false;
 
   const latestReactionsEqual =


### PR DESCRIPTION
## 🎯 Goal

Fixes - https://github.com/GetStream/stream-chat-react-native/pull/1219/files#r844457438

<!-- Describe why we are making this change -->

## 🛠 Implementation details

- Fixed the condition of isAttachmentEqual logic in MessageSimple and MessageContent component. 
- Fixed the test suite name for isAttachmentEqual prop in Channel.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

