### PR TITLE
fix: added condition to render only the video thumbnail in video reply and fix styles and theming

### DIFF
--- a/package/src/components/Attachment/VideoThumbnail.tsx
+++ b/package/src/components/Attachment/VideoThumbnail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ImageBackground, StyleSheet, View, ViewProps } from 'react-native';
+import { ImageBackground, ImageStyle, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { Play } from '../../icons';
@@ -18,13 +18,23 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     borderRadius: 50,
     display: 'flex',
+    elevation: 6,
     height: 36,
     justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      height: 3,
+      width: 0,
+    },
+    shadowOpacity: 0.27,
+    shadowRadius: 4.65,
     width: 36,
   },
 });
 
-export type VideoThumbnailProps = ViewProps & {
+export type VideoThumbnailProps = {
+  imageStyle?: StyleProp<ImageStyle>;
+  style?: StyleProp<ViewStyle>;
   thumb_url?: string;
 };
 
@@ -36,12 +46,12 @@ export const VideoThumbnail: React.FC<VideoThumbnailProps> = (props) => {
       },
     },
   } = useTheme();
-  const { style, thumb_url, ...rest } = props;
+  const { imageStyle, style, thumb_url } = props;
   return (
     <ImageBackground
       accessibilityLabel='video-thumbnail'
+      imageStyle={imageStyle}
       source={{ uri: thumb_url }}
-      {...rest}
       style={[styles.container, container, style]}
     >
       <View style={[styles.roundedView, roundedView]}>

--- a/package/src/components/Reply/Reply.tsx
+++ b/package/src/components/Reply/Reply.tsx
@@ -53,12 +53,15 @@ const styles = StyleSheet.create({
   },
   text: { fontSize: 12 },
   textContainer: { maxWidth: undefined, paddingHorizontal: 8 },
-  videoAttachment: {
+  videoThumbnailContainerStyle: {
     borderRadius: 8,
     height: 50,
     marginLeft: 8,
     marginVertical: 8,
     width: 50,
+  },
+  videoThumbnailImageStyle: {
+    borderRadius: 10,
   },
 });
 
@@ -140,6 +143,10 @@ const ReplyWithContext = <
         markdownStyles,
         messageContainer,
         textContainer,
+        videoThumbnail: {
+          container: videoThumbnailContainerStyle,
+          image: videoThumbnailImageStyle,
+        },
       },
     },
   } = useTheme();
@@ -153,6 +160,7 @@ const ReplyWithContext = <
     !error &&
     lastAttachment &&
     messageType !== 'file' &&
+    messageType !== 'video' &&
     (lastAttachment.image_url || lastAttachment.thumb_url || lastAttachment.og_scrape_url);
 
   const onlyEmojis = !lastAttachment && !!quotedMessage.text && emojiRegex.test(quotedMessage.text);
@@ -207,7 +215,11 @@ const ReplyWithContext = <
           ) : null
         ) : null}
         {messageType === 'video' && !lastAttachment.og_scrape_url ? (
-          <VideoThumbnail style={[styles.videoAttachment]} />
+          <VideoThumbnail
+            imageStyle={[styles.videoThumbnailImageStyle, videoThumbnailImageStyle]}
+            style={[styles.videoThumbnailContainerStyle, videoThumbnailContainerStyle]}
+            thumb_url={lastAttachment.thumb_url}
+          />
         ) : null}
         <MessageTextContainer<StreamChatGenerics>
           markdownStyles={

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -529,6 +529,10 @@ export type Theme = {
     markdownStyles: MarkdownStyle;
     messageContainer: ViewStyle;
     textContainer: ViewStyle;
+    videoThumbnail: {
+      container: ViewStyle;
+      image: ImageStyle;
+    };
   };
   screenPadding: number;
   spinner: ViewStyle;
@@ -1058,6 +1062,10 @@ export const defaultTheme: Theme = {
     markdownStyles: {},
     messageContainer: {},
     textContainer: {},
+    videoThumbnail: {
+      container: {},
+      image: {},
+    },
   },
   screenPadding: 8,
   spinner: {},


### PR DESCRIPTION
## 🎯 Goal

The PR fixes the Video reply UI in the message list.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

Initially, the thumbnail and the image were rendered separately. This is fixed by adding a condition and the design of the video thumbnail is fixed thereby.

PS: Refer screenshots for more details.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/39884168/179487191-22924e34-c79e-4681-b166-c86a424fbd5c.png" /> 
            </td>
            <td>
               <img src="https://user-images.githubusercontent.com/39884168/179487132-5a6ef7ee-0475-49ae-9ff9-09c2736b9fd2.png" /> 
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


