### PR TITLE
fix: github workflow did not support android compileSdk 31

### DIFF
--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -49,9 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: '11'
+          check-latest: true
       - name: RN setup
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -3,7 +3,7 @@ name: sample-distribution
 on:
   push:
     branches:
-      - develop
+      - santhosh/fix-android-gh-workflow
 jobs:
   build_and_deploy_ios_testflight_qa:
     runs-on: [macos-latest]

--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -43,6 +43,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         run: |
           cd examples/SampleApp
+          bundle exec fastlane deploy_to_testflight_qa
 
   build_and_deploy_android_s3:
     runs-on: ubuntu-latest

--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -3,7 +3,7 @@ name: sample-distribution
 on:
   push:
     branches:
-      - santhosh/fix-android-gh-workflow
+      - develop
 jobs:
   build_and_deploy_ios_testflight_qa:
     runs-on: [macos-latest]

--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -43,7 +43,6 @@ jobs:
           APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         run: |
           cd examples/SampleApp
-          bundle exec fastlane deploy_to_testflight_qa
 
   build_and_deploy_android_s3:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 🎯 Goal

Android compile SDK was updated to 31 for the latest firebase support. This broke the GitHub sample distribution workflow. As JDK 8 is not supported with compile SDK 31.

## 🛠 Implementation details

Updated to JDK 11.

## 🎨 UI Changes

NA

## 🧪 Testing

NA

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

