### PR TITLE
fix: mentions dont work if giphy is disabled

### DIFF
--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -362,7 +362,7 @@ const AutoCompleteInputWithContext = <
       isTrackingStarted.current
     ) {
       stopTracking();
-    } else if (giphyEnabled && !(await handleCommand(text))) {
+    } else if (!(await handleCommand(text))) {
       const mentionTokenMatch = text
         .slice(0, selectionEnd.current)
         .match(/(?!^|\W)?@[^\s@]*\s?[^\s@]*$/g);


### PR DESCRIPTION
## 🎯 Goal

In the watercooler production app, Giphy command is disabled via dashboard. In this case, only Giphy must be disabled in the SDK.. but if Giphy is disabled, the mentions are also disabled. This should not be the case.

## 🛠 Implementation details

Remove giphy-enabled verification from the if clause that handles mentions and emojis.

## 🎨 UI Changes

NA

## 🧪 Testing

NA

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [ ] Screenshots added for visual changes
- [ ] Documentation is updated

