### PR TITLE
feat: allow customization of the close icon for uploads

### DIFF
--- a/package/src/components/MessageInput/ImageUploadPreview.tsx
+++ b/package/src/components/MessageInput/ImageUploadPreview.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { FlatList, Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import {
+  FlatList,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  TouchableOpacityProps,
+  View,
+} from 'react-native';
 
 import { UploadProgressIndicator } from './UploadProgressIndicator';
 
@@ -87,9 +95,8 @@ const ImageUploadPreviewWithContext = <
 
   const {
     theme: {
-      colors: { overlay, white },
       messageInput: {
-        imageUploadPreview: { dismiss, flatList, itemContainer, upload },
+        imageUploadPreview: { flatList, itemContainer, upload },
       },
     },
   } = useTheme();
@@ -140,15 +147,11 @@ const ImageUploadPreviewWithContext = <
             style={[styles.upload, upload]}
           />
         </UploadProgressIndicator>
-        <TouchableOpacity
+        <DismissUpload
           onPress={() => {
             removeImage(item.id);
           }}
-          style={[styles.dismiss, { backgroundColor: overlay }, dismiss]}
-          testID='remove-image-upload-preview'
-        >
-          <Close pathFill={white} />
-        </TouchableOpacity>
+        />
         <UnsupportedImageTypeIndicator indicatorType={indicatorType} />
       </View>
     );
@@ -168,6 +171,29 @@ const ImageUploadPreviewWithContext = <
       style={[styles.flatList, flatList]}
     />
   ) : null;
+};
+
+type DismissUploadProps = {} & Pick<TouchableOpacityProps, 'onPress'>;
+
+const DismissUpload = ({ onPress }: DismissUploadProps) => {
+  const {
+    theme: {
+      colors: { overlay, white },
+      messageInput: {
+        imageUploadPreview: { dismiss, dismissIconColor },
+      },
+    },
+  } = useTheme();
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={[styles.dismiss, { backgroundColor: overlay }, dismiss]}
+      testID='remove-image-upload-preview'
+    >
+      <Close pathFill={dismissIconColor || white} />
+    </TouchableOpacity>
+  );
 };
 
 const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics>(

--- a/package/src/components/MessageInput/ImageUploadPreview.tsx
+++ b/package/src/components/MessageInput/ImageUploadPreview.tsx
@@ -173,7 +173,7 @@ const ImageUploadPreviewWithContext = <
   ) : null;
 };
 
-type DismissUploadProps = {} & Pick<TouchableOpacityProps, 'onPress'>;
+type DismissUploadProps = Pick<TouchableOpacityProps, 'onPress'>;
 
 const DismissUpload = ({ onPress }: DismissUploadProps) => {
   const {

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -267,6 +267,7 @@ export type Theme = {
     };
     imageUploadPreview: {
       dismiss: ViewStyle;
+      dismissIconColor: Color;
       flatList: ViewStyle;
       itemContainer: ViewStyle;
       upload: ImageStyle;
@@ -766,6 +767,7 @@ export const defaultTheme: Theme = {
     },
     imageUploadPreview: {
       dismiss: {},
+      dismissIconColor: '',
       flatList: {},
       itemContainer: {},
       upload: {},


### PR DESCRIPTION
## 🎯 Goal

Currently, you can customize the background behind the dismiss icon for uploaded photos in the message input. This PR allows users to also customize the color of the icon itself (the `x` icon to dismiss the image)

## 🛠 Implementation details

n/a

## 🎨 UI Changes

no UI changes

## 🧪 Testing

In an app, change the value of `messageInput.imageUploadPreview.dismissIconColor`. Any color should be fine.

Then upload an image in the message input, and see that the icon has the color you've selected.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


