### PR TITLE
fix: issue with the link text overflowing the reply view

### DIFF
--- a/package/src/components/Reply/Reply.tsx
+++ b/package/src/components/Reply/Reply.tsx
@@ -203,7 +203,9 @@ const ReplyWithContext = <
             />
           ) : null
         ) : null}
-        {messageType === 'video' ? <VideoThumbnail style={[styles.videoAttachment]} /> : null}
+        {messageType === 'video' && !lastAttachment.og_scrape_url ? (
+          <VideoThumbnail style={[styles.videoAttachment]} />
+        ) : null}
         <MessageTextContainer<StreamChatGenerics>
           markdownStyles={
             quotedMessage.deleted_at


### PR DESCRIPTION
## 🎯 Goal

This PR fixes the issue with the link text in the Reply view which is overflowing the Reply view area.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

Added the condition `!lastAttachment.og_scrape_url` to check if the attachment is a video or a link with a video in it.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/171574229-5d7549f6-5841-47a5-b63b-b6df235f6407.png" /> 
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/171576621-5d2a356f-6491-4e63-8fb9-0aef7efe38b0.png" /> 
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [ ] Documentation is updated

