### PR TITLE
chore: update ios sample app build number

### DIFF
--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - develop
+
+concurrency:
+  group: sample-distribution
+  cancel-in-progress: true
+
 jobs:
   build_and_deploy_ios_testflight_qa:
     runs-on: [macos-latest]

--- a/examples/SampleApp/ios/SampleApp.xcodeproj/project.pbxproj
+++ b/examples/SampleApp/ios/SampleApp.xcodeproj/project.pbxproj
@@ -514,7 +514,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SampleApp/SampleAppDebug.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 144;
+				CURRENT_PROJECT_VERSION = 145;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = SampleApp/Info.plist;
@@ -545,7 +545,7 @@
 				CODE_SIGN_ENTITLEMENTS = SampleApp/SampleAppRelease.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 144;
+				CURRENT_PROJECT_VERSION = 145;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = SampleApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/examples/SampleApp/ios/SampleApp/Info.plist
+++ b/examples/SampleApp/ios/SampleApp/Info.plist
@@ -21,7 +21,7 @@
 		<key>CFBundleSignature</key>
 		<string>????</string>
 		<key>CFBundleVersion</key>
-		<string>141</string>
+		<string>145</string>
 		<key>LSRequiresIPhoneOS</key>
 		<true />
 		<key>NSAppTransportSecurity</key>

--- a/examples/SampleApp/ios/SampleAppTests/Info.plist
+++ b/examples/SampleApp/ios/SampleAppTests/Info.plist
@@ -19,6 +19,6 @@
 		<key>CFBundleSignature</key>
 		<string>????</string>
 		<key>CFBundleVersion</key>
-		<string>144</string>
+		<string>145</string>
 	</dict>
 </plist>


### PR DESCRIPTION
## 🎯 Goal

The sample app distribution failed because the build number at the app store hasn't been pushed by the GH action.

## 🛠 Implementation details

* `bundle exec fastlane run increment_build_number xcodeproj:"./ios/SampleApp.xcodeproj"`
* [disable concurrent distributions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


