### PR TITLE
fix: missing userSyncStatus db upon clean install

### DIFF
--- a/package/src/components/Chat/hooks/useAppSettings.ts
+++ b/package/src/components/Chat/hooks/useAppSettings.ts
@@ -10,12 +10,14 @@ export const useAppSettings = <
   client: StreamChat<StreamChatGenerics>,
   isOnline: boolean | null,
   enableOfflineSupport: boolean,
+  initialisingDatabase: boolean,
 ): AppSettingsAPIResponse | null => {
   const [appSettings, setAppSettings] = useState<AppSettingsAPIResponse | null>(null);
   const isMounted = useRef(true);
 
   useEffect(() => {
     async function enforeAppSettings() {
+      if (!initialisingDatabase) return;
       if (!client.userID) return;
 
       if (!isOnline && enableOfflineSupport) {
@@ -46,7 +48,7 @@ export const useAppSettings = <
     return () => {
       isMounted.current = false;
     };
-  }, [client, isOnline]);
+  }, [client, isOnline, initialisingDatabase]);
 
   return appSettings;
 };


### PR DESCRIPTION
## 🎯 Goal

While doing a clean install with offline support, or changing from enableOfflineSupport={false} to true on the sample with no previous db table. We get the following error:

```
Error: [react-native-quick-sqlite] SQL execution error: no such table: userSyncStatus
```

This PR aims to fix the issue.

## 🛠 Implementation details

A race condition happens such that the userSyncStatus table is accessed before it is created. In this PR, I added a state to wait till DB is initialized.

## 🎨 UI Changes

NA

## 🧪 Testing

1. Remove the current sample app on iOS simulator
2. Set enableOfflineSupport to false
3. Open app
4. Force closes the app
5. Set enableOfflineSupport to true
6. Open the app again
7. The error shared above should not happen

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


