### PR TITLE
fix: export pickDocument from the handler dir

### DIFF
--- a/package/native-package/src/handlers/index.ts
+++ b/package/native-package/src/handlers/index.ts
@@ -4,6 +4,7 @@ export * from './compressImage';
 export * from './getLocalAssetUri';
 export * from './getPhotos';
 export * from './NetInfo';
+export * from './pickDocument';
 export * from './saveFile';
 export * from './takePhoto';
 export * from './triggerHaptic';


### PR DESCRIPTION
## 🎯 Goal

Missing export of pickDocument made it through to develop, not caught automatically since the index file in native-package is JS and not TS

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


