### PR TITLE
build: use ios build number from app store and add pods caching

### DIFF
--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -30,6 +30,13 @@ jobs:
             yarn && yarn bootstrap-ci;
             cd package/native-package
             yarn;
+      - name: Cache iOS pods
+        uses: actions/cache@v2
+        with:
+          path: examples/SampleApp/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('examples/SampleApp/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
       - name: iOS Pods setup
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -3,7 +3,7 @@ name: sample-distribution
 on:
   push:
     branches:
-      - santhosh/get-version-from-app-store
+      - develop
 
 concurrency:
   group: sample-distribution

--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -3,7 +3,7 @@ name: sample-distribution
 on:
   push:
     branches:
-      - develop
+      - santhosh/get-version-from-app-store
 
 concurrency:
   group: sample-distribution

--- a/examples/SampleApp/fastlane/Fastfile
+++ b/examples/SampleApp/fastlane/Fastfile
@@ -85,6 +85,7 @@ platform :ios do
       package = load_json(json_path: "./package.json")
       increment_version_number(version_number: package["version"], xcodeproj: "./ios/SampleApp.xcodeproj")
       current_build_number = app_store_build_number(
+        live: false,
         app_identifier: "io.getstream.reactnative.SampleApp",
       )
       increment_build_number(

--- a/examples/SampleApp/fastlane/Fastfile
+++ b/examples/SampleApp/fastlane/Fastfile
@@ -84,7 +84,13 @@ platform :ios do
 
       package = load_json(json_path: "./package.json")
       increment_version_number(version_number: package["version"], xcodeproj: "./ios/SampleApp.xcodeproj")
-      increment_build_number(xcodeproj: "./ios/SampleApp.xcodeproj")
+      current_build_number = app_store_build_number(
+        app_identifier: "io.getstream.reactnative.SampleApp",
+      )
+      increment_build_number(
+        build_number: current_build_number + 1,
+        xcodeproj: "./ios/SampleApp.xcodeproj"
+      )
 
       gym(
           workspace: "./ios/SampleApp.xcworkspace",
@@ -112,12 +118,5 @@ platform :ios do
         end
       end
 
-      commit_version_bump(
-        message: "[fastlane][ios] Bump version [skip ci]",
-        xcodeproj: "./ios/SampleApp.xcodeproj",
-        force: true # otherwise untracked files may crash the CI build
-      )
-
-      push_to_git_remote()
   end
 end


### PR DESCRIPTION
## 🎯 Goal

- Getting ios build number from app store would be better than having it in codebase because of the non triggering changelog previews in the "next release" PRs.
- Setting up pods take a lot of time now. This can be saved by caching it. 

## 🛠 Implementation details

NA

## 🎨 UI Changes

NA

## 🧪 Testing

NA

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


