### PR TITLE
refactor: change the direction gallery thumbnails are rendered

### DIFF
--- a/package/src/components/Attachment/__tests__/Gallery.test.js
+++ b/package/src/components/Attachment/__tests__/Gallery.test.js
@@ -248,13 +248,13 @@ describe('Gallery', () => {
     const { queryAllByTestId } = render(component);
 
     await waitFor(() => {
-      expect(queryAllByTestId('gallery-column-0').length).toBe(1);
-      expect(queryAllByTestId('gallery-column-1').length).toBe(1);
+      expect(queryAllByTestId('gallery-row-0').length).toBe(1);
+      expect(queryAllByTestId('gallery-row-1').length).toBe(1);
 
-      expect(queryAllByTestId('gallery-column-0-item-0').length).toBe(1);
-      expect(queryAllByTestId('gallery-column-0-item-1').length).toBe(1);
-      expect(queryAllByTestId('gallery-column-1-item-0').length).toBe(1);
-      expect(queryAllByTestId('gallery-column-1-item-1').length).toBe(1);
+      expect(queryAllByTestId('gallery-row-0-item-0').length).toBe(1);
+      expect(queryAllByTestId('gallery-row-0-item-1').length).toBe(1);
+      expect(queryAllByTestId('gallery-row-1-item-0').length).toBe(1);
+      expect(queryAllByTestId('gallery-row-1-item-1').length).toBe(1);
     });
   });
 

--- a/package/src/components/Attachment/utils/buildGallery/buildGallery.ts
+++ b/package/src/components/Attachment/utils/buildGallery/buildGallery.ts
@@ -71,7 +71,7 @@ export function buildGallery<
       [1, 1],
     ],
     images: images.slice(0, 4),
-    invertedDirections: false,
+    invertedDirections: true,
     sizeConfig,
   });
 }


### PR DESCRIPTION
## 🎯 Goal

This applies to grids of 2x2 images.
Currently, we render images by column. This means that the first two pictures are in column one, the last two in column two.

To conform to what the other SDKs does, this PR flips in by changing `invertedDirection` to `true` for our use of `buildThumbnailGallery`. This will render the photos by row instead.

This fixes #1736

<!-- Describe why we are making this change -->

## 🛠 Implementation details

See above

## 🎨 UI Changes

<!-- Add relevant screenshots -->
N/A

## 🧪 Testing

Pick 4 photos to upload, then send the message.

The grid should be rendered with the first two photos you selected in the first row, as opposed to the first column.



## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


