### PR TITLE
fix: add pathFill to the image and file upload Close icon

### DIFF
--- a/package/src/components/MessageInput/FileUploadPreview.tsx
+++ b/package/src/components/MessageInput/FileUploadPreview.tsx
@@ -132,7 +132,7 @@ const FileUploadPreviewWithContext = <
 
   const {
     theme: {
-      colors: { black, grey_whisper, overlay },
+      colors: { black, grey_dark, grey_gainsboro, grey_whisper },
       messageInput: {
         fileUploadPreview: {
           dismiss,
@@ -209,10 +209,10 @@ const FileUploadPreviewWithContext = <
           onPress={() => {
             removeFile(item.id);
           }}
-          style={[styles.dismiss, { backgroundColor: overlay }, dismiss]}
+          style={[styles.dismiss, { backgroundColor: grey_gainsboro }, dismiss]}
           testID='remove-file-upload-preview'
         >
-          <Close />
+          <Close pathFill={grey_dark} />
         </TouchableOpacity>
       </>
     );

--- a/package/src/components/MessageInput/ImageUploadPreview.tsx
+++ b/package/src/components/MessageInput/ImageUploadPreview.tsx
@@ -87,7 +87,7 @@ const ImageUploadPreviewWithContext = <
 
   const {
     theme: {
-      colors: { overlay },
+      colors: { overlay, white },
       messageInput: {
         imageUploadPreview: { dismiss, flatList, itemContainer, upload },
       },
@@ -147,7 +147,7 @@ const ImageUploadPreviewWithContext = <
           style={[styles.dismiss, { backgroundColor: overlay }, dismiss]}
           testID='remove-image-upload-preview'
         >
-          <Close />
+          <Close pathFill={white} />
         </TouchableOpacity>
         <UnsupportedImageTypeIndicator indicatorType={indicatorType} />
       </View>


### PR DESCRIPTION
## 🎯 Goal

Fixes - #1571 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The appropriate colours are added in accordance with the design for the File and Image upload preview.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

![simulator_screenshot_7AD5DFA6-A194-4B20-ADB6-F5CCADDCC569](https://user-images.githubusercontent.com/39884168/179933898-f1a0ee8b-7251-4634-88c7-1642307409da.png)

![simulator_screenshot_A35D2CDC-4304-49A6-9785-E54A07555C93](https://user-images.githubusercontent.com/39884168/179933973-0105718a-1ffe-482f-bc07-bfdc5e6d2fec.png)

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


