### PR TITLE
docs: update gif library needs for android

### DIFF
--- a/docusaurus/docs/reactnative/basics/troubleshooting.mdx
+++ b/docusaurus/docs/reactnative/basics/troubleshooting.mdx
@@ -236,17 +236,15 @@ You will need to add some modules in your `android/app/build.gradle`
 
 ```java
 dependencies {
-  // For Android versions less than Ice Cream Sandwich (API level 14)
-  implementation 'com.facebook.fresco:animated-base-support:1.3.0'
+  // For animated GIF support
+  implementation 'com.facebook.fresco:animated-gif:2.6.0'
 
-  // For GIF support
-  implementation 'com.facebook.fresco:animated-gif:2.0.0'
+  // For WebP support, including animated WebP
+  implementation 'com.facebook.fresco:animated-webp:2.6.0'
+  implementation 'com.facebook.fresco:webpsupport:2.6.0'
 
-  // For WebP support, with animations
-  implementation 'com.facebook.fresco:animated-webp:2.1.0'
-
-  // For WebP support, without animations
-  implementation 'com.facebook.fresco:webpsupport:2.0.0'
+  // Provide the Android support library (you might already have this or a similar dependency)
+  implementation 'com.android.support:support-core-utils:24.2.1'
   ...
 }
 ```


### PR DESCRIPTION
## 🎯 Goal

While adding giphy support for Android in watercooler app, realized that animated webp is essential. Also, our docs mention ice cream sandwich which are outdated now.

## 🛠 Implementation details

Align the troubleshooting docs to the latest fresco getting started page: https://frescolib.org/docs/

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

NA

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


