### PR TITLE
feat: deprecates old docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,10 +4,46 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Stream Chat React Native - Docs</title>
+    <title>DEPRECATED Stream Chat React Native - Docs DEPRECATED</title>
     <link rel="icon" type="image/x-icon" href="https://getstream.imgix.net/images/favicons/favicon-96x96.png">
+    <style>
+      .deprecationBanner {
+          position: fixed;
+          right: 0;
+          left: 210px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          background-color: #ae423f;
+      }
+
+      .deprecationText, a {
+          color: #fff;
+          font-weight: bold;
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif
+      }
+
+      a {
+          color: #78d4fc;
+          font-size: 1.5rem;
+          padding: 20px 0;
+      }
+
+
+      @media only screen and (max-width: 600px){
+          .deprecationBanner {
+              left: 0;
+          }
+
+      }
+    </style>
   </head>
   <body>
+    <div class='deprecationBanner'>
+      <h1 class='deprecationText'>⚠️ This Documentation is Deprecated ⚠️</h1>
+      <a href='https://getstream.io/chat/docs/sdk/reactnative/'>Click here to consult our new docs</a>
+    </div>
     <div id="rsg-root"></div>
     <script src="build/bundle.38535de9.js"></script>
   </body>

--- a/docs/v3/index.html
+++ b/docs/v3/index.html
@@ -1,14 +1,50 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Stream Chat React Native - Docs</title>
-    <link rel="icon" type="image/x-icon" href="https://getstream.imgix.net/images/favicons/favicon-96x96.png">
-  </head>
-  <body>
-    <div id="rsg-root"></div>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>DEPRECATED Stream Chat React Native - Docs DEPRECATED</title>
+  <link rel="icon" type="image/x-icon" href="https://getstream.imgix.net/images/favicons/favicon-96x96.png">
+  <style>
+      .deprecationBanner {
+          position: fixed;
+          right: 0;
+          left: 210px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          background-color: #ae423f;
+      }
+
+      .deprecationText, a {
+          color: #fff;
+          font-weight: bold;
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif
+      }
+
+      a {
+          color: #78d4fc;
+          font-size: 1.5rem;
+          padding: 20px 0;
+      }
+
+
+      @media only screen and (max-width: 600px){
+          .deprecationBanner {
+              left: 0;
+          }
+
+      }
+  </style>
+</head>
+<body>
+<div class='deprecationBanner'>
+  <h1 class='deprecationText'>⚠️ This Documentation is Deprecated ⚠️</h1>
+  <a href='https://getstream.io/chat/docs/sdk/reactnative/'>Click here to consult our new docs</a>
+</div>
+<div id="rsg-root"></div>
     <script src="build/bundle.a39375a1.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## 🎯 Goal

This PR aims to deprecate the old docs.

## 🛠 Implementation details

Adding a sticky header with a deprecation message and a link to the new docs.

## 🎨 UI Changes

<img width="1714" alt="Screenshot 2022-08-24 at 13 40 53" src="https://user-images.githubusercontent.com/25864161/186409906-9ed76502-0036-4c41-81a9-a04b573890a2.png">

## 🧪 Testing

N/A


## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


