### PR TITLE
fix: import React Dependency into Video / Sound files

### DIFF
--- a/package/native-package/src/handlers/Sound.tsx
+++ b/package/native-package/src/handlers/Sound.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import AudioVideoPlayer from '../optionalDependencies/Video';
 
 export const Sound = {
@@ -6,22 +7,22 @@ export const Sound = {
   // eslint-disable-next-line react/display-name
   Player: AudioVideoPlayer
     ? ({ onBuffer, onEnd, onLoad, onProgress, paused, soundRef, style, uri }) => (
-      <AudioVideoPlayer
-        audioOnly={true}
-        onBuffer={onBuffer}
-        onEnd={onEnd}
-        onError={(error: Error) => {
-          console.log(error);
-        }}
-        onLoad={onLoad}
-        onProgress={onProgress}
-        paused={paused}
-        ref={soundRef}
-        source={{
-          uri,
-        }}
-        style={style}
-      />
-    )
+        <AudioVideoPlayer
+          audioOnly={true}
+          onBuffer={onBuffer}
+          onEnd={onEnd}
+          onError={(error: Error) => {
+            console.log(error);
+          }}
+          onLoad={onLoad}
+          onProgress={onProgress}
+          paused={paused}
+          ref={soundRef}
+          source={{
+            uri,
+          }}
+          style={style}
+        />
+      )
     : null,
 };

--- a/package/native-package/src/handlers/Sound.tsx
+++ b/package/native-package/src/handlers/Sound.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import AudioVideoPlayer from '../optionalDependencies/Video';
 
 export const Sound = {
@@ -5,22 +6,22 @@ export const Sound = {
   // eslint-disable-next-line react/display-name
   Player: AudioVideoPlayer
     ? ({ onBuffer, onEnd, onLoad, onProgress, paused, soundRef, style, uri }) => (
-        <AudioVideoPlayer
-          audioOnly={true}
-          onBuffer={onBuffer}
-          onEnd={onEnd}
-          onError={(error: Error) => {
-            console.log(error);
-          }}
-          onLoad={onLoad}
-          onProgress={onProgress}
-          paused={paused}
-          ref={soundRef}
-          source={{
-            uri,
-          }}
-          style={style}
-        />
-      )
+      <AudioVideoPlayer
+        audioOnly={true}
+        onBuffer={onBuffer}
+        onEnd={onEnd}
+        onError={(error: Error) => {
+          console.log(error);
+        }}
+        onLoad={onLoad}
+        onProgress={onProgress}
+        paused={paused}
+        ref={soundRef}
+        source={{
+          uri,
+        }}
+        style={style}
+      />
+    )
     : null,
 };

--- a/package/native-package/src/handlers/Video.tsx
+++ b/package/native-package/src/handlers/Video.tsx
@@ -1,22 +1,23 @@
+import React from 'react';
 import AudioVideoPlayer from '../optionalDependencies/Video';
 export const Video = AudioVideoPlayer
   ? ({ onBuffer, onEnd, onLoad, onProgress, paused, repeat, style, uri, videoRef }) => (
-      <AudioVideoPlayer
-        ignoreSilentSwitch={'ignore'}
-        onBuffer={onBuffer}
-        onEnd={onEnd}
-        onError={(error) => {
-          console.error(error);
-        }}
-        onLoad={onLoad}
-        onProgress={onProgress}
-        paused={paused}
-        ref={videoRef}
-        repeat={repeat}
-        source={{
-          uri,
-        }}
-        style={style}
-      />
-    )
+    <AudioVideoPlayer
+      ignoreSilentSwitch={'ignore'}
+      onBuffer={onBuffer}
+      onEnd={onEnd}
+      onError={(error) => {
+        console.error(error);
+      }}
+      onLoad={onLoad}
+      onProgress={onProgress}
+      paused={paused}
+      ref={videoRef}
+      repeat={repeat}
+      source={{
+        uri,
+      }}
+      style={style}
+    />
+  )
   : null;

--- a/package/native-package/src/handlers/Video.tsx
+++ b/package/native-package/src/handlers/Video.tsx
@@ -1,23 +1,24 @@
 import React from 'react';
+
 import AudioVideoPlayer from '../optionalDependencies/Video';
 export const Video = AudioVideoPlayer
   ? ({ onBuffer, onEnd, onLoad, onProgress, paused, repeat, style, uri, videoRef }) => (
-    <AudioVideoPlayer
-      ignoreSilentSwitch={'ignore'}
-      onBuffer={onBuffer}
-      onEnd={onEnd}
-      onError={(error) => {
-        console.error(error);
-      }}
-      onLoad={onLoad}
-      onProgress={onProgress}
-      paused={paused}
-      ref={videoRef}
-      repeat={repeat}
-      source={{
-        uri,
-      }}
-      style={style}
-    />
-  )
+      <AudioVideoPlayer
+        ignoreSilentSwitch={'ignore'}
+        onBuffer={onBuffer}
+        onEnd={onEnd}
+        onError={(error) => {
+          console.error(error);
+        }}
+        onLoad={onLoad}
+        onProgress={onProgress}
+        paused={paused}
+        ref={videoRef}
+        repeat={repeat}
+        source={{
+          uri,
+        }}
+        style={style}
+      />
+    )
   : null;


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->
Currently, if you try to play a video from chat or upload a mp3 file the sdk errors up saying React is not present inside the relevant files.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->
Adding React import to Sound.tsx and Video.tsx

## 🎨 UI Changes

<!-- Add relevant screenshots -->
None
<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->
Upload a Sound file to GetStream chat or a video file

## ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [] Documentation is updated
- [] New code is tested in main example apps, including all possible scenarios
  - [] SampleApp iOS and Android
  - [] Expo iOS and Android


