### PR TITLE
docs(push): unsubscribe of push token was not called properly

### DIFF
--- a/docusaurus/docs/reactnative/guides/push_notifications_v1.mdx
+++ b/docusaurus/docs/reactnative/guides/push_notifications_v1.mdx
@@ -118,11 +118,13 @@ const requestPermission = async () => {
 
 const App = () => {
   const [isReady, setIsReady] = useState(false);
+  const unsubscribeTokenRefreshListenerRef = useRef<() => void>();
 
   useEffect(() => {
-    let unsubscribeTokenRefreshListener;
     // Register FCM token with stream chat server.
     const registerPushToken = async () => {
+      // unsubscribe any previous listener
+      unsubscribeTokenRefreshListenerRef.current?.();
       const token = await messaging().getToken();
       await client.addDevice(token, 'firebase');
 
@@ -144,7 +146,7 @@ const App = () => {
 
     return async () => {
       await client?.disconnectUser();
-      unsubscribeTokenRefreshListener?.();
+      unsubscribeTokenRefreshListenerRef.current?.();
     };
   }, []);
 

--- a/docusaurus/docs/reactnative/guides/push_notifications_v2.mdx
+++ b/docusaurus/docs/reactnative/guides/push_notifications_v2.mdx
@@ -138,11 +138,13 @@ const requestPermission = async () => {
 
 const App = () => {
   const [isReady, setIsReady] = useState(false);
+  const unsubscribeTokenRefreshListenerRef = useRef<() => void>();
 
   useEffect(() => {
-    let unsubscribeTokenRefreshListener;
     // Register FCM token with stream chat server.
     const registerPushToken = async () => {
+      // unsubscribe any previous listener
+      unsubscribeTokenRefreshListenerRef.current?.();
       const token = await messaging().getToken();
       const push_provider = 'firebase';
       const push_provider_name = 'MyRNAppFirebasePush'; // name an alias for your push provider (optional)
@@ -161,7 +163,7 @@ const App = () => {
         }
       };
 
-      unsubscribeTokenRefreshListener = messaging().onTokenRefresh(async newToken => {
+      unsubscribeTokenRefreshListenerRef.current = messaging().onTokenRefresh(async newToken => {
         await Promise.all([
           removeOldToken(),
           client.addDevice(newToken, push_provider, USER_ID, push_provider_name),
@@ -182,7 +184,7 @@ const App = () => {
 
     return async () => {
       await client?.disconnectUser();
-      unsubscribeTokenRefreshListener?.();
+      unsubscribeTokenRefreshListenerRef.current?.();
     };
   }, []);
 

--- a/docusaurus/reactnative_versioned_docs/version-4.x.x/guides/push_notifications_v1.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-4.x.x/guides/push_notifications_v1.mdx
@@ -118,11 +118,13 @@ const requestPermission = async () => {
 
 const App = () => {
   const [isReady, setIsReady] = useState(false);
+  const unsubscribeTokenRefreshListenerRef = useRef<() => void>();
 
   useEffect(() => {
-    let unsubscribeTokenRefreshListener;
     // Register FCM token with stream chat server.
     const registerPushToken = async () => {
+      // unsubscribe any previous listener
+      unsubscribeTokenRefreshListenerRef.current?.();
       const token = await messaging().getToken();
       await client.addDevice(token, 'firebase');
 
@@ -144,7 +146,7 @@ const App = () => {
 
     return async () => {
       await client?.disconnectUser();
-      unsubscribeTokenRefreshListener?.();
+      unsubscribeTokenRefreshListenerRef.current?.();
     };
   }, []);
 

--- a/docusaurus/reactnative_versioned_docs/version-4.x.x/guides/push_notifications_v2.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-4.x.x/guides/push_notifications_v2.mdx
@@ -133,11 +133,13 @@ const requestPermission = async () => {
 
 const App = () => {
   const [isReady, setIsReady] = useState(false);
+  const unsubscribeTokenRefreshListenerRef = useRef<() => void>();
 
   useEffect(() => {
-    let unsubscribeTokenRefreshListener;
     // Register FCM token with stream chat server.
     const registerPushToken = async () => {
+      // unsubscribe any previous listener
+      unsubscribeTokenRefreshListenerRef.current?.();
       const token = await messaging().getToken();
       const push_provider = 'firebase';
       const push_provider_name = 'MyRNAppFirebasePush'; // name an alias for your push provider (optional)
@@ -156,7 +158,7 @@ const App = () => {
         }
       };
 
-      unsubscribeTokenRefreshListener = messaging().onTokenRefresh(async newToken => {
+      unsubscribeTokenRefreshListenerRef.current = messaging().onTokenRefresh(async newToken => {
         await Promise.all([
           removeOldToken(),
           client.addDevice(newToken, push_provider, USER_ID, push_provider_name),
@@ -177,7 +179,7 @@ const App = () => {
 
     return async () => {
       await client?.disconnectUser();
-      unsubscribeTokenRefreshListener?.();
+      unsubscribeTokenRefreshListenerRef.current?.();
     };
   }, []);
 


### PR DESCRIPTION
## 🎯 Goal

The docs of unsubscribe of push token was not called properly. Causing support questions related to this. However sample app doesn't have this problem as it is using useRef so never faced this there. This part of the docs was ported from v2 so another reason that it was never checked.

## 🛠 Implementation details

NA

## 🎨 UI Changes

NA

## 🧪 Testing

NA

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


