### PR TITLE
ci: bump node version in release workflows to 16.x

### DIFF
--- a/.github/workflows/next-release.yml
+++ b/.github/workflows/next-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
    runs-on: ubuntu-latest
    strategy:
      matrix:
-       node-version: [12.x]
+       node-version: [16.x]
    steps:
      - uses: actions/checkout@v2
        with:


### PR DESCRIPTION
## 🎯 Goal

With RN 0.69, our release breaks with the following error message:

```
sampleapp: error react-native@0.69.4: The engine "node" is incompatible with this module. Expected version ">=14". Got "12.22.12"
```

This PR raises the version used to 16.x

## 🛠 Implementation details

16.x is the [Active LTS version of node](https://nodejs.org/en/about/releases/)

## 🎨 UI Changes

N/A

## 🧪 Testing

N/A
## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


