### PR TITLE
fix: use the default export of haptic feedback

### DIFF
--- a/package/native-package/src/handlers/triggerHaptic.ts
+++ b/package/native-package/src/handlers/triggerHaptic.ts
@@ -1,7 +1,7 @@
 let ReactNativeHapticFeedback;
 
 try {
-  ReactNativeHapticFeedback = require('react-native-haptic-feedback');
+  ReactNativeHapticFeedback = require('react-native-haptic-feedback').default;
 } catch (e) {
   console.warn('react-native-haptic-feedback is not installed.');
 }


### PR DESCRIPTION
## 🎯 Goal

For haptic feedback, we weren't using the default export, resulting in the function not being available. This PR sorts that out by explicitly using the default export.

This fixes #1753 

## 🛠 Implementation details

see above

## 🎨 UI Changes

n/a

## 🧪 Testing

Run an app without haptic feedback, then long press a message. Overlay should be visible, no error should be thrown.

Then install react-native-haptic-feedback and do the same.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


