### PR TITLE
docs: correct the parameter type for removeImage and removeFile

### DIFF
--- a/docusaurus/docs/reactnative/common-content/contexts/message-input-context/remove_file.mdx
+++ b/docusaurus/docs/reactnative/common-content/contexts/message-input-context/remove_file.mdx
@@ -1,6 +1,6 @@
 Removes attached file in message, which is being composed in `MessageInput` component. By default, this function is attached to onPress handler for close button in [FileUploadPreview](../../../core-components/channel.mdx#fileuploadpreview).
-It takes index of file (to be removed) in [`fileUploads`](../../../contexts/message_input_context.mdx#fileuploads) array as parameter.
+It takes a string ID of the file to be removed in the [`fileUploads`](../../../contexts/message_input_context.mdx#fileuploads) array as parameter.
 
-| Type              |
-| ----------------- |
-| `(index) => void` |
+| Type                   |
+| ---------------------- |
+| `(id: string) => void` |

--- a/docusaurus/docs/reactnative/common-content/contexts/message-input-context/remove_image.mdx
+++ b/docusaurus/docs/reactnative/common-content/contexts/message-input-context/remove_image.mdx
@@ -1,6 +1,6 @@
-Removes attached image in message, which is being composed in `MessageInput` component. By default, this function is attached to onPress handler for close button in [ImageUploadPreview](../../../core-components/channel.mdx#imageuploadpreview).
-It takes index of file (to be removed) in [imageUploads](../../../contexts/message_input_context.mdx#imageuploads) array as parameter.
+Removes an attached image in a message being composed in the `MessageInput` component. By default, this function is attached to onPress handler for close button in [ImageUploadPreview](../../../core-components/channel.mdx#imageuploadpreview).
+It takes a string ID of the image to be removed in the [imageUploads](../../../contexts/message_input_context.mdx#imageuploads) array as parameter.
 
-| Type              |
-| ----------------- |
-| `(index) => void` |
+| Type                   |
+| ---------------------- |
+| `(id: string) => void` |


### PR DESCRIPTION
## 🎯 Goal

Our documentation currently shows the wrong parameter type for `removeFile` and `removeImage` - this PR aims to correct this.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [x] Documentation is updated

