### PR TITLE
fix(docs): ios foreground push notifications

### DIFF
--- a/docusaurus/docs/reactnative/guides/push_notifications_v2.mdx
+++ b/docusaurus/docs/reactnative/guides/push_notifications_v2.mdx
@@ -559,7 +559,7 @@ useEffect(() => {
     await notifee.displayNotification({
       title: 'New message from ' + message.message.user.name,
       body: message.message.text,
-      data: remoteMessage.data,
+      data,
       android: {
         channelId,
         pressAction: {

--- a/docusaurus/docs/reactnative/guides/push_notifications_v2.mdx
+++ b/docusaurus/docs/reactnative/guides/push_notifications_v2.mdx
@@ -279,10 +279,15 @@ messaging().setBackgroundMessageHandler(async remoteMessage => {
   });
 
   // display the notification
+  const { stream, ...rest } = remoteMessage.data ?? {};
+  const data = {
+    ...rest,
+    ...((stream as unknown as Record<string, string> | undefined) ?? {}), // extract and merge stream object if present
+  };
   await notifee.displayNotification({
     title: 'New message from ' + message.message.user.name,
     body: message.message.text,
-    data: remoteMessage.data,
+    data,
     android: {
       channelId,
       // add a press action to open the app on press
@@ -546,6 +551,11 @@ useEffect(() => {
     });
 
     // display the notification
+    const { stream, ...rest } = remoteMessage.data ?? {};
+    const data = {
+      ...rest,
+      ...((stream as unknown as Record<string, string> | undefined) ?? {}), // extract and merge stream object if present
+    };
     await notifee.displayNotification({
       title: 'New message from ' + message.message.user.name,
       body: message.message.text,

--- a/examples/SampleApp/src/hooks/useChatClient.ts
+++ b/examples/SampleApp/src/hooks/useChatClient.ts
@@ -45,6 +45,11 @@ messaging().setBackgroundMessageHandler(async (remoteMessage) => {
   });
 
   if (message.message.user?.name && message.message.text) {
+    const { stream, ...rest } = remoteMessage.data ?? {};
+    const data = {
+      ...rest,
+      ...((stream as unknown as Record<string, string> | undefined) ?? {}), // extract and merge stream object if present
+    };
     await notifee.displayNotification({
       android: {
         channelId,
@@ -53,7 +58,7 @@ messaging().setBackgroundMessageHandler(async (remoteMessage) => {
         },
       },
       body: message.message.text,
-      data: remoteMessage.data,
+      data,
       title: 'New message from ' + message.message.user.name,
     });
   }
@@ -111,6 +116,11 @@ export const useChatClient = () => {
             name: 'Foreground Messages',
           });
           // display the notification on foreground
+          const { stream, ...rest } = remoteMessage.data ?? {};
+          const data = {
+            ...rest,
+            ...((stream as unknown as Record<string, string> | undefined) ?? {}), // extract and merge stream object if present
+          };
           await notifee.displayNotification({
             android: {
               channelId,
@@ -119,7 +129,7 @@ export const useChatClient = () => {
               },
             },
             body: message.message.text,
-            data: remoteMessage.data,
+            data,
             title: 'New message from ' + message.message.user.name,
           });
         }


### PR DESCRIPTION
## 🎯 Goal

iOS foreground notifications are not working anymore due to the new presence of stream object in the data payload from the default template. This PR aims to correct it through the docs and sample app implementation. 

## 🛠 Implementation details

extract the payload and add it to a new object.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


