### PR TITLE
fix: unresponsive clear button when the file type is not supported

### DIFF
--- a/package/src/components/MessageInput/FileUploadPreview.tsx
+++ b/package/src/components/MessageInput/FileUploadPreview.tsx
@@ -100,6 +100,7 @@ const UnsupportedFileTypeOrFileSizeIndicator = ({
   } = useTheme();
 
   const { t } = useTranslationContext();
+
   return indicatorType === ProgressIndicatorTypes.NOT_SUPPORTED ? (
     <View style={styles.unsupportedFile}>
       <Warning

--- a/package/src/components/MessageInput/UploadProgressIndicator.tsx
+++ b/package/src/components/MessageInput/UploadProgressIndicator.tsx
@@ -70,7 +70,7 @@ export const UploadProgressIndicator: React.FC<UploadProgressIndicatorProps> = (
     theme: {
       colors: { overlay: overlayColor },
       messageInput: {
-        uploadProgressIndicator: { container, overlay },
+        uploadProgressIndicator: { container },
       },
     },
   } = useTheme();
@@ -82,7 +82,6 @@ export const UploadProgressIndicator: React.FC<UploadProgressIndicatorProps> = (
   ) : (
     <View style={[styles.overflowHidden, style]} testID='active-upload-progress-indicator'>
       {children}
-      <View style={[styles.overlay, { backgroundColor: overlayColor }, overlay]} />
       <View
         style={[
           type === ProgressIndicatorTypes.NOT_SUPPORTED ? styles.overflowHidden : styles.container,


### PR DESCRIPTION
## 🎯 Goal

Fixes #1732 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The overlay is removed which was not making the entire file area unresponsive. It doesn't make sense to keep it and therefore it is removed in this PR.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


