### PR TITLE
docs: fix irrelavant arrow due to comment in message input documentation

### DIFF
--- a/docusaurus/docs/reactnative/ui-components/message_input.mdx
+++ b/docusaurus/docs/reactnative/ui-components/message_input.mdx
@@ -153,7 +153,7 @@ Additionally please take a look at our [Guide Section](../guides/message_input_c
 
 ### <div class="label description">_overrides the value from [MessageInputContext](../contexts/message_input_context.mdx#sending)_</div> sending {#sending}
 
-<Sending /> -->
+<Sending />
 
 ### <div class="label description">_overrides the value from [MessageInputContext](../contexts/message_input_context.mdx#sendmessageasync)_</div> sendMessageAsync {#sendmessageasync}
 


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


