### PR TITLE
fix: image sharing in android

### DIFF
--- a/package/src/components/ImageGallery/components/ImageGalleryFooter.tsx
+++ b/package/src/components/ImageGallery/components/ImageGalleryFooter.tsx
@@ -164,7 +164,7 @@ export const ImageGalleryFooterWithContext = <
   const share = async () => {
     setShareMenuOpen(true);
     try {
-      const extension = photo.mime_type ? photo.mime_type?.split('/')[1] : 'jpg';
+      const extension = photo.mime_type?.split('/')[1] || 'jpg';
       const localFile = await saveFile({
         fileName: `${photo.user?.id || 'ChatPhoto'}-${
           photo.messageId

--- a/package/src/components/ImageGallery/components/ImageGalleryFooter.tsx
+++ b/package/src/components/ImageGallery/components/ImageGalleryFooter.tsx
@@ -164,7 +164,7 @@ export const ImageGalleryFooterWithContext = <
   const share = async () => {
     setShareMenuOpen(true);
     try {
-      const extension = photo.mime_type?.split('/')[1] || 'jpg';
+      const extension = photo.mime_type ? photo.mime_type?.split('/')[1] : 'jpg';
       const localFile = await saveFile({
         fileName: `${photo.user?.id || 'ChatPhoto'}-${
           photo.messageId
@@ -172,7 +172,7 @@ export const ImageGalleryFooterWithContext = <
         fromUrl: photo.uri,
       });
       // `image/jpeg` is added for the case where the mime_type isn't available for a file/image
-      await shareImage({ type: photo.mime_type ?? 'image/jpeg', url: localFile });
+      await shareImage({ type: photo.mime_type || 'image/jpeg', url: localFile });
       await deleteFile({ uri: localFile });
     } catch (error) {
       console.log(error);
@@ -206,7 +206,7 @@ export const ImageGalleryFooterWithContext = <
           ) : (
             <TouchableOpacity disabled={shareMenuOpen} onPress={share}>
               <View style={[styles.leftContainer, leftContainer]}>
-                {ShareIcon ? ShareIcon : <ShareIconDefault />}
+                {ShareIcon ? ShareIcon : <ShareIconDefault pathFill={black} />}
               </View>
             </TouchableOpacity>
           )}

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -700,9 +700,9 @@ export const MessageInputProvider = <
           attachments.push({
             fallback: file.file.name,
             image_url: file.url,
-            mime_type,
+            mime_type: mime_type ? mime_type : undefined,
             type: 'image',
-          } as Attachment<StreamChatGenerics>);
+          });
         } else if (file.file.type?.startsWith('audio/')) {
           attachments.push({
             asset_url: file.url,
@@ -711,7 +711,7 @@ export const MessageInputProvider = <
             mime_type: file.file.type,
             title: file.file.name,
             type: 'audio',
-          } as Attachment<StreamChatGenerics>);
+          });
         } else if (file.file.type?.startsWith('video/')) {
           attachments.push({
             asset_url: file.url,
@@ -721,7 +721,7 @@ export const MessageInputProvider = <
             thumb_url: file.thumb_url,
             title: file.file.name,
             type: 'video',
-          } as Attachment<StreamChatGenerics>);
+          });
         } else {
           attachments.push({
             asset_url: file.url,
@@ -729,7 +729,7 @@ export const MessageInputProvider = <
             mime_type: file.file.type,
             title: file.file.name,
             type: 'file',
-          } as Attachment<StreamChatGenerics>);
+          });
         }
       }
     }

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -676,11 +676,11 @@ export const MessageInputProvider = <
         attachments.push({
           fallback: image.file.name,
           image_url: image.url,
-          mime_type,
+          mime_type: mime_type ? mime_type : undefined,
           original_height: image.height,
           original_width: image.width,
           type: 'image',
-        } as Attachment<StreamChatGenerics>);
+        });
       }
     }
 

--- a/package/src/contexts/messageInputContext/__tests__/__snapshots__/sendMessage.test.tsx.snap
+++ b/package/src/contexts/messageInputContext/__tests__/__snapshots__/sendMessage.test.tsx.snap
@@ -6,7 +6,7 @@ Object {
     Object {
       "fallback": undefined,
       "image_url": undefined,
-      "mime_type": false,
+      "mime_type": undefined,
       "original_height": undefined,
       "original_width": undefined,
       "type": "image",
@@ -87,7 +87,7 @@ Object {
     Object {
       "fallback": undefined,
       "image_url": undefined,
-      "mime_type": false,
+      "mime_type": undefined,
       "original_height": undefined,
       "original_width": undefined,
       "type": "image",
@@ -95,7 +95,7 @@ Object {
     Object {
       "fallback": undefined,
       "image_url": undefined,
-      "mime_type": false,
+      "mime_type": undefined,
       "original_height": undefined,
       "original_width": undefined,
       "type": "image",


### PR DESCRIPTION
## 🎯 Goal

This PR fixes the issues with sharing an image from android and ios devices.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The condition for mime_type availability is added to fix the issue. The colour of the share icon is also fixed for dark mode.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


