### PR TITLE
fix: overwriting of the translation files when running test or build script

### DIFF
--- a/package/.babelrc
+++ b/package/.babelrc
@@ -16,24 +16,6 @@
       "compact": false
     }
   ],
-  "plugins": [
-    [
-      "i18next-extract",
-      {
-        "contextSeparator": "__",
-        "defaultContexts": [""],
-        "defaultNS": "en",
-        "locales": ["en", "fr", "hi", "it", "nl", "ru", "tr"],
-        "jsonSpace": 4,
-        "keySeparator": null,
-        "nsSeparator": null,
-        "keyAsDefaultValue": ["en"],
-        "keyAsDefaultValueForDerivedKeys": false,
-        "outputPath": "src/i18n/{{locale}}.json",
-        "discardOldKeys": true
-      }
-    ],
-    "module-resolver"
-  ],
+  "plugins": ["module-resolver"],
   "presets": ["@babel/env", "module:metro-react-native-babel-preset"]
 }

--- a/package/babel.config.js
+++ b/package/babel.config.js
@@ -9,26 +9,7 @@ module.exports = (api) => {
           compact: false,
         },
       ],
-      plugins: [
-        [
-          'i18next-extract',
-          {
-            contextSeparator: '__',
-            defaultContexts: [''],
-            defaultNS: 'en',
-            discardOldKeys: true,
-            jsonSpace: 4,
-            keyAsDefaultValue: ['en'],
-            keyAsDefaultValueForDerivedKeys: false,
-            keySeparator: null,
-            locales: ['en', 'fr', 'hi', 'it', 'nl', 'ru', 'tr'],
-            nsSeparator: null,
-            outputPath: 'src/i18n/{{locale}}.json',
-          },
-        ],
-        'module-resolver',
-        'react-native-reanimated/plugin',
-      ],
+      plugins: ['module-resolver', 'react-native-reanimated/plugin'],
       presets: ['@babel/env', 'module:metro-react-native-babel-preset', '@babel/preset-typescript'],
     };
   }
@@ -51,25 +32,7 @@ module.exports = (api) => {
         compact: false,
       },
     ],
-    plugins: [
-      [
-        'i18next-extract',
-        {
-          contextSeparator: '__',
-          defaultContexts: [''],
-          defaultNS: 'en',
-          discardOldKeys: true,
-          jsonSpace: 4,
-          keyAsDefaultValue: ['en'],
-          keyAsDefaultValueForDerivedKeys: false,
-          keySeparator: null,
-          locales: ['nl', 'en', 'it', 'tr', 'fr', 'hi', 'ru'],
-          nsSeparator: null,
-          outputPath: 'src/i18n/{{locale}}.json',
-        },
-      ],
-      'module-resolver',
-    ],
+    plugins: ['module-resolver'],
     presets: ['@babel/env', 'module:metro-react-native-babel-preset', '@babel/preset-typescript'],
   };
 };

--- a/package/package.json
+++ b/package/package.json
@@ -113,7 +113,7 @@
     "babel-eslint": "10.1.0",
     "babel-jest": "26.6.3",
     "babel-loader": "8.2.2",
-    "babel-plugin-i18next-extract": "0.8.3",
+    "babel-plugin-i18next-extract": "^0.8.3",
     "babel-plugin-module-resolver": "4.1.0",
     "babel-plugin-react-native-web": "0.16.3",
     "eslint": "7.32.0",

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -426,12 +426,12 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.9.5":
+"@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
-"@babel/helper-validator-identifier@^7.18.6":
+"@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.9.5":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
@@ -3160,7 +3160,7 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-i18next-extract@0.8.3:
+babel-plugin-i18next-extract@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-i18next-extract/-/babel-plugin-i18next-extract-0.8.3.tgz#4b1c279f5ac607c96b6b71074dd15842b5c21df0"
   integrity sha512-ZBhGjP2nLF3pGJO/X6s8DlyUo8zkuPQ09sGZK4XGqtJit/ccj8zocO5JI/F+oFZgKVH1tN8pAQT4fm0JWk2SIQ==
@@ -6853,7 +6853,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
 json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  integrity sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==
   dependencies:
     jsonify "~0.0.0"
 


### PR DESCRIPTION
## 🎯 Goal

This PR fixes the issue of overwriting the translation files every time we run the build/test script.
<!-- Describe why we are making this change -->

## 🛠 Implementation details

The plugin is removed from the `babel.config.js` and `.babelrc`. This is still used under the `build-translations` script so it doesn't need to be present in the config files. The overwriting was probably because of its usage at two places, but the clean-up was done only once.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


