### PR TITLE
fix: auto focus on input box on mount and command selection

### DIFF
--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -389,6 +389,7 @@ const AutoCompleteInputWithContext = <
 
   return (
     <TextInput
+      autoFocus={true}
       maxLength={maxMessageLength}
       multiline
       onChangeText={(newText) => {


### PR DESCRIPTION
## 🎯 Goal

Fixes #1508 

## 🛠 Implementation details

Set `autoFocus={true}` prop on underlying `TextInput` component. So that when you select a command or mount MessageInput component, focus will be automatically set on input box.
