### PR TITLE
fix: do not render images twice on markdown

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -261,6 +261,8 @@ export const renderText = <
   );
 
   const customRules = {
+    // do not render images, we will scrape them out of the message and show on attachment card component
+    image: { match: () => null },
     link: { react: link },
     list: { react: list },
     // Truncate long text content in the message overlay


### PR DESCRIPTION
## 🎯 Goal

Fixes #1883 

## 🛠 Implementation details

Disables the markdown parser for images. This is in alignment with iOS SDK and react SDK.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

Put this message `![Some GIF](https://media.giphy.com/media/dkGhBWE3SyzXW/giphy.gif)`. You should see only one gif.

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


