### PR TITLE
fix: allow pound sign in link paths

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/parseLinks.test.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.test.ts
@@ -22,6 +22,10 @@ describe('parseLinksFromText', () => {
     ],
     ['127.0.0.1/local_(development)_server', '127.0.0.1/local_(development)_server'],
     ['https://a.co:8999/ab.php?p=12', 'a.co:8999/ab.php?p=12'],
+    [
+      'http://help.apple.com/xcode/mac/current/#/devba7f53ad4',
+      'help.apple.com/xcode/mac/current/#/devba7f53ad4',
+    ],
   ])('Returns the encoded value of %p as %p', (link, expected) => {
     const result = parseLinksFromText(link);
 

--- a/package/src/components/Message/MessageSimple/utils/parseLinks.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.ts
@@ -11,7 +11,7 @@ const schema = `(\\w{2,15}:\\/\\/)`;
 // something.tld OR 123.123.123.123
 const domain = `((?:\\w+\\.[a-zA-Z]+)+(?:[^:\\/\\s]+)|(?:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}))`;
 const port = `(:[0-9]{1,5})`;
-const path = `((?:\\/)?[^?#\\s]+)`;
+const path = `((?:\\/)?[^?\\s]+)`;
 const queryString = `(\\?[^#\\s]+)`;
 const fragment = `(#[\\w_-]+)`;
 


### PR DESCRIPTION
## 🎯 Goal

In the watercooler app, we noticed that a URL including `#` in its path got cut off at `#` when parsed as a link.

This PR should fix this.

## 🛠 Implementation details

Regex is modified to allow the symbol

## 🧪 Testing

Send a message containing a link with a pound sign in the path, and see that it's made into a link in its entirety. The URL that caught the issue is `http://help.apple.com/xcode/mac/current/#/devba7f53ad4`

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


