### PR TITLE
fix: allow overriding message from props on gallery component

### DIFF
--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -580,6 +580,7 @@ export const Gallery = <
     ImageLoadingFailedIndicator: PropImageLoadingFailedIndicator,
     ImageLoadingIndicator: PropImageLoadingIndicator,
     images: propImages,
+    message: propMessage,
     onLongPress: propOnLongPress,
     onPress: propOnPress,
     onPressIn: propOnPressIn,
@@ -596,7 +597,7 @@ export const Gallery = <
     alignment: contextAlignment,
     groupStyles: contextGroupStyles,
     images: contextImages,
-    message,
+    message: contextMessage,
     onLongPress: contextOnLongPress,
     onPress: contextOnPress,
     onPressIn: contextOnPressIn,
@@ -615,6 +616,7 @@ export const Gallery = <
 
   const images = propImages || contextImages;
   const videos = propVideos || contextVideos;
+  const message = propMessage || contextMessage;
 
   if (!images.length && !videos.length) return null;
 


### PR DESCRIPTION
## 🎯 Goal

Resolves the following
- GH issue #1618
- ZD ticket https://getstream.zendesk.com/agent/tickets/25050

Architectural design of our component is such that they access required values from contexts but those values can be overriden from props if needed.  In this particular case, Gallery component uses `message` from MessageContext, but message is missing in its prop. So there is no way to override the underlying message in Gallery component.

I am marking this as bug since it goes against our intention of component designs and seems like something we missed.

## 🛠 Implementation details

Added message prop to Gallery component.

## 🎨 UI Changes

NO UI CHANGES

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


