### PR TITLE
fix: apply workaround for android anr

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -93,10 +93,8 @@ const styles = StyleSheet.create({
   },
 });
 
-const CustomCellRendererComponent = ({ children, ...props }: React.PropsWithChildren<unknown>) => (
-  <View {...props} style={styles.invertAndroid}>
-    {children}
-  </View>
+const InvertedCellRendererComponent = (props: React.PropsWithChildren<unknown>) => (
+  <View {...props} style={styles.invertAndroid} />
 );
 
 const keyExtractor = <
@@ -991,7 +989,7 @@ const MessageListWithContext = <
     >
       <FlatList
         CellRendererComponent={
-          shouldApplyAndroidWorkaround ? CustomCellRendererComponent : undefined
+          shouldApplyAndroidWorkaround ? InvertedCellRendererComponent : undefined
         }
         contentContainerStyle={[styles.contentContainer, contentContainer]}
         data={messageList}

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -75,6 +75,11 @@ const styles = StyleSheet.create({
   },
   flex: { flex: 1 },
   invert: { transform: [{ scaleY: -1 }] },
+  invertAndroid: {
+    // Invert the Y AND X axis to prevent a react native issue that can lead to ANRs on android 13
+    // details: https://github.com/Expensify/App/pull/12820
+    transform: [{ scaleX: -1 }, { scaleY: -1 }],
+  },
   listContainer: {
     flex: 1,
     width: '100%',
@@ -87,6 +92,12 @@ const styles = StyleSheet.create({
     top: 0,
   },
 });
+
+const CustomCellRendererComponent = ({ children, ...props }: React.PropsWithChildren<unknown>) => (
+  <View {...props} style={styles.invertAndroid}>
+    {children}
+  </View>
+);
 
 const keyExtractor = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -970,17 +981,23 @@ const MessageListWithContext = <
     return null;
   };
 
+  const shouldApplyAndroidWorkaround =
+    inverted && Platform.OS === 'android' && Platform.Version >= 33;
+
   return (
     <View
       style={[styles.container, { backgroundColor: white_snow }, container]}
       testID='message-flat-list-wrapper'
     >
       <FlatList
+        CellRendererComponent={
+          shouldApplyAndroidWorkaround ? CustomCellRendererComponent : undefined
+        }
         contentContainerStyle={[styles.contentContainer, contentContainer]}
         data={messageList}
         /** Disables the MessageList UI. Which means, message actions, reactions won't work. */
         extraData={disabled || !hasNoMoreRecentMessagesToLoad}
-        inverted={inverted}
+        inverted={shouldApplyAndroidWorkaround ? false : inverted}
         keyboardShouldPersistTaps='handled'
         keyExtractor={keyExtractor}
         ListEmptyComponent={renderListEmptyComponent}
@@ -1000,7 +1017,12 @@ const MessageListWithContext = <
         ref={refCallback}
         renderItem={renderItem}
         scrollEnabled={overlay === 'none'}
-        style={[styles.listContainer, listContainer]}
+        showsVerticalScrollIndicator={!shouldApplyAndroidWorkaround}
+        style={[
+          styles.listContainer,
+          listContainer,
+          shouldApplyAndroidWorkaround ? styles.invertAndroid : undefined,
+        ]}
         testID='message-flat-list'
         viewabilityConfig={flatListViewabilityConfig}
         {...additionalFlatListProps}

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -162,6 +162,7 @@ exports[`Thread should match thread snapshot 1`] = `
         renderItem={[Function]}
         scrollEnabled={false}
         scrollEventThrottle={50}
+        showsVerticalScrollIndicator={true}
         stickyHeaderIndices={Array []}
         style={
           Array [
@@ -178,6 +179,7 @@ exports[`Thread should match thread snapshot 1`] = `
                 "width": "100%",
               },
               Object {},
+              undefined,
             ],
           ]
         }


### PR DESCRIPTION
## 🎯 Goal

fixes #1810 

## 🛠 Implementation details

ref: https://github.com/Expensify/App/pull/12820


## 🧪 Testing

Open message list in Android 33 OS, it should behave as normal without any freeze.

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [x] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


