### PR TITLE
fix: set border radius to 16 for giphy selector

### DIFF
--- a/package/src/components/Attachment/Giphy.tsx
+++ b/package/src/components/Attachment/Giphy.tsx
@@ -65,6 +65,7 @@ const styles = StyleSheet.create({
   },
   giphyHeaderTitle: {
     fontSize: 14,
+    marginLeft: 8,
   },
   giphyMask: {
     bottom: 8,
@@ -84,7 +85,8 @@ const styles = StyleSheet.create({
     width: '60%',
   },
   selectionContainer: {
-    borderBottomLeftRadius: 8,
+    borderRadius: 16,
+    borderBottomRightRadius: 0,
     borderWidth: 1,
     overflow: 'hidden',
     width: 272,

--- a/package/src/components/Attachment/Giphy.tsx
+++ b/package/src/components/Attachment/Giphy.tsx
@@ -85,8 +85,8 @@ const styles = StyleSheet.create({
     width: '60%',
   },
   selectionContainer: {
-    borderRadius: 16,
     borderBottomRightRadius: 0,
+    borderRadius: 16,
     borderWidth: 1,
     overflow: 'hidden',
     width: 272,


### PR DESCRIPTION
## 🎯 Goal

The border radiuses (radi? radii? corner go bendy) on the giphy selector doesn't match the design spec, and the corners of the border get cut off. This PR aims to fix that by ensuring a border radius of 16 on all corners except bottom right, as it's shown in the figma designs.

I also snuck in a margin before the `/giphy UserInput` text in the header, as that was missing - the margin being set to 8 is me just copying the margin in the designs. 

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/1548276/164779476-a149cb51-a575-485c-b58b-4aa114799106.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/1548276/164779555-46d427d5-9fae-4ffa-8fd3-69cb795f426c.png" />
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

type `/giphy something` and hit send to render the giphy selector. Then you should see the component in question. Check that the corner borders aren't getting cut off. See my screenshots here for an example

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [X] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [ ] Documentation is updated

