### PR TITLE
fix: remove the unnecessary remapping of chat-core import

### DIFF
--- a/package/src/components/Chat/hooks/useAppSettings.ts
+++ b/package/src/components/Chat/hooks/useAppSettings.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 
 import type { AppSettingsAPIResponse, StreamChat } from 'stream-chat';
-import type { DefaultStreamChatGenerics } from 'stream-chat-react-native';
+
+import type { DefaultStreamChatGenerics } from '../../../types/types';
 
 export const useAppSettings = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,

--- a/package/tsconfig.json
+++ b/package/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "stream-chat-react-native": ["./src/index"]
-    },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "esModuleInterop": true,


### PR DESCRIPTION
## 🎯 Goal

We found remapping of `stream-chat-react-native` in tsconfig to be ugly. This PR removes it.

## 🛠 Implementation details

NA

## 🎨 UI Changes

NA

## 🧪 Testing

`yarn` build must complete successfully.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


