### PR TITLE
fix: set an initial image index for the ImageGallery

### DIFF
--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -381,6 +381,7 @@ export const ImageGallery = <
     scale,
     screenHeight,
     screenWidth,
+    selectedIndex,
     setSelectedIndex,
     translateX,
     translateY,

--- a/package/src/components/ImageGallery/hooks/useImageGalleryGestures.tsx
+++ b/package/src/components/ImageGallery/hooks/useImageGalleryGestures.tsx
@@ -42,6 +42,7 @@ export const useImageGalleryGestures = ({
   scale,
   screenHeight,
   screenWidth,
+  selectedIndex,
   setSelectedIndex,
   translateX,
   translateY,
@@ -57,6 +58,7 @@ export const useImageGalleryGestures = ({
   scale: SharedValue<number>;
   screenHeight: number;
   screenWidth: number;
+  selectedIndex: number;
   setSelectedIndex: React.Dispatch<React.SetStateAction<number>>;
   translateX: SharedValue<number>;
   translateY: SharedValue<number>;
@@ -81,6 +83,20 @@ export const useImageGalleryGestures = ({
   const focalX = useSharedValue(0);
   const focalY = useSharedValue(0);
   const index = useSharedValue(0);
+
+  /**
+   * if a specific image index > 0 has been passed in
+   * while creating the hook, set the value of the index
+   * reference to its value.
+   *
+   * This makes it possible to seelct an image in the list,
+   * and scroll/pan as normal. Prior to this,
+   * it was always assumed that one started at index 0 in the
+   * gallery.
+   * */
+  if (index.value !== selectedIndex) {
+    index.value = selectedIndex;
+  }
 
   /**
    * Shared values for movement


### PR DESCRIPTION
## 🎯 Goal

Without this, the initial index is always assumed to be 0. This allows selecting another image for the gallery to start at, for the gestures.

## 🛠 Implementation details

n/a

## 🎨 UI Changes

n/a

## 🧪 Testing

Open the image gallery by selecting an image in an image grid. See that you can navigate right and left between images as normal/expected.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


