### PR TITLE
feat: always open connection when app goes to foreground

### DIFF
--- a/package/src/components/Chat/hooks/useIsOnline.ts
+++ b/package/src/components/Chat/hooks/useIsOnline.ts
@@ -40,10 +40,10 @@ export const useIsOnline = <
   }, [closeConnectionOnBackground, client, clientExists]);
 
   const onForeground = useCallback(() => {
-    if (!closeConnectionOnBackground || !clientExists) return;
+    if (!clientExists) return;
 
     client.openConnection();
-  }, [closeConnectionOnBackground, client, clientExists]);
+  }, [client, clientExists]);
 
   useAppStateListener(onForeground, onBackground);
 


### PR DESCRIPTION
## 🎯 Goal
Android app state handling makes us disconnect the client every time an Activity is launched (even if it’s the same bundle ID). 

By calling `openConnection` regardless of `closeConnectionOnBackground` we're making sure that the chat functionality will behave normally when returning to the app. 

## 🛠 Implementation details
Changing the logics of the `onForeground` callback.

Calling `openConnection` regardless of `closeConnectionOnBackground` we're making sure that the chat functionality will behave normally when returning to the app. 

## 🎨 UI Changes

N/A

## 🧪 Testing

- on android device launch the sample app
- enable logger on the chat client
- go from background to foreground immediately (within a couple of seconds), then you should see `client:openConnection() - open connection called twice...`
- wait for around 20-30 seconds, then this.wsPromise = this.connect(); should get called

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


