### PR TITLE
fix: reactions and pinning are not updating on attachments

### DIFF
--- a/package/src/components/Attachment/Card.tsx
+++ b/package/src/components/Attachment/Card.tsx
@@ -309,6 +309,7 @@ export const Card = <
 
   return (
     <MemoizedCard
+      key={`${message?.id}${message?.updated_at}`} // press listeners must change on message update, updating key ensures this
       {...{
         additionalTouchableProps,
         CardCover,

--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -525,7 +525,9 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
     videos: nextVideos,
   } = nextProps;
 
-  const messageEqual = prevMessage?.id === nextMessage?.id;
+  const messageEqual =
+    prevMessage?.id === nextMessage?.id &&
+    `${prevMessage?.updated_at}` === `${nextMessage?.updated_at}`;
   if (!messageEqual) return false;
 
   const groupStylesEqual =

--- a/package/src/components/Attachment/Giphy.tsx
+++ b/package/src/components/Attachment/Giphy.tsx
@@ -392,11 +392,13 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
     attachment: { actions: prevActions, image_url: prevImageUrl, thumb_url: prevThumbUrl },
     giphyVersion: prevGiphyVersion,
     isMyMessage: prevIsMyMessage,
+    message: prevMessage,
   } = prevProps;
   const {
     attachment: { actions: nextActions, image_url: nextImageUrl, thumb_url: nextThumbUrl },
     giphyVersion: nextGiphyVersion,
     isMyMessage: nextIsMyMessage,
+    message: nextMessage,
   } = nextProps;
 
   const imageUrlEqual = prevImageUrl === nextImageUrl;
@@ -419,6 +421,11 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
   const isMyMessageEqual = prevIsMyMessage === nextIsMyMessage;
   if (!isMyMessageEqual) return false;
 
+  const messageEqual =
+    prevMessage?.id === nextMessage?.id &&
+    `${prevMessage?.updated_at}` === `${nextMessage?.updated_at}`;
+
+  if (!messageEqual) return false;
   return true;
 };
 

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -763,7 +763,7 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
     prevMessage.type === nextMessage.type &&
     prevMessage.text === nextMessage.text &&
     prevMessage.pinned === nextMessage.pinned &&
-    prevMessage.updated_at === nextMessage.updated_at;
+    `${prevMessage?.updated_at}` === `${nextMessage?.updated_at}`;
 
   if (!messageEqual) return false;
 


### PR DESCRIPTION
## 🎯 Goal

When using a long press to pin or give reactions in Attachments, the state does not update unless you close the chat screen and return. This PR aims to fix it.

- fixes #1543 

## 🛠 Implementation details

I used `${prevMessage?.updated_at} === ${nextMessage?.updated_at}` to see if the message was updated and then used it to remove the memoization on the attachment when its reactions or pinning state was updated. 

## 🎨 UI Changes

NA

## 🧪 Testing

1. Long press on any GIF or image.
2. Select "Pin to conversation".
3. Long press again, it should show "Unpin from conversation".

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


