### PR TITLE
fix: always watch channel before passing to channel component

### DIFF
--- a/examples/SampleApp/src/screens/ChannelScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelScreen.tsx
@@ -121,11 +121,10 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
       if (!chatClient || !channelId) return;
 
       const newChannel = chatClient?.channel('messaging', channelId);
-      setChannel(newChannel);
-
       if (!newChannel?.initialized) {
         await newChannel?.watch();
       }
+      setChannel(newChannel);
     };
 
     initChannel();


### PR DESCRIPTION
## 🎯 Goal

Details: https://github.com/GetStream/stream-chat-react-native/issues/1853#issuecomment-1354260277

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


