### PR TITLE
fix: avoid use of finally as redux middlewares remove it

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -639,7 +639,7 @@ const MessageListWithContext = <
    * 2. Ensures that we call `loadMoreRecent`, once per content length
    * 3. If the call to `loadMore` is in progress, we wait for it to finish to make sure scroll doesn't jump.
    */
-  const maybeCallOnStartReached = (limit?: number) => {
+  const maybeCallOnStartReached = async (limit?: number) => {
     // If onStartReached has already been called for given data length, then ignore.
     if (messageList?.length && onStartReachedTracker.current[messageList.length]) {
       return;
@@ -664,9 +664,8 @@ const MessageListWithContext = <
 
     // If onEndReached is in progress, better to wait for it to finish for smooth UX
     if (onEndReachedInPromise.current) {
-      onEndReachedInPromise.current.finally(() => {
-        onStartReachedInPromise.current = loadMoreRecent(limit).then(callback).catch(onError);
-      });
+      await onEndReachedInPromise.current;
+      onStartReachedInPromise.current = loadMoreRecent(limit).then(callback).catch(onError);
     } else {
       onStartReachedInPromise.current = loadMoreRecent(limit).then(callback).catch(onError);
     }
@@ -677,7 +676,7 @@ const MessageListWithContext = <
    * 2. Ensures that we call `loadMore`, once per content length
    * 3. If the call to `loadMoreRecent` is in progress, we wait for it to finish to make sure scroll doesn't jump.
    */
-  const maybeCallOnEndReached = () => {
+  const maybeCallOnEndReached = async () => {
     // If onEndReached has already been called for given messageList length, then ignore.
     if (messageList?.length && onEndReachedTracker.current[messageList.length]) {
       return;
@@ -701,11 +700,10 @@ const MessageListWithContext = <
 
     // If onStartReached is in progress, better to wait for it to finish for smooth UX
     if (onStartReachedInPromise.current) {
-      onStartReachedInPromise.current.finally(() => {
-        onEndReachedInPromise.current = (threadList ? loadMoreThread() : loadMore())
-          .then(callback)
-          .catch(onError);
-      });
+      await onStartReachedInPromise.current;
+      onEndReachedInPromise.current = (threadList ? loadMoreThread() : loadMore())
+        .then(callback)
+        .catch(onError);
     } else {
       onEndReachedInPromise.current = (threadList ? loadMoreThread() : loadMore())
         .then(callback)


### PR DESCRIPTION
## 🎯 Goal

Avoid usage of finally in our SDK, as finally definition becomes undefined when certain redux middlewares are used. Example: redux-api-middleware, redux-saga middleware

The above-mentioned redux middlewares are web focused, and they use a common-js preset which removes the finally function definition inside the promise. ref: https://github.com/zloirock/core-js/issues/749. This can be patch fixed easily also. So the best fix is to avoid using finally

## 🛠 Implementation details

Replace finally with await

## 🎨 UI Changes

NA

## 🧪 Testing

open sample app from the branch `santhosjh/redux-crash-repro`. open a channel with a very short message list, say 5 messages. scroll down => crash. Merge this change to the branch then the crash will disappear.

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


