### PR TITLE
fix: do not fixate on peer dependency versions unnecessarily

### DIFF
--- a/package/expo-package/package.json
+++ b/package/expo-package/package.json
@@ -13,7 +13,7 @@
     "stream-chat-react-native-core": "5.7.0"
   },
   "peerDependencies": {
-    "@react-native-community/netinfo": "^6.0.0",
+    "@react-native-community/netinfo": ">=6.0.0",
     "expo": ">=44.0.0",
     "expo-document-picker": "*",
     "expo-file-system": "*",

--- a/package/native-package/package.json
+++ b/package/native-package/package.json
@@ -14,7 +14,7 @@
     "stream-chat-react-native-core": "5.7.0"
   },
   "peerDependencies": {
-    "@react-native-camera-roll/camera-roll": "^5.0.0",
+    "@react-native-camera-roll/camera-roll": ">=5.0.0",
     "@react-native-community/netinfo": ">=2.0.7",
     "@stream-io/flat-list-mvcp": "^0.10.2",
     "react-native": ">=0.60.0",

--- a/package/package.json
+++ b/package/package.json
@@ -82,7 +82,7 @@
     "stream-chat": "8.1.2"
   },
   "peerDependencies": {
-    "react-native-svg": "^12.1.0"
+    "react-native-svg": ">=12.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.17",


### PR DESCRIPTION
## 🎯 Goal

- having an old netinfo peer dependency forces users to use `npm i --force` while the latest is compatible as well
- SVG peer dependency needs updating - fixes #1898
- camera roll dependency is unnecessarily fixated to v5, while v6 may come out

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


