### PR TITLE
Small video on Android

### DIFF
--- a/package/native-package/src/index.js
+++ b/package/native-package/src/index.js
@@ -278,6 +278,7 @@ registerNativeHandlers({
     ? ({ onBuffer, onEnd, onLoad, onProgress, paused, style, uri, videoRef }) => (
         <AudioVideoPlayer
           ignoreSilentSwitch={'ignore'}
+          resizeMode="contain"
           onBuffer={onBuffer}
           onEnd={onEnd}
           onError={(error) => {


### PR DESCRIPTION
## 🎯 Goal
Fixes the issue mentioned here https://github.com/GetStream/stream-chat-react-native/issues/1495 for what I could tell, the problem seems to be in `react-native-video` or the underlying `Exoplayer` setting the resize mode gives the desired effect, and the video takes up the whole screen.




