### PR TITLE
fix: typescript definition was wrong for getLocalAssetUri and initializeSound

### DIFF
--- a/package/src/native.ts
+++ b/package/src/native.ts
@@ -27,7 +27,7 @@ export let compressImage: CompressImage = fail;
 type DeleteFile = ({ uri }: { uri: string }) => Promise<boolean> | never;
 export let deleteFile: DeleteFile = fail;
 
-type GetLocalAssetUri = (uriOrAssetId: string) => never;
+type GetLocalAssetUri = (uriOrAssetId: string) => Promise<string> | never;
 export let getLocalAssetUri: GetLocalAssetUri = fail;
 
 type GetPhotos = ({ after, first }: { first: number; after?: string }) =>

--- a/package/src/native.ts
+++ b/package/src/native.ts
@@ -157,7 +157,7 @@ export type SoundType = {
     source?: { uri: string },
     initialStatus?: Partial<AVPlaybackStatusToSet>,
     onPlaybackStatusUpdate?: (playbackStatus: PlaybackStatus) => void,
-  ) => SoundReturnType | null;
+  ) => Promise<SoundReturnType | null>;
   Player: React.ComponentType<SoundReturnType> | null;
 };
 


### PR DESCRIPTION
## 🎯 Goal

Fix a few typescript definition inconsistencies:

1) Currently, if you want to implement a new `getLocalAssetUri` function, typescript will complain as it expects a `never` response, not a string as you can see here

https://github.com/GetStream/stream-chat-react-native/blob/53a9c41981e0b602c2d817696490c66a8045b9f2/package/expo-package/src/index.js#L34-L41

2) The `initializeSound` function is async in code, but in the typedef it is currently sync

https://github.com/GetStream/stream-chat-react-native/blob/75561fdc2d59732a6b8a35dd12d3a0f2b6a56126/package/src/components/Attachment/AudioAttachment.tsx#L163


## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


