### PR TITLE
fix: channel preview message only updates on the first last message

### DIFF
--- a/package/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreview.tsx
@@ -78,9 +78,12 @@ const ChannelPreviewWithContext = <
     };
 
     const handleUpdatedOrDeletedMessage = (event: Event<StreamChatGenerics>) => {
-      if (event.message?.id === lastMessage?.id) {
-        setLastMessage(event.message);
-      }
+      setLastMessage((prevLastMessage) => {
+        if (prevLastMessage?.id === event.message?.id) {
+          return event.message;
+        }
+        return prevLastMessage;
+      });
     };
 
     const listeners = [


### PR DESCRIPTION
## 🎯 Goal

- Fixes https://getstream.zendesk.com/agent/tickets/26263 (2nd part)

Deleting/Updating messages doesn't always update in the channel preview. 

## 🛠 Implementation details

NA

## 🎨 UI Changes

NA

## 🧪 Testing

Delete or update a message in the chat in one device and see the preview on the other. The preview must correspondingly update. Send a few new messages and test updating each one of them. The preview must update. 

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


