### PR TITLE
fix: wrap the SampleApp with ThemeProvider

### DIFF
--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -116,26 +116,28 @@ const App = () => {
         backgroundColor: streamChatTheme.colors?.white_snow || '#FCFCFC',
       }}
     >
-      <NavigationContainer
-        ref={RootNavigationRef}
-        theme={{
-          colors: {
-            ...(colorScheme === 'dark' ? DarkTheme : DefaultTheme).colors,
-            background: streamChatTheme.colors?.white_snow || '#FCFCFC',
-          },
-          dark: colorScheme === 'dark',
-        }}
-      >
-        <AppContext.Provider value={{ chatClient, loginUser, logout, switchUser }}>
-          {isConnecting ? (
-            <LoadingScreen />
-          ) : chatClient ? (
-            <DrawerNavigatorWrapper chatClient={chatClient} />
-          ) : (
-            <UserSelector />
-          )}
-        </AppContext.Provider>
-      </NavigationContainer>
+      <ThemeProvider style={streamChatTheme}>
+        <NavigationContainer
+          ref={RootNavigationRef}
+          theme={{
+            colors: {
+              ...(colorScheme === 'dark' ? DarkTheme : DefaultTheme).colors,
+              background: streamChatTheme.colors?.white_snow || '#FCFCFC',
+            },
+            dark: colorScheme === 'dark',
+          }}
+        >
+          <AppContext.Provider value={{ chatClient, loginUser, logout, switchUser }}>
+            {isConnecting ? (
+              <LoadingScreen />
+            ) : chatClient ? (
+              <DrawerNavigatorWrapper chatClient={chatClient} />
+            ) : (
+              <UserSelector />
+            )}
+          </AppContext.Provider>
+        </NavigationContainer>
+      </ThemeProvider>
     </SafeAreaProvider>
   );
 };
@@ -176,23 +178,19 @@ const DrawerNavigatorWrapper: React.FC<{
 };
 
 const UserSelector = () => {
-  const streamChatTheme = useStreamChatTheme();
-
   return (
-    <ThemeProvider style={streamChatTheme}>
-      <UserSelectorStack.Navigator initialRouteName='UserSelectorScreen'>
-        <UserSelectorStack.Screen
-          component={AdvancedUserSelectorScreen}
-          name='AdvancedUserSelectorScreen'
-          options={{ gestureEnabled: false, headerShown: false }}
-        />
-        <UserSelectorStack.Screen
-          component={UserSelectorScreen}
-          name='UserSelectorScreen'
-          options={{ gestureEnabled: false, headerShown: false }}
-        />
-      </UserSelectorStack.Navigator>
-    </ThemeProvider>
+    <UserSelectorStack.Navigator initialRouteName='UserSelectorScreen'>
+      <UserSelectorStack.Screen
+        component={AdvancedUserSelectorScreen}
+        name='AdvancedUserSelectorScreen'
+        options={{ gestureEnabled: false, headerShown: false }}
+      />
+      <UserSelectorStack.Screen
+        component={UserSelectorScreen}
+        name='UserSelectorScreen'
+        options={{ gestureEnabled: false, headerShown: false }}
+      />
+    </UserSelectorStack.Navigator>
   );
 };
 

--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -177,22 +177,20 @@ const DrawerNavigatorWrapper: React.FC<{
   );
 };
 
-const UserSelector = () => {
-  return (
-    <UserSelectorStack.Navigator initialRouteName='UserSelectorScreen'>
-      <UserSelectorStack.Screen
-        component={AdvancedUserSelectorScreen}
-        name='AdvancedUserSelectorScreen'
-        options={{ gestureEnabled: false, headerShown: false }}
-      />
-      <UserSelectorStack.Screen
-        component={UserSelectorScreen}
-        name='UserSelectorScreen'
-        options={{ gestureEnabled: false, headerShown: false }}
-      />
-    </UserSelectorStack.Navigator>
-  );
-};
+const UserSelector = () => (
+  <UserSelectorStack.Navigator initialRouteName='UserSelectorScreen'>
+    <UserSelectorStack.Screen
+      component={AdvancedUserSelectorScreen}
+      name='AdvancedUserSelectorScreen'
+      options={{ gestureEnabled: false, headerShown: false }}
+    />
+    <UserSelectorStack.Screen
+      component={UserSelectorScreen}
+      name='UserSelectorScreen'
+      options={{ gestureEnabled: false, headerShown: false }}
+    />
+  </UserSelectorStack.Navigator>
+);
 
 // TODO: Split the stack into multiple stacks - ChannelStack, CreateChannelStack etc.
 const HomeScreen = () => {


### PR DESCRIPTION
## 🎯 Goal

With the newest develop, I get an error when running the SampleApp reading 

```
Error: The useThemeContext hook was called outside the ThemeContext Provider. Make sure you have configured OverlayProvider component correctly - https://getstream.io/chat/docs/sdk/reactnative/basics/hello_stream_chat/#overlay-provider
```

This seems expected, but also makes it clear we miss wrapping a component in the ThemeProvider before it's used.

## 🛠 Implementation details

This PR simply wraps the entire SampleApp with the ThemeProvider.

## 🧪 Testing

1. Build and run the SampleApp on `develop`. This should cause the error to be thrown.
2. Build an run the SampleApp on this branch. This should *not* cause the error to be thrown.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

