### PR TITLE
fix: remove error thrown in useMessageContext

### DIFF
--- a/package/src/contexts/__tests__/index.test.tsx
+++ b/package/src/contexts/__tests__/index.test.tsx
@@ -9,7 +9,6 @@ import {
   useChannelsContext,
   useChatContext,
   useImageGalleryContext,
-  useMessageContext,
   useMessageOverlayContext,
   useMessagesContext,
   useOverlayContext,
@@ -74,10 +73,6 @@ describe('contexts hooks in a component throws an error with message when not wr
     [
       useImageGalleryContext,
       `The useImageGalleryContext hook was called outside the ImageGalleryContext Provider. Make sure you have configured OverlayProvider component correctly - https://getstream.io/chat/docs/sdk/reactnative/basics/hello_stream_chat/#overlay-provider`,
-    ],
-    [
-      useMessageContext,
-      `The useMessageContext hook was called outside of the MessageContext provider. Make sure you have configured MessageList component correctly - https://getstream.io/chat/docs/sdk/reactnative/basics/hello_stream_chat/#message-list`,
     ],
     [
       useMessageOverlayContext,

--- a/package/src/contexts/messageContext/MessageContext.tsx
+++ b/package/src/contexts/messageContext/MessageContext.tsx
@@ -14,7 +14,6 @@ import type { DefaultStreamChatGenerics, UnknownType } from '../../types/types';
 import { DEFAULT_BASE_CONTEXT_VALUE } from '../utils/defaultBaseContextValue';
 
 import { getDisplayName } from '../utils/getDisplayName';
-import { isTestEnvironment } from '../utils/isTestEnvironment';
 
 export type Alignment = 'right' | 'left';
 

--- a/package/src/contexts/messageContext/MessageContext.tsx
+++ b/package/src/contexts/messageContext/MessageContext.tsx
@@ -129,12 +129,6 @@ export const useMessageContext = <
     MessageContext,
   ) as unknown as MessageContextValue<StreamChatGenerics>;
 
-  if (contextValue === DEFAULT_BASE_CONTEXT_VALUE && !isTestEnvironment()) {
-    throw new Error(
-      `The useMessageContext hook was called outside of the MessageContext provider. Make sure you have configured MessageList component correctly - https://getstream.io/chat/docs/sdk/reactnative/basics/hello_stream_chat/#message-list`,
-    );
-  }
-
   return contextValue;
 };
 


### PR DESCRIPTION
## 🎯 Goal

Currently, trying to reply to a message will throw the error `The useMessageContext hook was called outside of the MessageContext provider. Make sure you have configured MessageList component correctly - https://getstream.io/chat/docs/sdk/reactnative/basics/hello_stream_chat/#message-list` out of the box with the SDK.

This PR is a suggestion to avoid this (see next headline)

## 🛠 Implementation details

<!-- Provide a description of the implementation -->
This error is intended to give users a hint when using a context outside
of its provider.

However, the MessageContext specifically is something we use ourselves
in the Reply component, as well as multiple child components of it, both
as part of the MessageList (within Message context) and in the
MessageInput component (outside Message context).

I've considered two approaches:

1. Removing the error - the idea being that the probable value of it is
low enough in this context for it not to catch any possible bugs for any
users
2. Creating a secondary `useMessageContextDangerously` or something
along those lines for use in the specific case of the MessageInput
component.

Alternative 2 works, but seems unneccessary/redundant. However, I am
open for input/other ideas on this.

## 🧪 Testing

1. Open a message list with >= 1 message
2. Longpress a message
3. Select "Reply"
4. Should not throw an error

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

