### PR TITLE
fix: reposition image error indicator

### DIFF
--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -62,6 +62,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     position: 'absolute',
   },
+  imageLoadingErrorIndicatorStyle: {
+    position: 'absolute',
+    bottom: 4,
+    left: 4,
+  },
   moreImagesContainer: {
     alignItems: 'center',
     justifyContent: 'center',
@@ -317,9 +322,6 @@ const GalleryThumbnail = <
   thumbnail,
   VideoThumbnail,
 }: GalleryThumbnailProps<StreamChatGenerics>) => {
-  const { isLoadingImage, isLoadingImageError, setLoadingImage, setLoadingImageError } =
-    useLoadingImage();
-
   const {
     theme: {
       colors: { overlay },
@@ -409,6 +411,65 @@ const GalleryThumbnail = <
         />
       ) : (
         <View style={styles.imageContainerStyle}>
+          <GalleryImageThumbnail
+            borderRadius={borderRadius}
+            ImageLoadingFailedIndicator={ImageLoadingFailedIndicator}
+            ImageLoadingIndicator={ImageLoadingIndicator}
+            thumbnail={thumbnail}
+          />
+        </View>
+      )}
+      {colIndex === numOfColumns - 1 && rowIndex === numOfRows - 1 && imagesAndVideos.length > 4 ? (
+        <View
+          style={[
+            StyleSheet.absoluteFillObject,
+            styles.moreImagesContainer,
+            { backgroundColor: overlay },
+            moreImagesContainer,
+          ]}
+        >
+          <Text style={[styles.moreImagesText, moreImagesText]}>
+            {`+${imagesAndVideos.length - 4}`}
+          </Text>
+        </View>
+      ) : null}
+    </TouchableOpacity>
+  );
+};
+
+const GalleryImageThumbnail = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+>({
+  borderRadius,
+  ImageLoadingFailedIndicator,
+  ImageLoadingIndicator,
+  thumbnail,
+}: Pick<
+  GalleryThumbnailProps<StreamChatGenerics>,
+  'ImageLoadingFailedIndicator' | 'ImageLoadingIndicator' | 'thumbnail' | 'borderRadius'
+>) => {
+  const { isLoadingImage, isLoadingImageError, setLoadingImage, setLoadingImageError } =
+    useLoadingImage();
+
+  const {
+    theme: {
+      messageSimple: {
+        gallery: { image },
+      },
+    },
+  } = useTheme();
+
+  return (
+    <View
+      style={{
+        height: thumbnail.height - 1,
+        width: thumbnail.width - 1,
+      }}
+    >
+      {isLoadingImageError ? (
+        <ImageLoadingFailedIndicator style={[styles.imageLoadingErrorIndicatorStyle]} />
+      ) : (
+        <>
           <MemoizedGalleryImage
             onError={(error) => {
               console.warn(error);
@@ -433,28 +494,9 @@ const GalleryThumbnail = <
               <ImageLoadingIndicator style={styles.imageLoadingIndicatorStyle} />
             </View>
           )}
-          {isLoadingImageError && (
-            <View style={{ position: 'absolute' }}>
-              <ImageLoadingFailedIndicator style={styles.imageLoadingIndicatorStyle} />
-            </View>
-          )}
-        </View>
+        </>
       )}
-      {colIndex === numOfColumns - 1 && rowIndex === numOfRows - 1 && imagesAndVideos.length > 4 ? (
-        <View
-          style={[
-            StyleSheet.absoluteFillObject,
-            styles.moreImagesContainer,
-            { backgroundColor: overlay },
-            moreImagesContainer,
-          ]}
-        >
-          <Text style={[styles.moreImagesText, moreImagesText]}>
-            {`+${imagesAndVideos.length - 4}`}
-          </Text>
-        </View>
-      ) : null}
-    </TouchableOpacity>
+    </View>
   );
 };
 


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


