### PR TITLE
fix: image and giphy sharing issue

### DIFF
--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -273,21 +273,25 @@ export const ImageGallery = <
 
     const attachmentPhotos = attachmentImages.map((a) => {
       const imageUrl = getUrlOfImageAttachment(a) as string;
+      const giphyURL = a.giphy?.[giphyVersion]?.url || a.thumb_url || a.image_url;
 
       return {
         channelId: cur.cid,
         created_at: cur.created_at,
         id: `photoId-${cur.id}-${imageUrl}`,
         messageId: cur.id,
-        mime_type: a.mime_type,
+        mime_type: a.type === 'giphy' ? 'image/gif' : a.mime_type,
         original_height: a.original_height,
         original_width: a.original_width,
         type: a.type,
-        uri: getResizedImageUrl({
-          height: screenHeight,
-          url: imageUrl,
-          width: screenWidth,
-        }),
+        uri:
+          a.type === 'giphy'
+            ? giphyURL
+            : getResizedImageUrl({
+                height: screenHeight,
+                url: imageUrl,
+                width: screenWidth,
+              }),
         user: cur.user,
         user_id: cur.user_id,
       };

--- a/package/src/components/ImageGallery/components/ImageGalleryFooter.tsx
+++ b/package/src/components/ImageGallery/components/ImageGalleryFooter.tsx
@@ -171,7 +171,8 @@ export const ImageGalleryFooterWithContext = <
         }-${selectedIndex}.${extension}`,
         fromUrl: photo.uri,
       });
-      await shareImage({ type: photo.mime_type, url: localFile });
+      // `image/jpeg` is added for the case where the mime_type isn't available for a file/image
+      await shareImage({ type: photo.mime_type ?? 'image/jpeg', url: localFile });
       await deleteFile({ uri: localFile });
     } catch (error) {
       console.log(error);

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -669,10 +669,14 @@ export const MessageInputProvider = <
         }
       }
 
+      // To get the mime type of the image from the file name and send it as an response for an image
+      const mime_type: string | boolean = lookup(image.file.filename as string);
+
       if (image.state === FileState.UPLOADED || image.state === FileState.FINISHED) {
         attachments.push({
           fallback: image.file.name,
           image_url: image.url,
+          mime_type,
           original_height: image.height,
           original_width: image.width,
           type: 'image',
@@ -689,11 +693,14 @@ export const MessageInputProvider = <
         sending.current = false;
         return;
       }
+      const mime_type: string | boolean = lookup(file.file.name as string);
+
       if (file.state === FileState.UPLOADED || file.state === FileState.FINISHED) {
         if (file.file.type?.startsWith('image/')) {
           attachments.push({
             fallback: file.file.name,
             image_url: file.url,
+            mime_type,
             type: 'image',
           } as Attachment<StreamChatGenerics>);
         } else if (file.file.type?.startsWith('audio/')) {

--- a/package/src/contexts/messageInputContext/__tests__/__snapshots__/sendMessage.test.tsx.snap
+++ b/package/src/contexts/messageInputContext/__tests__/__snapshots__/sendMessage.test.tsx.snap
@@ -6,6 +6,7 @@ Object {
     Object {
       "fallback": undefined,
       "image_url": undefined,
+      "mime_type": false,
       "original_height": undefined,
       "original_width": undefined,
       "type": "image",
@@ -65,6 +66,7 @@ Object {
     Object {
       "fallback": "dummy.pdf",
       "image_url": undefined,
+      "mime_type": "application/pdf",
       "type": "image",
     },
   ],
@@ -85,6 +87,7 @@ Object {
     Object {
       "fallback": undefined,
       "image_url": undefined,
+      "mime_type": false,
       "original_height": undefined,
       "original_width": undefined,
       "type": "image",
@@ -92,6 +95,7 @@ Object {
     Object {
       "fallback": undefined,
       "image_url": undefined,
+      "mime_type": false,
       "original_height": undefined,
       "original_width": undefined,
       "type": "image",


### PR DESCRIPTION
## 🎯 Goal

This PR fixes issue #1545 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The mime_type is calculated for the image through file name and is added in the attachments and thereby sent to the backend. Therefore, you will always get the mime_type if available. To share a file/image mime_type is an essential field for android mainly. Therefore it is made sure that the mime_type is available. For the giphy `image/gif` is added explicitly.

Note: `image/jpeg` is added on the share API by default as the attachments with no mime_type(older ones, before this change) will have mime_type as undefined, and therefore the share API won't work.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


