### PR TITLE
fix: smart gallery rendering while optimistically adding a message to list

### DIFF
--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -665,6 +665,8 @@ export const MessageInputProvider = <
         attachments.push({
           fallback: image.file.name,
           image_url: image.url,
+          original_height: image.height,
+          original_width: image.width,
           type: 'image',
         } as Attachment<StreamChatGenerics>);
       }


### PR DESCRIPTION
## 🎯 Goal

We render image attachments smartly according to their aspect ratio. Although this logic currently doesn't work when we send a message. This is because when we optimistically add a message to list before actually making api call (sendMessage), the image attachment doesn't include `original_height` and `original_width` properties. We rely on backend to populate these values. 

## 🛠 Implementation details

In this PR, we are adding these properties in a message while optimistically adding it to the list.

## 🎨 UI Changes

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <video src="https://user-images.githubusercontent.com/11586388/170325164-433f7d9b-6c7e-4e60-86ff-d9023ca6f2ea.mov" />
            </td>
            <td>
                <video src="https://user-images.githubusercontent.com/11586388/170325097-9c9b5f19-e263-44de-9008-869892026f1c.mov" />
            </td>
        </tr>
    </tbody>
</table>

## 🧪 How to reproduce the issue

- Open attachment picker and select some portrait image
- Send that image to channel
- Notice it gets rendered in a default square sized container (nor fully visible and cropped on the side)
- Now go back to ChannelList and come back, and notice that image is rendered in a portrait container and fully visible