### PR TITLE
fix: handling of empty channels corresponding to filters/sort in offline support

### DIFF
--- a/package/src/__tests__/offline-feature.test.js
+++ b/package/src/__tests__/offline-feature.test.js
@@ -51,9 +51,11 @@ const ChannelPreviewComponent = ({ channel, setActiveChannel }) => (
 
 const ChannelListComponent = (props) => {
   const { channels, onSelect } = useChannelsContext();
+  if (!channels) return null;
+
   return (
     <View testID='channel-list'>
-      {channels.map((channel) => (
+      {channels?.map((channel) => (
         <ChannelPreviewComponent
           {...props}
           channel={channel}

--- a/package/src/components/ChannelList/ChannelList.tsx
+++ b/package/src/components/ChannelList/ChannelList.tsx
@@ -314,12 +314,13 @@ export const ChannelList = <
     setChannels,
   });
 
-  const channelIdsStr = channels.reduce((acc, channel) => `${acc}${channel.cid}`, '');
+  const channelIdsStr = channels?.reduce((acc, channel) => `${acc}${channel.cid}`, '');
 
   useEffect(() => {
-    if (staticChannelsActive || !enableOfflineSupport) {
+    if (channels === null || staticChannelsActive || !enableOfflineSupport) {
       return;
     }
+
     upsertCidsForQuery({
       cids: channels.map((c) => c.cid),
       filters,

--- a/package/src/components/ChannelList/ChannelListMessenger.tsx
+++ b/package/src/components/ChannelList/ChannelListMessenger.tsx
@@ -132,14 +132,14 @@ const ChannelListMessengerWithContext = <
     if (debugRef.current.setSendEventParams)
       debugRef.current.setSendEventParams({
         action: 'Channels',
-        data: channels.map((channel) => ({
+        data: channels?.map((channel) => ({
           data: channel.data,
           members: channel.state.members,
         })),
       });
   }
 
-  if (error && !refreshing && !loadingChannels && !channels?.length) {
+  if (error && !refreshing && !loadingChannels && channels === null) {
     return (
       <LoadingErrorIndicator
         error={error}
@@ -157,7 +157,7 @@ const ChannelListMessengerWithContext = <
   };
 
   const ListFooterComponent = () =>
-    channels.length && ListHeaderComponent ? <ListHeaderComponent /> : null;
+    channels?.length && ListHeaderComponent ? <ListHeaderComponent /> : null;
 
   if (loadingChannels) {
     return <LoadingIndicator listType='channel' />;

--- a/package/src/components/ChannelList/__tests__/ChannelList.test.js
+++ b/package/src/components/ChannelList/__tests__/ChannelList.test.js
@@ -43,7 +43,7 @@ const ChannelListComponent = (props) => {
   const { channels, onSelect } = useChannelsContext();
   return (
     <View testID='channel-list'>
-      {channels.map((channel) => (
+      {channels?.map((channel) => (
         <ChannelPreviewComponent
           {...props}
           channel={channel}

--- a/package/src/components/ChannelList/hooks/useCreateChannelsContext.ts
+++ b/package/src/components/ChannelList/hooks/useCreateChannelsContext.ts
@@ -38,7 +38,7 @@ export const useCreateChannelsContext = <
   Skeleton,
 }: ChannelsContextValue<StreamChatGenerics>) => {
   const channelValueString = channels
-    .map(
+    ?.map(
       (channel) =>
         `${channel.data?.name ?? ''}${channel.id ?? ''}${Object.values(channel.state.members)
           .map((member) => member.user?.online)

--- a/package/src/contexts/channelsContext/ChannelsContext.tsx
+++ b/package/src/contexts/channelsContext/ChannelsContext.tsx
@@ -48,7 +48,7 @@ export type ChannelsContextValue<
   /**
    * Channels can be either an array of channels or a promise which resolves to an array of channels
    */
-  channels: Channel<StreamChatGenerics>[];
+  channels: Channel<StreamChatGenerics>[] | null;
   /**
    * Custom indicator to use when channel list is empty
    *


### PR DESCRIPTION

## 🎯 Goal

Fixes: https://github.com/GetStream/stream-chat-react-native/issues/1695

## 🛠 Implementation details

We need explicit way to know whether `channels` have been queries either from local db or server. Currently we initialize `channels` as `[]`, but we can't differentiate between following two cases:
  - there are no channels corresponding to certain `filters`
  - channels have not been queried from local db or server yet.

Thus in this PR, `channels` have been initialized as `null`, and it will make it explicit what exactly the state of channel list is.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


