### PR TITLE
fix: Allow theme override for certain components

### DIFF
--- a/package/src/components/ImageGallery/components/ImageGalleryFooter.tsx
+++ b/package/src/components/ImageGallery/components/ImageGalleryFooter.tsx
@@ -178,7 +178,7 @@ export const ImageGalleryFooterWithContext = <
       pointerEvents={'box-none'}
       style={styles.wrapper}
     >
-      <ReanimatedSafeAreaView style={[container, footerStyle, { backgroundColor: white }]}>
+      <ReanimatedSafeAreaView style={[container, { backgroundColor: white }, footerStyle]}>
         {photo.type === 'video' ? (
           videoControlElement ? (
             videoControlElement({ duration, onPlayPause, paused, progress })
@@ -191,7 +191,7 @@ export const ImageGalleryFooterWithContext = <
             />
           )
         ) : null}
-        <View style={[styles.innerContainer, innerContainer, { backgroundColor: white }]}>
+        <View style={[styles.innerContainer, { backgroundColor: white }, innerContainer]}>
           {leftElement ? (
             leftElement({ openGridView, photo, share, shareMenuOpen })
           ) : (

--- a/package/src/components/ImageGallery/components/ImageGalleryFooter.tsx
+++ b/package/src/components/ImageGallery/components/ImageGalleryFooter.tsx
@@ -178,7 +178,7 @@ export const ImageGalleryFooterWithContext = <
       pointerEvents={'box-none'}
       style={styles.wrapper}
     >
-      <ReanimatedSafeAreaView style={[container, { backgroundColor: white }, footerStyle]}>
+      <ReanimatedSafeAreaView style={[footerStyle, { backgroundColor: white }, container]}>
         {photo.type === 'video' ? (
           videoControlElement ? (
             videoControlElement({ duration, onPlayPause, paused, progress })

--- a/package/src/components/Message/MessageSimple/MessageTextContainer.tsx
+++ b/package/src/components/Message/MessageSimple/MessageTextContainer.tsx
@@ -87,7 +87,7 @@ const MessageTextContainerWithContext = <
 
   return (
     <View
-      style={[styles.textContainer, textContainer, stylesProp.textContainer]}
+      style={[styles.textContainer, stylesProp.textContainer, textContainer]}
       testID='message-text-container'
     >
       {MessageText ? (

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -552,9 +552,9 @@ const MessageInputWithContext = <
       {triggerType && suggestions ? (
         <View
           style={[
-            suggestionListContainer,
             styles.suggestionsListContainer,
             { backgroundColor: white, bottom: height },
+            suggestionListContainer,
           ]}
         >
           <AutoCompleteSuggestionList

--- a/package/src/components/MessageOverlay/OverlayReactions.tsx
+++ b/package/src/components/MessageOverlay/OverlayReactions.tsx
@@ -319,7 +319,7 @@ export const OverlayReactions: React.FC<OverlayReactionsProps> = (props) => {
         keyExtractor={({ name }, index) => `${name}_${index}`}
         numColumns={numColumns}
         renderItem={renderItem}
-        style={[styles.flatListContainer, flatListContainer, { maxHeight: maxHeight / numColumns }]}
+        style={[styles.flatListContainer, { maxHeight: maxHeight / numColumns }, flatListContainer]}
       />
     </Animated.View>
   );


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

Allow overriding UI component styles using theme configs.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

The order of styles in the style prop array affects the order in which the styles are implemented. To allow theme styles to override default styles, the theme styles have to be placed last in the style prop array.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img src="https://user-images.githubusercontent.com/16998534/203428513-30a86248-3f19-4d2f-93e4-63cfcc3e7505.png" />
            </td>
            <td>
                <img src="https://user-images.githubusercontent.com/16998534/203429612-f5bc5fed-32a6-41d9-878c-2fc9f1494234.png" />
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


