### PR TITLE
fix: align placeholderText to right when when in RTL

### DIFF
--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { StyleSheet, TextInput, TextInputProps } from 'react-native';
+import { I18nManager, StyleSheet, TextInput, TextInputProps } from 'react-native';
 
 import throttle from 'lodash/throttle';
 
@@ -417,6 +417,7 @@ const AutoCompleteInputWithContext = <
         {
           color: black,
           maxHeight: (textHeight || 17) * numberOfLines,
+          textAlign: I18nManager.isRTL ? 'right' : 'left',
         },
         inputBox,
       ]}

--- a/package/src/components/AutoCompleteInput/AutoCompleteSuggestionItem.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteSuggestionItem.tsx
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 14,
     fontWeight: 'bold',
-    paddingRight: 8,
+    paddingHorizontal: 8,
   },
 });
 

--- a/package/src/components/MessageInput/__tests__/__snapshots__/MessageInput.test.js.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/MessageInput.test.js.snap
@@ -286,6 +286,7 @@ Array [
                     Object {
                       "color": "#000000",
                       "maxHeight": 85,
+                      "textAlign": "left",
                     },
                     Object {},
                   ]

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -1623,6 +1623,7 @@ exports[`Thread should match thread snapshot 1`] = `
                   Object {
                     "color": "#000000",
                     "maxHeight": 85,
+                    "textAlign": "left",
                   },
                   Object {},
                 ]


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->
Cursor position and hint text position of TextInput remained in the LTR alignment even after enforcing RTL. 

## 🛠 Implementation details

- check if the app is in rtl and changed TextInput alignment accordingly

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/24194413/175532057-6b9b7307-7c6f-4412-bb71-f02f5a32c2bd.png" /> 
            </td>
            <td>
               <img src="https://user-images.githubusercontent.com/24194413/175538027-298e9c5f-f1fa-4502-a6da-709cd60bceb4.png" />
            </td>
        </tr>
    </tbody>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/24194413/175532156-0e6b67b5-d9cb-42e0-abb6-f534cf306781.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/24194413/175538012-8a0616bd-5991-444f-93b8-a6df5c3544ea.png" /> 
            </td>
        </tr>
    </tbody>
    <thead>
        <tr>
            <td>Before LTR</td>
            <td>After LTR</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/24194413/176655332-f1db31fd-c89f-417a-80fb-02aa71aedb05.png" /> 
            </td>
            <td>
               <img src="https://user-images.githubusercontent.com/24194413/176655622-c2bfa1b8-af2f-413a-81b0-88cce2477d00.png" />
            </td>
        </tr>
    </tbody>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/24194413/176654932-796ee496-b4e0-489d-b1b3-741fe761267b.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/24194413/176655811-51987981-bf0b-4ea3-991c-b0e4bcea0f2b.png" /> 
            </td>
        </tr>
    </tbody>
    </tbody>
    <thead>
        <tr>
            <td>RTL with hebrew</td>
            <td>RTL with hebrew</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/24194413/176656548-2329aae9-864a-4c06-8658-e70988bcdf5c.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/24194413/176656449-37ada810-9808-44b3-8d85-d2b9c0147f87.png" /> 
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
- [ ] New code is covered by tests
- [x] Screenshots added for visual changes
- [ ] Documentation is updated

