### PR TITLE
fix: generics typing issues if js client is above 6.7.1

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -80,7 +80,7 @@
     "react-art": "^17.0.2",
     "react-native-markdown-package": "1.8.2",
     "react-native-url-polyfill": "^1.3.0",
-    "stream-chat": "6.7.0"
+    "stream-chat": "~6.7.3"
   },
   "peerDependencies": {
     "react-native-svg": "^12.1.0"

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -9562,10 +9562,10 @@ stream-buffers@2.2.x:
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
   integrity sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=
 
-stream-chat@6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-6.7.0.tgz#1add1e612f0009f9e7a69d35f2a2fae1296d85ef"
-  integrity sha512-usH/kh0ZjbjOP8TTlsbXS53UZRUmwP0r1dOYf0jrQg3HPfwG51iTkrXGNlzPF9ueNXkPB8ObSm7bcdVRoo+4bg==
+stream-chat@~6.7.3:
+  version "6.7.3"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-6.7.3.tgz#5d3a0f1678c5bcac6241e15882230bf71b56d06d"
+  integrity sha512-O2gBocLG4rgAMOHq4PlXDkexfgkXFp1ZEGF+W3lllFXBC2/e52KbbojQNMhyoQPv82n2JQCGpkychUP4jdpn9Q==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "^8.5.6"


### PR DESCRIPTION
## 🎯 Goal

Fixes #1644 

## 🛠 Implementation details

Updating the core's JS client version solves the issue. It was because a new function was added to the channel in the JS client in https://github.com/GetStream/stream-chat-js/pull/974

## 🎨 UI Changes

NA

## 🧪 Testing

Set the js client version to 6.7.1 in the TypeScriptMessaging App and then use the client with default generics in App.tsx as below,

`const chatClient = StreamChat.getInstance('q95x9hkbyd6p');`

and no generics errors should pop up

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


