### PR TITLE
feat(SampleApp): Add dev menu item to clear the local DB

### DIFF
--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -1,10 +1,16 @@
 import React, { useEffect } from 'react';
-import { LogBox, Platform, useColorScheme } from 'react-native';
+import { DevSettings, LogBox, Platform, useColorScheme } from 'react-native';
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Chat, OverlayProvider, ThemeProvider, useOverlayContext } from 'stream-chat-react-native';
+import {
+  Chat,
+  OverlayProvider,
+  QuickSqliteClient,
+  ThemeProvider,
+  useOverlayContext,
+} from 'stream-chat-react-native';
 import messaging from '@react-native-firebase/messaging';
 import notifee, { EventType } from '@notifee/react-native';
 import { AppContext } from './src/context/AppContext';
@@ -33,6 +39,11 @@ import type { StreamChat } from 'stream-chat';
 
 LogBox.ignoreLogs(["Seems like you're using an old API"]);
 LogBox.ignoreLogs(['Each child in a list should have a unique']);
+
+DevSettings.addMenuItem('Reset local DB (offline storage)', () => {
+  QuickSqliteClient.resetDB();
+  console.info('Local DB reset');
+});
 
 import type {
   StackNavigatorParamList,


### PR DESCRIPTION
## 🎯 Goal

This allows for easily resetting the database through the dev menu in the SampleApp

## 🛠 Implementation details

n/a

## 🎨 UI Changes

<img width="423" alt="image" src="https://user-images.githubusercontent.com/1548276/208913160-2ff4605b-7e12-4601-86b8-5187e24cdd06.png">


## 🧪 Testing

Selecting the button in the dev menu should clear out your local database for the offline support

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


