### PR TITLE
feat: add asset url for file attachment's press event emitter

### DIFF
--- a/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
@@ -34,6 +34,11 @@ For example:
             return;
           }
 
+          if (emitter === 'fileAttachment') {
+            console.log(additionalInfo?.attachment);
+            return;
+          }
+
           defaultHandler?.();
       }}
     >

--- a/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
@@ -29,7 +29,7 @@ For example:
             return;
           }
 
-          if (emitter === 'card' || emitter === 'textLink' || emitter === 'fileAttachment') {
+          if (emitter === 'card' || emitter === 'textLink') {
             console.log(additionalInfo?.url);
             return;
           }

--- a/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
@@ -29,13 +29,8 @@ For example:
             return;
           }
 
-          if (emitter === 'card' || emitter === 'textLink') {
+          if (emitter === 'card' || emitter === 'textLink' || emitter === 'fileAttachment') {
             console.log(additionalInfo?.url);
-            return;
-          }
-
-          if (emitter === 'fileAttachment') {
-            console.log(additionalInfo?.assetUrl);
             return;
           }
 

--- a/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/channel/props/on_press_message.mdx
@@ -34,6 +34,11 @@ For example:
             return;
           }
 
+          if (emitter === 'fileAttachment') {
+            console.log(additionalInfo?.assetUrl);
+            return;
+          }
+
           defaultHandler?.();
       }}
     >

--- a/package/src/components/Attachment/FileAttachment.tsx
+++ b/package/src/components/Attachment/FileAttachment.tsx
@@ -103,7 +103,7 @@ const FileAttachmentWithContext = <
       onLongPress={(event) => {
         if (onLongPress) {
           onLongPress({
-            additionalInfo: { url: attachment.asset_url },
+            additionalInfo: { attachment },
             emitter: 'fileAttachment',
             event,
           });
@@ -112,7 +112,7 @@ const FileAttachmentWithContext = <
       onPress={(event) => {
         if (onPress) {
           onPress({
-            additionalInfo: { url: attachment.asset_url },
+            additionalInfo: { attachment },
             defaultHandler: defaultOnPress,
             emitter: 'fileAttachment',
             event,
@@ -122,7 +122,7 @@ const FileAttachmentWithContext = <
       onPressIn={(event) => {
         if (onPressIn) {
           onPressIn({
-            additionalInfo: { url: attachment.asset_url },
+            additionalInfo: { attachment },
             defaultHandler: defaultOnPress,
             emitter: 'fileAttachment',
             event,

--- a/package/src/components/Attachment/FileAttachment.tsx
+++ b/package/src/components/Attachment/FileAttachment.tsx
@@ -103,6 +103,7 @@ const FileAttachmentWithContext = <
       onLongPress={(event) => {
         if (onLongPress) {
           onLongPress({
+            additionalInfo: { assetUrl: attachment.asset_url },
             emitter: 'fileAttachment',
             event,
           });
@@ -111,6 +112,7 @@ const FileAttachmentWithContext = <
       onPress={(event) => {
         if (onPress) {
           onPress({
+            additionalInfo: { assetUrl: attachment.asset_url },
             defaultHandler: defaultOnPress,
             emitter: 'fileAttachment',
             event,
@@ -120,6 +122,7 @@ const FileAttachmentWithContext = <
       onPressIn={(event) => {
         if (onPressIn) {
           onPressIn({
+            additionalInfo: { assetUrl: attachment.asset_url },
             defaultHandler: defaultOnPress,
             emitter: 'fileAttachment',
             event,

--- a/package/src/components/Attachment/FileAttachment.tsx
+++ b/package/src/components/Attachment/FileAttachment.tsx
@@ -103,7 +103,7 @@ const FileAttachmentWithContext = <
       onLongPress={(event) => {
         if (onLongPress) {
           onLongPress({
-            additionalInfo: { assetUrl: attachment.asset_url },
+            additionalInfo: { url: attachment.asset_url },
             emitter: 'fileAttachment',
             event,
           });
@@ -112,7 +112,7 @@ const FileAttachmentWithContext = <
       onPress={(event) => {
         if (onPress) {
           onPress({
-            additionalInfo: { assetUrl: attachment.asset_url },
+            additionalInfo: { url: attachment.asset_url },
             defaultHandler: defaultOnPress,
             emitter: 'fileAttachment',
             event,
@@ -122,7 +122,7 @@ const FileAttachmentWithContext = <
       onPressIn={(event) => {
         if (onPressIn) {
           onPressIn({
-            additionalInfo: { assetUrl: attachment.asset_url },
+            additionalInfo: { url: attachment.asset_url },
             defaultHandler: defaultOnPress,
             emitter: 'fileAttachment',
             event,

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -69,8 +69,15 @@ export type TextMentionTouchableHandlerPayload<
 };
 
 export type UrlTouchableHandlerPayload = {
-  emitter: 'textLink' | 'card' | 'fileAttachment';
+  emitter: 'textLink' | 'card';
   additionalInfo?: { url?: string };
+};
+
+export type FileAttachmentTouchableHandlerPayload<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+> = {
+  emitter: 'fileAttachment';
+  additionalInfo?: { attachment?: Attachment<StreamChatGenerics> };
 };
 
 export type TouchableHandlerPayload = {
@@ -78,10 +85,11 @@ export type TouchableHandlerPayload = {
   event?: GestureResponderEvent;
 } & (
   | {
-      emitter?: TouchableEmitter;
+      emitter?: Exclude<TouchableEmitter, 'textMention' | 'textLink' | 'card' | 'fileAttachment'>;
     }
   | TextMentionTouchableHandlerPayload
   | UrlTouchableHandlerPayload
+  | FileAttachmentTouchableHandlerPayload
 );
 
 export type MessageTouchableHandlerPayload<

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -73,6 +73,11 @@ export type UrlTouchableHandlerPayload = {
   additionalInfo?: { url?: string };
 };
 
+export type FileAttachmentTouchableHandlerPayload = {
+  additionalInfo: { assetUrl?: string };
+  emitter: 'fileAttachment';
+};
+
 export type TouchableHandlerPayload = {
   defaultHandler?: () => void;
   event?: GestureResponderEvent;
@@ -82,6 +87,7 @@ export type TouchableHandlerPayload = {
     }
   | TextMentionTouchableHandlerPayload
   | UrlTouchableHandlerPayload
+  | FileAttachmentTouchableHandlerPayload
 );
 
 export type MessageTouchableHandlerPayload<

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -69,13 +69,8 @@ export type TextMentionTouchableHandlerPayload<
 };
 
 export type UrlTouchableHandlerPayload = {
-  emitter: 'textLink' | 'card';
+  emitter: 'textLink' | 'card' | 'fileAttachment';
   additionalInfo?: { url?: string };
-};
-
-export type FileAttachmentTouchableHandlerPayload = {
-  additionalInfo: { url?: string };
-  emitter: 'fileAttachment';
 };
 
 export type TouchableHandlerPayload = {
@@ -87,7 +82,6 @@ export type TouchableHandlerPayload = {
     }
   | TextMentionTouchableHandlerPayload
   | UrlTouchableHandlerPayload
-  | FileAttachmentTouchableHandlerPayload
 );
 
 export type MessageTouchableHandlerPayload<

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -74,7 +74,7 @@ export type UrlTouchableHandlerPayload = {
 };
 
 export type FileAttachmentTouchableHandlerPayload = {
-  additionalInfo: { assetUrl?: string };
+  additionalInfo: { url?: string };
   emitter: 'fileAttachment';
 };
 


### PR DESCRIPTION
## 🎯 Goal

- Fixes https://getstream.zendesk.com/agent/tickets/26224

Adds support for listening to assetUrls in the fileAttachment onPress listeners.

## 🛠 Implementation details

NA

## 🎨 UI Changes

NA

## 🧪 Testing

NA

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


