### PR TITLE
Update broken Docusaurus links 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ e2e/.env
 *.log
 .DS_STORE
 *.db
+.idea

--- a/docusaurus/docs/reactnative/basics/translations.mdx
+++ b/docusaurus/docs/reactnative/basics/translations.mdx
@@ -392,7 +392,7 @@ const { t, tDateTimeParser } = await streami18n.getTranslators();
 Allows you to register a custom translation, this will override a translation if one already exists for the given language code.
 The third parameter, which is optional, is a Day.js locale, which is structured the same as [dayjsLocaleConfigForLanguage](#dayjslocaleconfigforlanguage).
 
-It is suggested you look at the [`enTranslations` json file](https://github.com/GetStream/stream-chat-react-native/tree/main/src/i18n) exported from `stream-chat-react-native` for a current list of used translation keys.
+It is suggested you look at the [`enTranslations` json file](https://github.com/GetStream/stream-chat-react/blob/master/src/i18n/en.json) exported from `stream-chat-react-native` for a current list of used translation keys.
 
 ```ts
 streami18n.registerTranslation('mr', {

--- a/docusaurus/docs/reactnative/contexts/translation_context.mdx
+++ b/docusaurus/docs/reactnative/contexts/translation_context.mdx
@@ -4,7 +4,7 @@ title: TranslationContext
 ---
 
 `TranslationContext` is provided by [`OverlayProvider`](../core-components/overlay_provider.mdx) and [`Chat`](../core-components/chat.mdx) components.
-Read the [translations section](../basics/translations/) for more information on how to customize your translations.
+Read the [translations section](basics/translations.mdx) for more information on how to customize your translations.
 If you are not familiar with React Context API, please read about it on [React docs](https://reactjs.org/docs/context.html).
 
 ## Basic Usage

--- a/docusaurus/docs/reactnative/customization/theming.mdx
+++ b/docusaurus/docs/reactnative/customization/theming.mdx
@@ -149,6 +149,6 @@ The resulting changes by applying the custom theme are easily seen in the change
 
 Most of the styles are standard React Native styles, but some styles applying to SVGs, Markdown, or custom components are numbers, strings, or other specified types.
 The TypeScript documentation of [`Theme`](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/contexts/themeContext/utils/theme.ts) should help you in this regard.
-Message text is an instance of an exception as it is rendered using [`react-native-markdown-package`](https://github.com/andangrd/react-native-markdown-package) and the [`MarkdownStyle`](https://github.com/andangrd/react-native-markdown-package/blob/main/styles.js) is added to the theme at key `messageSimple` -> `content` -> `markdown`.
+Message text is an instance of an exception as it is rendered using [`react-native-markdown-package`](https://github.com/andangrd/react-native-markdown-package) and the [`MarkdownStyle`](https://github.com/andangrd/react-native-markdown-package/blob/master/styles.js) is added to the theme at key `messageSimple` -> `content` -> `markdown`.
 
 :::

--- a/docusaurus/docs/reactnative/guides/message_actions_customization.mdx
+++ b/docusaurus/docs/reactnative/guides/message_actions_customization.mdx
@@ -42,7 +42,7 @@ type MessageAction = {
 };
 ```
 
-You can customize each one of the default actions using props on the [`Channel component`](../) as shown further on this page. The channel component makes these props available in the `MessagesContext` context.
+You can customize each one of the default actions using props on the [`Channel component`](../core-components/channel.mdx) as shown further on this page. The channel component makes these props available in the `MessagesContext` context.
 
 The channel component accepts a prop called `messageActions`. You can use this prop as a callback function to render message actions selectively.
 
@@ -148,7 +148,7 @@ import { messageActions as defaultMessageActions, Mute as MuteIcon } from 'strea
 
 ## How to customize message action UI
 
-[`OverlayProvider`](../) component accepts props called - `MessageActionList` and `MessageActionListItem`. They both serve a different purpose.
+[`OverlayProvider`](../core-components/overlay_provider.mdx) component accepts props called - `MessageActionList` and `MessageActionListItem`. They both serve a different purpose.
 
 - `MessageActionList` - Allows full customizability of the message action list and allows users to add/define their own message action along with the style they prefer for the application.
 - `MessageActionListItem` - Allows customizability of an item in a message action list.

--- a/docusaurus/docs/reactnative/guides/push_notifications_v1.mdx
+++ b/docusaurus/docs/reactnative/guides/push_notifications_v1.mdx
@@ -264,7 +264,7 @@ function App() {
 
 ## Troubleshooting
 
-If you are having trouble receiving push notifications, please use our [Push Notification Test Application](https://github.com/GetStream/chat-push-test/tree/main/react-native) to check if you have setup Push Configuration correctly.
-Please follow the steps mentioned in [Readme](https://github.com/GetStream/chat-push-test/tree/main/react-native) for further instructions
+If you are having trouble receiving push notifications, please use our [Push Notification Test Application](https://github.com/GetStream/chat-push-test/tree/master/react-native) to check if you have setup Push Configuration correctly.
+Please follow the steps mentioned in [Readme](https://github.com/GetStream/chat-push-test/tree/master/react-native) for further instructions
 
 If you are still having trouble with Push Notifications, please contact [support@getstream.io](mailto:support@getstream.io)

--- a/docusaurus/docs/reactnative/ui-components/overlay_reactions.mdx
+++ b/docusaurus/docs/reactnative/ui-components/overlay_reactions.mdx
@@ -36,7 +36,7 @@ const reactions = message.latest_reactions.map(reaction => ({
 
 ### <div class="label required">required</div> **showScreen** {#showscreen}
 
-`Shared` value from React Native Reanimated's [`useSharedValue`](https://docs.swmansion.com/react-native-reanimated/docs/api/useSharedValue/) hook.
+`Shared` value from React Native Reanimated's [`useSharedValue`](https://docs.swmansion.com/react-native-reanimated/docs/api/hooks/useSharedValue/) hook.
 
 | Type   |
 | ------ |

--- a/docusaurus/reactnative_versioned_docs/version-3.x.x/basics/translations.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-3.x.x/basics/translations.mdx
@@ -95,7 +95,7 @@ streami18n.registerTranslation('pl', {
 });
 ```
 
-Please take a look at all the available texts [here](https://github.com/GetStream/stream-chat-react-native/blob/develop/package/src/i18n/en.json).
+Please take a look at all the available texts [here](https://github.com/GetStream/stream-chat-react/blob/master/src/i18n/en.json).
 
 ### Overriding existing languages
 
@@ -392,7 +392,7 @@ const { t, tDateTimeParser } = await streami18n.getTranslators();
 Allows you to register a custom translation, this will override a translation if one already exists for the given language code.
 The third parameter, which is optional, is a Day.js locale, which is structured the same as [dayjsLocaleConfigForLanguage](#dayjslocaleconfigforlanguage).
 
-It is suggested you look at the [`enTranslations` json file](https://github.com/GetStream/stream-chat-react-native/tree/main/src/i18n) exported from `stream-chat-react-native` for a current list of used translation keys.
+It is suggested you look at the [`enTranslations` json file](https://github.com/GetStream/stream-chat-react/blob/master/src/i18n/en.json) exported from `stream-chat-react-native` for a current list of used translation keys.
 
 ```ts
 streami18n.registerTranslation('mr', {

--- a/docusaurus/reactnative_versioned_docs/version-3.x.x/basics/troubleshooting.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-3.x.x/basics/troubleshooting.mdx
@@ -298,7 +298,7 @@ The solution may require using a different touchable from React Native Gesture H
 
 ## Reanimated 2
 
-We rely on Reanimated 2 heavily for gesture based interactions and animations. It is vital you follow the [Reanimated 2 installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/installation/) for the library to work properly.
+We rely on Reanimated 2 heavily for gesture based interactions and animations. It is vital you follow the [Reanimated 2 installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation/) for the library to work properly.
 
 ### Failed to create a worklet
 
@@ -306,7 +306,7 @@ If you are encountering errors related to `Reanimated 2 failed to create a workl
 
 ### Blank screen on Android
 
-If you are encountering errors on Android and the screen is blank it is likely you forgot to finish the [Reanimated 2 Android setup](https://docs.swmansion.com/react-native-reanimated/docs/installation/#android).
+If you are encountering errors on Android and the screen is blank it is likely you forgot to finish the [Reanimated 2 Android setup](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation/#android).
 
 Ensure Hermes is enabled in `android/app/build.gradle`
 

--- a/docusaurus/reactnative_versioned_docs/version-3.x.x/customization/theming.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-3.x.x/customization/theming.mdx
@@ -149,6 +149,6 @@ The resulting changes by applying the custom theme are easily seen in the change
 
 Most of the styles are standard React Native styles, but some styles applying to SVGs, Markdown, or custom components are numbers, strings, or other specified types.
 The TypeScript documentation of [`Theme`](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/contexts/themeContext/utils/theme.ts) should help you in this regard.
-Message text is an instance of an exception as it is rendered using [`react-native-markdown-package`](https://github.com/andangrd/react-native-markdown-package) and the [`MarkdownStyle`](https://github.com/andangrd/react-native-markdown-package/blob/main/styles.js) is added to the theme at key `messageSimple` -> `content` -> `markdown`.
+Message text is an instance of an exception as it is rendered using [`react-native-markdown-package`](https://github.com/andangrd/react-native-markdown-package) and the [`MarkdownStyle`](https://github.com/andangrd/react-native-markdown-package/blob/master/styles.js) is added to the theme at key `messageSimple` -> `content` -> `markdown`.
 
 :::

--- a/docusaurus/reactnative_versioned_docs/version-3.x.x/guides/push_notifications.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-3.x.x/guides/push_notifications.mdx
@@ -262,7 +262,7 @@ function App() {
 
 ## Troubleshooting
 
-If you are having trouble receiving push notifications, please use our [Push Notification Test Application](https://github.com/GetStream/chat-push-test/tree/main/react-native) to check if you have setup Push Configuration correctly.
-Please follow the steps mentioned in [Readme](https://github.com/GetStream/chat-push-test/tree/main/react-native) for further instructions
+If you are having trouble receiving push notifications, please use our [Push Notification Test Application](https://github.com/GetStream/chat-push-test/tree/master/react-native) to check if you have setup Push Configuration correctly.
+Please follow the steps mentioned in [Readme](https://github.com/GetStream/chat-push-test/tree/master/react-native) for further instructions
 
 If you are still having trouble with Push Notifications, please contact [support@getstream.io](mailto:support@getstream.io)

--- a/docusaurus/reactnative_versioned_docs/version-3.x.x/guides/upgrade_helper.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-3.x.x/guides/upgrade_helper.mdx
@@ -36,7 +36,7 @@ yarn add @react-native-community/blur @react-native-community/cameraroll @react-
 After adding these dependencies, go through following links and follow any additional installation steps:
 
 - `react-native` - [additional installation steps](https://reactnative.dev/docs/image#gif-and-webp-support-on-android)
-- `react-native-reanimated` - [additional installation steps](https://docs.swmansion.com/react-native-reanimated/docs/installation).
+- `react-native-reanimated` - [additional installation steps](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation/).
 - `react-native-image-crop-picker` - [additional installation steps](https://github.com/ivpusic/react-native-image-crop-picker#step-3)
 - `react-native-cameraroll` - [additional installation steps](https://github.com/react-native-cameraroll/react-native-cameraroll#permissions)
 - `react-native-gesture-handler` - [additional installation steps](https://docs.swmansion.com/react-native-gesture-handler/docs/#android)

--- a/docusaurus/reactnative_versioned_docs/version-3.x.x/ui-components/overlay_reactions.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-3.x.x/ui-components/overlay_reactions.mdx
@@ -36,7 +36,7 @@ const reactions = message.latest_reactions.map(reaction => ({
 
 ### <div class="label required">required</div> **showScreen** {#showscreen}
 
-`Shared` value from React Native Reanimated's [`useSharedValue`](https://docs.swmansion.com/react-native-reanimated/docs/api/useSharedValue/) hook.
+`Shared` value from React Native Reanimated's [`useSharedValue`](https://docs.swmansion.com/react-native-reanimated/docs/api/hooks/useSharedValue/) hook.
 
 | Type   |
 | ------ |


### PR DESCRIPTION
## 🎯 Goal
This PR address the broken links in docusaurus as outlined by [this](https://docs.google.com/spreadsheets/d/1ekfYOYl1HSs97uU13yYV-I-xjxTQ1cTOnFe0tOdX_BA/edit#gid=0) internal document. 

The changes included in this PR are scoped to v5 content. 


## 🛠 Implementation details

- Updates external links 
- Updates internal docusaurus links
- Adds `.idea` to `.gitignore` 


## 🧪 Testing

No tests added, only docs changes.

cc: @jeroenleenarts 