### PR TITLE
fix: unmatched border radius for image gallery grid handle

### DIFF
--- a/package/src/components/ImageGallery/components/ImageGridHandle.tsx
+++ b/package/src/components/ImageGallery/components/ImageGridHandle.tsx
@@ -13,8 +13,8 @@ const styles = StyleSheet.create({
   },
   handle: {
     alignItems: 'center',
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
     flexDirection: 'row',
     height: 40,
     justifyContent: 'center',


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

The top border radius for the image gallery grid handle creates an unpleasant-looking small gap when displayed in dark mode.

## 🛠 Implementation details

This PR removes the gap by reducing the top border radius from `16` to `12`.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/16998534/203241034-26f6a24e-cb06-4fb3-8569-4402e6eb721d.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/16998534/203241115-8edb2f70-960c-4954-93f9-949ee777e23a.png" />
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


