### PR TITLE
feat: Make the DocumentPicker dependency optional

### DIFF
--- a/package/native-package/src/handlers/pickDocument.ts
+++ b/package/native-package/src/handlers/pickDocument.ts
@@ -1,27 +1,50 @@
-import DocumentPicker from 'react-native-document-picker';
-
-export const pickDocument = async ({ maxNumberOfFiles }: { maxNumberOfFiles: number }) => {
-  try {
-    let res = await DocumentPicker.pickMultiple({
-      type: [DocumentPicker.types.allFiles],
-    });
-
-    if (maxNumberOfFiles && res.length > maxNumberOfFiles) {
-      res = res.slice(0, maxNumberOfFiles);
-    }
-
-    return {
-      cancelled: false,
-      docs: res.map(({ name, size, type, uri }) => ({
-        name,
-        size,
-        type,
-        uri,
-      })),
-    };
-  } catch (err) {
-    return {
-      cancelled: true,
-    };
-  }
+/**
+ * Types are approximated from what we need from the DocumentPicker API.
+ *
+ * For its full API, see https://github.com/rnmods/react-native-document-picker/blob/master/src/index.tsx
+ * */
+type ResponseValue = {
+  name: string;
+  uri: string;
+  size: number;
+  type: string;
 };
+
+let DocumentPicker: {
+  types: { allFiles: string };
+  pickMultiple: (opts?: { type: string[] }) => Promise<ResponseValue[]>;
+};
+
+try {
+  DocumentPicker = require('react-native-document-picker').default;
+} catch (err) {
+  console.log('react-native-document-picker is not installed');
+}
+
+export const pickDocument = DocumentPicker
+  ? async ({ maxNumberOfFiles }: { maxNumberOfFiles: number }) => {
+      try {
+        let res = await DocumentPicker.pickMultiple({
+          type: [DocumentPicker.types.allFiles],
+        });
+
+        if (maxNumberOfFiles && res.length > maxNumberOfFiles) {
+          res = res.slice(0, maxNumberOfFiles);
+        }
+
+        return {
+          cancelled: false,
+          docs: res.map(({ name, size, type, uri }) => ({
+            name,
+            size,
+            type,
+            uri,
+          })),
+        };
+      } catch (err) {
+        return {
+          cancelled: true,
+        };
+      }
+    }
+  : null;

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -71,7 +71,7 @@ import {
   ThumbsUpReaction,
   WutReaction,
 } from '../../icons';
-import { FlatList as FlatListDefault } from '../../native';
+import { FlatList as FlatListDefault, pickDocument } from '../../native';
 import type { DefaultStreamChatGenerics } from '../../types/types';
 import { generateRandomId, MessageStatusTypes, ReactionData } from '../../utils/utils';
 import { Attachment as AttachmentDefault } from '../Attachment/Attachment';
@@ -447,7 +447,8 @@ const ChannelWithContext = <
     handleRetry,
     handleThreadReply,
     hasCommands = true,
-    hasFilePicker = true,
+    // If pickDocument isn't available, default to hiding the file picker
+    hasFilePicker = pickDocument !== null,
     hasImagePicker = true,
     hideDateSeparators = false,
     hideStickyDateHeader = false,
@@ -558,8 +559,9 @@ const ChannelWithContext = <
   const [loadingMore, setLoadingMore] = useState(false);
 
   const [loadingMoreRecent, setLoadingMoreRecent] = useState(false);
-  const [quotedMessage, setQuotedMessage] =
-    useState<boolean | MessageType<StreamChatGenerics>>(false);
+  const [quotedMessage, setQuotedMessage] = useState<boolean | MessageType<StreamChatGenerics>>(
+    false,
+  );
   const [thread, setThread] = useState<ThreadContextValue<StreamChatGenerics>['thread']>(
     threadProps || null,
   );

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -559,9 +559,8 @@ const ChannelWithContext = <
   const [loadingMore, setLoadingMore] = useState(false);
 
   const [loadingMoreRecent, setLoadingMoreRecent] = useState(false);
-  const [quotedMessage, setQuotedMessage] = useState<boolean | MessageType<StreamChatGenerics>>(
-    false,
-  );
+  const [quotedMessage, setQuotedMessage] =
+    useState<boolean | MessageType<StreamChatGenerics>>(false);
   const [thread, setThread] = useState<ThreadContextValue<StreamChatGenerics>['thread']>(
     threadProps || null,
   );

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -574,6 +574,13 @@ export const MessageInputProvider = <
   };
 
   const pickFile = async () => {
+    if (pickDocument === null) {
+      console.log(
+        'The file picker is not installed. Check our Getting Started documentation to install it.',
+      );
+      return;
+    }
+
     if (numberOfUploads >= value.maxNumberOfFiles) {
       Alert.alert('Maximum number of files reached');
       return;

--- a/package/src/native.ts
+++ b/package/src/native.ts
@@ -251,7 +251,7 @@ export const registerNativeHandlers = (handlers: Handlers) => {
     getPhotos = handlers.getPhotos;
   }
 
-  if (handlers.pickDocument) {
+  if (handlers.pickDocument !== undefined) {
     pickDocument = handlers.pickDocument;
   }
 


### PR DESCRIPTION
## 🎯 Goal

Make the DocumentPicker dependency optional

## 🛠 Implementation details

This hides the document picker icon by default if the DocumentPicker isn't available

## 🎨 UI Changes

None

## 🧪 Testing

Set up an app without the document picker - you should not be able to access the document picker in the attachment picker.

If you then install the document picker, it should reappear, and work as expected.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [-] Expo iOS and Android


