### PR TITLE
fix: broken local element link in the push doc

### DIFF
--- a/docusaurus/docs/reactnative/guides/push_notifications_v2.mdx
+++ b/docusaurus/docs/reactnative/guides/push_notifications_v2.mdx
@@ -228,7 +228,7 @@ To listen to notifications on the background, you can use the [`setBackgroundMes
 
 :::caution
 
-This handler works only on Android. For this handler to work on iOS, the payload must be [customised](#make-ios-payload-to-be-data-only) `data` only.
+This handler works only on Android. For this handler to work on iOS, the payload must be [customised `data` only](#make-ios-payload-data-only).
 
 :::
 


### PR DESCRIPTION
## 🎯 Goal

A local link was broken in the push documentation.

Cause:  The header of a section was changed after the review comments. But I had terribly forgotten to update the local element link to it as well.

## 🛠 Implementation details

NA

## 🎨 UI Changes

NA

## 🧪 Testing

NA

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

