### PR TITLE
Fix: RTL command up

### DIFF
--- a/package/src/components/AutoCompleteInput/AutoCompleteSuggestionItem.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteSuggestionItem.tsx
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 14,
     fontWeight: 'bold',
-    paddingRight: 8,
+    paddingHorizontal: 8,
   },
 });
 


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->
This change was made to fix the padding between the titles and icons in command pop-ups that break in RTL

## 🛠 Implementation details

- switched paddingRight for paddingHorizontal so padding is maintained in both rtl and ltr

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/24194413/173497842-f6c11d7c-b829-490b-8ac6-50678ff3e739.jpg" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/24194413/175541500-b64e9fc6-4152-438c-a1f4-91050fdec35f.png" /> 
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [ ] Documentation is updated

