### PR TITLE
fix: url without http/s opening issue 

### DIFF
--- a/package/src/components/Attachment/Card.tsx
+++ b/package/src/components/Attachment/Card.tsx
@@ -69,13 +69,20 @@ const styles = StyleSheet.create({
 
 const goToURL = (url?: string) => {
   if (!url) return;
-  Linking.canOpenURL(url).then((supported) => {
-    if (supported) {
-      Linking.openURL(url);
-    } else {
-      console.log(`Don't know how to open URI: ${url}`);
+  else {
+    let finalUrl = url;
+    const pattern = new RegExp(/^.+\/\//);
+    if (!pattern.test(url)) {
+      finalUrl = 'http://' + url;
     }
-  });
+    Linking.canOpenURL(finalUrl).then((supported) => {
+      if (supported) {
+        Linking.openURL(finalUrl);
+      } else {
+        console.log(`Don't know how to open URI: ${finalUrl}`);
+      }
+    });
+  }
 };
 
 export type CardPropsWithContext<

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -147,10 +147,16 @@ export const renderText = <
     },
   };
 
-  const onLink = (url: string) =>
-    onLinkParams
+  const onLink = (url: string) => {
+    const pattern = new RegExp(/^.+\/\//);
+    if (!pattern.test(url)) {
+      url = 'http://' + url;
+    }
+
+    return onLinkParams
       ? onLinkParams(url)
       : Linking.canOpenURL(url).then((canOpenUrl) => canOpenUrl && Linking.openURL(url));
+  };
 
   const link: ReactNodeOutput = (node, output, { ...state }) => {
     const onPress = (event: GestureResponderEvent) => {


### PR DESCRIPTION
## 🎯 Goal

This PR focuses on fixing the issue #1286 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The URL is tested with a pattern `/^.+\/\//` and the ones which do not pass are prepended with `http://` so that the redirection in the web browser works.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

Not applicable

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

