### PR TITLE
fix: broken touch listeners on message overlay

### DIFF
--- a/package/src/components/MessageOverlay/MessageOverlay.tsx
+++ b/package/src/components/MessageOverlay/MessageOverlay.tsx
@@ -327,7 +327,6 @@ const MessageOverlayWithContext = <
                     <Animated.View style={[styles.flex, panStyle]}>
                       {message && (
                         <View
-                          pointerEvents='none'
                           style={[
                             styles.center,
                             styles.overlayPadding,
@@ -363,6 +362,7 @@ const MessageOverlayWithContext = <
                               <MessageAvatar {...{ alignment, message, showAvatar: true }} />
                             )}
                             <View
+                              pointerEvents='none'
                               style={[
                                 styles.containerInner,
                                 {


### PR DESCRIPTION
## 🎯 Goal

The commit cc3d391e1841faa8b7c1e35000f21c03d87c1d8c was supposed to block the touch on audio play button on message overlay. But it blocks every touch listeners in the overlay. This PR aims to fix it.

## 🛠 Implementation details

Move pointerEvents="none" to the child container that is 1 level deeper

## 🎨 UI Changes

NA

## 🧪 Testing

Long press on audio attachment.
- tap on play button -> nothing should happen
- give a reaction -> reaction works
- press reply -> we get reply on message input

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


