### PR TITLE
fix: empty state component was falsely inverted

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -956,10 +956,19 @@ const MessageListWithContext = <
       });
   }
 
-  const renderListEmptyComponent = () => (
-    <View style={[styles.flex, styles.invert]} testID='empty-state'>
-      <EmptyStateIndicator listType='message' />
-    </View>
+  const shouldApplyAndroidWorkaround =
+    inverted && Platform.OS === 'android' && Platform.Version >= 33;
+
+  const renderListEmptyComponent = useCallback(
+    () => (
+      <View
+        style={[styles.flex, shouldApplyAndroidWorkaround ? styles.invertAndroid : styles.invert]}
+        testID='empty-state'
+      >
+        <EmptyStateIndicator listType='message' />
+      </View>
+    ),
+    [EmptyStateIndicator, shouldApplyAndroidWorkaround],
   );
 
   if (!FlatList) return null;
@@ -978,9 +987,6 @@ const MessageListWithContext = <
     if (messageListLengthAfterUpdate) return <DateHeader dateString={stickyHeaderDateString} />;
     return null;
   };
-
-  const shouldApplyAndroidWorkaround =
-    inverted && Platform.OS === 'android' && Platform.Version >= 33;
 
   return (
     <View


### PR DESCRIPTION
## 🎯 Goal

Fixes #1968 

## 🧪 Testing

Set a EmptyStateComponent for message list and pass an empty array as data, it should not be inverted

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


