### PR TITLE
fix: read receipts should not be removed due to message update

### DIFF
--- a/package/src/components/MessageList/utils/getReadStates.ts
+++ b/package/src/components/MessageList/utils/getReadStates.ts
@@ -66,7 +66,7 @@ export const getReadStates = <
            * to the array of last reads for that message and remove
            * the user from the list of users being checked
            */
-          if (message.updated_at < member.last_read) {
+          if (message.created_at < member.last_read) {
             /**
              * if this is a direct message the length will be 1
              * as we already deleted the current user from the object


### PR DESCRIPTION
## 🎯 Goal

Fixes https://github.com/GetStream/stream-chat-react-native/issues/1778

Internal discussion thread - https://getstream.slack.com/archives/CE5N802GP/p1668528970036629

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


