### PR TITLE
fix: do not quit generating changelog on merge commit

### DIFF
--- a/release/release.config.js
+++ b/release/release.config.js
@@ -55,7 +55,6 @@ module.exports = Promise.resolve().then(() => {
   return {
     extends: [`${__dirname}/monorepo-setup.js`],
     workspaces: lernaPackage.packages,
-    filterRegex: mergeRegex,
     filterPath: process.env.FILTER_PATH,
     tagFormat: process.env.TAG_FORMAT,
     parseLinkedPackages: (item) => {


### PR DESCRIPTION
## 🎯 Goal

The changelog on the current develop branch is not generated due to the presence of a merge commit. However, the presence on mergePattern on the parserOpts should ignore it anyhow. Hence, let's enable to generate changelog even if a merge commit is present.

## 🛠 Implementation details

If I removed `filterRegex: mergeRegex,` the merge commit was ignored as expected and changelog was generated. I do not know however from where this field came from. I cant find it on [official docs.](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#options)

## 🎨 UI Changes

NA

## 🧪 Testing

In the root directory, run `yarn extract-changelog` and then check `NEXT_RELEASE_CHANGELOG.md`.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


