### PR TITLE
docs: add missing comma in notification template (push v2)

### DIFF
--- a/docusaurus/docs/reactnative/guides/push_notifications_v2.mdx
+++ b/docusaurus/docs/reactnative/guides/push_notifications_v2.mdx
@@ -394,7 +394,7 @@ To update the payload for Android to have notification payload also, you can add
 const client = StreamChat.getInstance(‘api_key’, ‘api_secret’);
 const notification_template = `{
     "title": "New message from {{ sender.name }}",
-    "body": "{{ truncate message.text 2000 }}"
+    "body": "{{ truncate message.text 2000 }}",
     "click_action": "OPEN_ACTIVITY_1",
     "sound": "default"
 }`;


### PR DESCRIPTION
## 🎯 Goal

A missing comma in the notification template in our docs introduces issues for any user copying the template from there. 

Looks like this will solve #1454 



## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [x] Documentation is updated

