### PR TITLE
feat: allow theming the container for pinned messages

### DIFF
--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -282,7 +282,7 @@ const MessageWithContext = <
   const {
     theme: {
       colors: { bg_gradient_start, targetedMessageBackground },
-      messageSimple: { targetedMessageUnderlay },
+      messageSimple: { targetedMessageContainer, targetedMessageUnderlay },
     },
   } = useTheme();
 
@@ -698,7 +698,12 @@ const MessageWithContext = <
 
   return (
     <View
-      style={[message.pinned && { backgroundColor: targetedMessageBackground }]}
+      style={[
+        message.pinned && {
+          backgroundColor: targetedMessageBackground,
+          ...targetedMessageContainer,
+        },
+      ]}
       testID='message-wrapper'
     >
       <View

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -700,8 +700,8 @@ const MessageWithContext = <
     <View
       style={[
         message.pinned && {
-          backgroundColor: targetedMessageBackground,
           ...targetedMessageContainer,
+          backgroundColor: targetedMessageBackground,
         },
       ]}
       testID='message-wrapper'

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -501,6 +501,7 @@ export type Theme = {
       statusContainer: ViewStyle;
       timeIcon: IconProps;
     };
+    targetedMessageContainer: ViewStyle;
     targetedMessageUnderlay: ViewStyle;
     videoThumbnail: {
       container: ViewStyle;
@@ -1042,6 +1043,7 @@ export const defaultTheme: Theme = {
         width: DEFAULT_STATUS_ICON_SIZE,
       },
     },
+    targetedMessageContainer: {},
     targetedMessageUnderlay: {},
     videoThumbnail: {
       container: {},


### PR DESCRIPTION
## 🎯 Goal

Currently you can only theme the background color for targeted messages. This aims to make it possible to add viewstyles to the container for pinned messages

This fixes #1865 

## 🛠 Implementation details

Kept naming similar to existing targeted message theming

## 🎨 UI Changes

None

## 🧪 Testing

Add styles to `theme.messageSimple.targetedMessageContainer`, pin a message, and see that your changes are reflected in the app

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


