### PR TITLE
fix: expo media library must sort by time

### DIFF
--- a/package/expo-package/src/index.js
+++ b/package/expo-package/src/index.js
@@ -49,6 +49,7 @@ registerNativeHandlers({
         after,
         first,
         mediaType: [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video],
+        sortBy: [MediaLibrary.SortBy.modificationTime],
       });
       const assets = results.assets.map((asset) => ({
         duration: asset.duration,


### PR DESCRIPTION
## 🎯 Goal

The expo media library by default shows videos first and then pictures. However, we need it to sort by time. The native package sorts by time by default. So this change also aligns it with expo and native. This bug was informed by a customer through zendesk.

## 🛠 Implementation details

use `SortBy` prop from expo.

## 🎨 UI Changes

NA

## 🧪 Testing

Open attachment picker from expo example app.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [x] Expo iOS and Android


