### PR TITLE
feat: initial unread count example

### DIFF
--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -65,7 +65,7 @@ const Drawer = createDrawerNavigator();
 const Stack = createStackNavigator<StackNavigatorParamList>();
 const UserSelectorStack = createStackNavigator<UserSelectorParamList>();
 const App = () => {
-  const { chatClient, isConnecting, loginUser, logout, switchUser } = useChatClient();
+  const { chatClient, isConnecting, loginUser, logout, switchUser, unreadCount } = useChatClient();
   const colorScheme = useColorScheme();
   const streamChatTheme = useStreamChatTheme();
 
@@ -131,7 +131,7 @@ const App = () => {
             dark: colorScheme === 'dark',
           }}
         >
-          <AppContext.Provider value={{ chatClient, loginUser, logout, switchUser }}>
+          <AppContext.Provider value={{ chatClient, loginUser, logout, switchUser, unreadCount }}>
             {isConnecting && !chatClient ? (
               <LoadingScreen />
             ) : chatClient ? (

--- a/examples/SampleApp/src/components/UnreadCountBadge.tsx
+++ b/examples/SampleApp/src/components/UnreadCountBadge.tsx
@@ -26,26 +26,13 @@ export const UnreadCountBadge: React.FC = () => {
     },
   } = useTheme();
 
-  const { chatClient } = useAppContext();
-  const [count, setCount] = useState<number>();
-
-  useEffect(() => {
-    const listener = chatClient?.on((e) => {
-      if (e.total_unread_count !== undefined) {
-        setCount(e.total_unread_count);
-      }
-    });
-
-    return () => {
-      if (listener) {
-        listener.unsubscribe();
-      }
-    };
-  }, [chatClient]);
+  const { unreadCount } = useAppContext();
 
   return (
     <View style={[styles.unreadContainer, { backgroundColor: accent_red }]}>
-      {!!count && <Text style={styles.unreadText}>{count > 99 ? '99+' : count}</Text>}
+      {!!unreadCount && (
+        <Text style={styles.unreadText}>{unreadCount > 99 ? '99+' : unreadCount}</Text>
+      )}
     </View>
   );
 };

--- a/examples/SampleApp/src/context/AppContext.ts
+++ b/examples/SampleApp/src/context/AppContext.ts
@@ -9,6 +9,7 @@ type AppContextType = {
   loginUser: (config: LoginConfig) => void;
   logout: () => void;
   switchUser: (userId?: string) => void;
+  unreadCount: number | undefined;
 };
 
 export const AppContext = React.createContext({} as AppContextType);

--- a/package/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreview.tsx
@@ -63,9 +63,8 @@ const ChannelPreviewWithContext = <
 
     const newUnreadCount = channel.countUnread();
 
-    if (newUnreadCount !== unread) {
-      setUnread(newUnreadCount);
-    }
+
+    setUnread(newUnreadCount);
   }, [channelLastMessageString]);
 
   useEffect(() => {


### PR DESCRIPTION
## 🎯 Goal

Sample app doesnt retrieve the unread count on the mount. This PR aims to add it.

Additionally, I removed a small unnecessary `if statement` in the SDK, which wouldn't fix any bug. 

## 🛠 Implementation details

NA

## 🎨 UI Changes

NA

## 🧪 Testing

Open sample app send some messages from another sample app instance. Do not open the channel. So that they remain unread. Reload the packager, the unread count should show what was shown previously before the reload.

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


