### PR TITLE
feat: expose link url in onPress

### DIFF
--- a/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
@@ -23,7 +23,7 @@ For example:
 ```tsx
     <Channel
       onPressMessage={({ additionalInfo, defaultHandler, emitter }) => {
-        
+
           if (emitter === 'textMention') {
             console.log(additionalInfo?.user);
             return;

--- a/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
@@ -22,13 +22,20 @@ For example:
 
 ```tsx
     <Channel
-    onPressMessage={({ additionalInfo, defaultHandler, emitter }) => {
-        if (emitter === 'textMention') {
-          console.log(additionalInfo?.user);
-          return;
-        }
-        defaultHandler?.();
-    }}
+      onPressMessage={({ additionalInfo, defaultHandler, emitter }) => {
+        
+          if (emitter === 'textMention') {
+            console.log(additionalInfo?.user);
+            return;
+          }
+
+          if (emitter === 'card' || emitter === 'textLink') {
+            console.log(additionalInfo?.url);
+            return;
+          }
+
+          defaultHandler?.();
+      }}
     >
 ```
 

--- a/package/native-package/yarn.lock
+++ b/package/native-package/yarn.lock
@@ -1619,10 +1619,10 @@ source-map@^0.5.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-stream-chat-react-native-core@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-4.3.1.tgz#bc53a044c45b60f6bd3feb425e70100d077cc064"
-  integrity sha512-2DZO89EyDtXtmc5MhivD1kOOU6aklK/rgZVvo4RZ15419VlpVFqMjswvFAcF41z2ZJujP86cSSKg5YMhNy7uZw==
+stream-chat-react-native-core@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-4.5.0.tgz#7c74f542e66ef9028f3c303b9a5149db681df1ff"
+  integrity sha512-koDw3Nzw8mORGrSeL2JfHqXWFHWHdJLMrhd/UIuShDVJcZmxcPjvXoFUrMWMbu4C8yrlftcsKKmDGWlUzdSqaA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gorhom/bottom-sheet" "4.1.5"

--- a/package/src/components/Attachment/Card.tsx
+++ b/package/src/components/Attachment/Card.tsx
@@ -157,6 +157,7 @@ const CardWithContext = <
       onPress={(event) => {
         if (onPress) {
           onPress({
+            additionalInfo: { url: og_scrape_url },
             defaultHandler: defaultOnPress,
             emitter: 'card',
             event,

--- a/package/src/components/Attachment/Card.tsx
+++ b/package/src/components/Attachment/Card.tsx
@@ -149,6 +149,7 @@ const CardWithContext = <
       onLongPress={(event) => {
         if (onLongPress) {
           onLongPress({
+            additionalInfo: { url: og_scrape_url },
             emitter: 'card',
             event,
           });
@@ -167,6 +168,7 @@ const CardWithContext = <
       onPressIn={(event) => {
         if (onPressIn) {
           onPressIn({
+            additionalInfo: { url: og_scrape_url },
             defaultHandler: defaultOnPress,
             emitter: 'card',
             event,

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -53,15 +53,13 @@ import {
 import type { MessageActionListItemProps } from '../MessageOverlay/MessageActionListItem';
 
 export type TouchableEmitter =
-  | 'card'
   | 'fileAttachment'
   | 'gallery'
   | 'giphy'
   | 'message'
   | 'messageContent'
   | 'messageReplies'
-  | 'reactionList'
-  | 'textLink';
+  | 'reactionList';
 
 export type TextMentionTouchableHandlerPayload<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -70,21 +68,27 @@ export type TextMentionTouchableHandlerPayload<
   additionalInfo?: { user?: UserResponse<StreamChatGenerics> };
 };
 
+export type CardAndTextLinkTouchableHandlerPayload = {
+  emitter: 'textLink' | 'card';
+  additionalInfo?: { url?: string };
+};
+
 export type TouchableHandlerPayload = {
   defaultHandler?: () => void;
   event?: GestureResponderEvent;
 } & (
   | {
-      additionalInfo?: Record<string, unknown>;
       emitter?: TouchableEmitter;
     }
   | TextMentionTouchableHandlerPayload
+  | CardAndTextLinkTouchableHandlerPayload
 );
 
 export type MessageTouchableHandlerPayload<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 > = TouchableHandlerPayload & {
   actionHandlers?: MessageActionHandlers;
+  additionalInfo?: Record<string, unknown>;
   message?: MessageType<StreamChatGenerics>;
 };
 

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -68,7 +68,7 @@ export type TextMentionTouchableHandlerPayload<
   additionalInfo?: { user?: UserResponse<StreamChatGenerics> };
 };
 
-export type CardAndTextLinkTouchableHandlerPayload = {
+export type UrlTouchableHandlerPayload = {
   emitter: 'textLink' | 'card';
   additionalInfo?: { url?: string };
 };
@@ -81,7 +81,7 @@ export type TouchableHandlerPayload = {
       emitter?: TouchableEmitter;
     }
   | TextMentionTouchableHandlerPayload
-  | CardAndTextLinkTouchableHandlerPayload
+  | UrlTouchableHandlerPayload
 );
 
 export type MessageTouchableHandlerPayload<

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -161,12 +161,13 @@ export const renderText = <
   };
 
   const link: ReactNodeOutput = (node, output, { ...state }) => {
+    const url = node.target;
     const onPress = (event: GestureResponderEvent) => {
       if (!preventPress && onPressParam) {
         onPressParam({
-          additionalInfo: { link: node.target },
+          additionalInfo: { url },
           defaultHandler: () => {
-            onLink(node.target);
+            onLink(url);
           },
           emitter: 'textLink',
           event,
@@ -177,6 +178,7 @@ export const renderText = <
     const onLongPress = (event: GestureResponderEvent) => {
       if (!preventPress && onLongPressParam) {
         onLongPressParam({
+          additionalInfo: { url },
           emitter: 'textLink',
           event,
         });

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -164,7 +164,10 @@ export const renderText = <
     const onPress = (event: GestureResponderEvent) => {
       if (!preventPress && onPressParam) {
         onPressParam({
-          defaultHandler: () => onLink(node.target),
+          additionalInfo: { link: node.target },
+          defaultHandler: () => {
+            onLink(node.target);
+          },
           emitter: 'textLink',
           event,
         });


### PR DESCRIPTION
## 🎯 Goal
This PR exposes the url to a customer when the emitter is a `card` or `textLink`
<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [x] Documentation is updated

