### PR TITLE
fix: hidden icons due to wrong screenHeight value and remove handleHeight to fix fullscreen top padding in AttachmentPicker

### DIFF
--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -326,23 +326,37 @@ export const AttachmentPicker = React.forwardRef(
           : statusBarHeight
         : 0;
 
+    const initialSnapPoint = useMemo(
+      () =>
+        attachmentPickerBottomSheetHeight ?? Platform.OS === 'android'
+          ? 308 +
+            (fullScreenHeight - screenHeight + androidBottomBarHeightAdjustment) -
+            handleHeight
+          : 308 + (fullScreenHeight - screenHeight + androidBottomBarHeightAdjustment),
+      [
+        attachmentPickerBottomSheetHeight,
+        androidBottomBarHeightAdjustment,
+        fullScreenHeight,
+        handleHeight,
+        screenHeight,
+      ],
+    );
+
+    const finalSnapPoint = useMemo(
+      () =>
+        Platform.OS === 'android'
+          ? fullScreenHeight - topInset - handleHeight
+          : fullScreenHeight - topInset,
+      [fullScreenHeight, handleHeight, topInset],
+    );
+
     /**
      * Snap points changing cause a rerender of the position,
      * this is an issue if you are calling close on the bottom sheet.
      */
     const snapPoints = useMemo(
-      () => [
-        attachmentPickerBottomSheetHeight ??
-          308 + (fullScreenHeight - screenHeight + androidBottomBarHeightAdjustment),
-        fullScreenHeight - topInset,
-      ],
-      [
-        androidBottomBarHeightAdjustment,
-        attachmentPickerBottomSheetHeight,
-        fullScreenHeight,
-        screenHeight,
-        topInset,
-      ],
+      () => [initialSnapPoint, finalSnapPoint],
+      [initialSnapPoint, finalSnapPoint],
     );
 
     return (

--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
 });
 
 const screenHeight = vh(100);
-const fullScreenHeight = Dimensions.get('screen').height;
+const fullScreenHeight = Dimensions.get('window').height;
 
 type AttachmentImageProps = {
   ImageOverlaySelectedComponent: React.ComponentType;
@@ -333,14 +333,13 @@ export const AttachmentPicker = React.forwardRef(
     const snapPoints = useMemo(
       () => [
         attachmentPickerBottomSheetHeight ??
-          308 + (fullScreenHeight - screenHeight + androidBottomBarHeightAdjustment) - handleHeight,
-        fullScreenHeight - topInset - handleHeight,
+          308 + (fullScreenHeight - screenHeight + androidBottomBarHeightAdjustment),
+        fullScreenHeight - topInset,
       ],
       [
         androidBottomBarHeightAdjustment,
         attachmentPickerBottomSheetHeight,
         fullScreenHeight,
-        handleHeight,
         screenHeight,
         topInset,
       ],

--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -354,10 +354,7 @@ export const AttachmentPicker = React.forwardRef(
      * Snap points changing cause a rerender of the position,
      * this is an issue if you are calling close on the bottom sheet.
      */
-    const snapPoints = useMemo(
-      () => [initialSnapPoint, finalSnapPoint],
-      [initialSnapPoint, finalSnapPoint],
-    );
+    const snapPoints = [initialSnapPoint, finalSnapPoint];
 
     return (
       <>

--- a/package/src/components/MessageInput/__tests__/__snapshots__/FileUploadPreview.test.js.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/FileUploadPreview.test.js.snap
@@ -1059,8 +1059,8 @@ Array [
     onChange={[Function]}
     snapPoints={
       Array [
-        288,
-        1314,
+        308,
+        1334,
       ]
     }
   >
@@ -2316,8 +2316,8 @@ Array [
     onChange={[Function]}
     snapPoints={
       Array [
-        288,
-        1314,
+        308,
+        1334,
       ]
     }
   >
@@ -3261,8 +3261,8 @@ Array [
     onChange={[Function]}
     snapPoints={
       Array [
-        288,
-        1314,
+        308,
+        1334,
       ]
     }
   >
@@ -4368,8 +4368,8 @@ Array [
     onChange={[Function]}
     snapPoints={
       Array [
-        288,
-        1314,
+        308,
+        1334,
       ]
     }
   >

--- a/package/src/components/MessageInput/__tests__/__snapshots__/MessageInput.test.js.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/MessageInput.test.js.snap
@@ -703,8 +703,8 @@ Array [
     onChange={[Function]}
     snapPoints={
       Array [
-        288,
-        1314,
+        308,
+        1334,
       ]
     }
   >


### PR DESCRIPTION
## 🎯 Goal

This PR fixes the UI issues with the bottom sheet in the attachment picker.

Fixes - #1299 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The `fullscreenHeight` was using Dimension.get("screen") while the `screenHeight` has the vh around Dimension.get("window") which caused the UI inconsistency. Also, the `handleHeight` caused the full-screen drag with inconsistency. We only need `handleHeight` for Android. 

Check the screenshots attached to see the changes.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

*Full screen issue*
<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/164721638-8899f852-5ee2-47a0-8fa6-c7efc0e6ca1d.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/164721662-d056a5bc-f15b-4876-9222-2cc24afe06f0.png" />
            </td>
        </tr>
    </tbody>
</table>
</details>

*Attachment Picker icons*

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/164721689-3d514621-d1fa-4849-bc31-b0b2016ef855.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/164721667-05926a8c-2308-4205-b555-78799d379302.png" />
            </td>
        </tr>
    </tbody>
</table>
</details>

<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/164722601-6dabd1aa-6570-49a0-9016-e8f940c227e7.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/164722610-914bcc0a-a684-41c5-996b-fc47bd528511.png" />
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [ ] Documentation is updated

