### PR TITLE
fix: wrong unread count issue in the SampleApp

### DIFF
--- a/examples/SampleApp/src/components/UnreadCountBadge.tsx
+++ b/examples/SampleApp/src/components/UnreadCountBadge.tsx
@@ -31,11 +31,8 @@ export const UnreadCountBadge: React.FC = () => {
   const [count, setCount] = useState<number>();
 
   useEffect(() => {
-    const user = chatClient?.user;
-    const unreadCount = isOwnUser(user) ? user.total_unread_count : undefined;
-    setCount(unreadCount);
     const listener = chatClient?.on((e) => {
-      if (e.total_unread_count) {
+      if (e.total_unread_count !== undefined) {
         setCount(e.total_unread_count);
       }
     });


### PR DESCRIPTION
## 🎯 Goal

The goal of this PR is to fix the unread count update issue in the Sample App.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The condition `if (e.total_unread_count)` is changed to `if (e.total_unread_count !== undefined)` to consider 0 as count too.

Loading the initial count when the app load is still an issue and is to be fixed once the TS issue is handled in the JS client. See the discussion here - https://getstream.slack.com/archives/CE5N802GP/p1663313393442849

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


