### PR TITLE
fix: blank screen on offline support if user id is lazily set

### DIFF
--- a/package/src/components/Chat/Chat.tsx
+++ b/package/src/components/Chat/Chat.tsx
@@ -167,7 +167,7 @@ const ChatWithContext = <
     closeConnectionOnBackground,
   );
 
-  const [initialisedDatabase, setInitialisedDatabase] = useState(!enableOfflineSupport);
+  const [initialisedDatabase, setInitialisedDatabase] = useState(false);
 
   /**
    * Setup muted user listener

--- a/package/src/components/Chat/Chat.tsx
+++ b/package/src/components/Chat/Chat.tsx
@@ -167,7 +167,7 @@ const ChatWithContext = <
     closeConnectionOnBackground,
   );
 
-  const [initialisingDatabase, setInitialisingDatabase] = useState(enableOfflineSupport);
+  const [initialisedDatabase, setInitialisedDatabase] = useState(!enableOfflineSupport);
 
   /**
    * Setup muted user listener
@@ -194,20 +194,20 @@ const ChatWithContext = <
           data: client.user,
         });
     }
-  }, [client]);
+  }, [client, enableOfflineSupport]);
 
   const setActiveChannel = (newChannel?: Channel<StreamChatGenerics>) => setChannel(newChannel);
 
   useEffect(() => {
     if (client.user?.id && enableOfflineSupport) {
-      setInitialisingDatabase(true);
+      setInitialisedDatabase(false);
       QuickSqliteClient.initializeDatabase();
       DBSyncManager.init(client as unknown as StreamChat);
-      setInitialisingDatabase(false);
+      setInitialisedDatabase(true);
     }
   }, [client?.user?.id, enableOfflineSupport]);
 
-  const appSettings = useAppSettings(client, isOnline, enableOfflineSupport, initialisingDatabase);
+  const appSettings = useAppSettings(client, isOnline, enableOfflineSupport, initialisedDatabase);
 
   const chatContext = useCreateChatContext({
     appSettings,
@@ -226,7 +226,7 @@ const ChatWithContext = <
     enableOfflineSupport,
   });
 
-  if (loadingTranslators || initialisingDatabase) return null;
+  if (loadingTranslators) return null;
 
   return (
     <ChatProvider<StreamChatGenerics> value={chatContext}>

--- a/package/src/components/Chat/hooks/useAppSettings.ts
+++ b/package/src/components/Chat/hooks/useAppSettings.ts
@@ -10,17 +10,16 @@ export const useAppSettings = <
   client: StreamChat<StreamChatGenerics>,
   isOnline: boolean | null,
   enableOfflineSupport: boolean,
-  initialisingDatabase: boolean,
+  initialisedDatabase: boolean,
 ): AppSettingsAPIResponse | null => {
   const [appSettings, setAppSettings] = useState<AppSettingsAPIResponse | null>(null);
   const isMounted = useRef(true);
 
   useEffect(() => {
     async function enforeAppSettings() {
-      if (initialisingDatabase) return;
       if (!client.userID) return;
 
-      if (!isOnline && enableOfflineSupport) {
+      if (!isOnline && enableOfflineSupport && initialisedDatabase) {
         const appSettings = dbApi.getAppSettings({ currentUserId: client.userID });
         setAppSettings(appSettings);
         return;
@@ -48,7 +47,7 @@ export const useAppSettings = <
     return () => {
       isMounted.current = false;
     };
-  }, [client, isOnline, initialisingDatabase]);
+  }, [client, isOnline, initialisedDatabase]);
 
   return appSettings;
 };


### PR DESCRIPTION
## 🎯 Goal

#2001 caused a bug that a blank screen would appear if user id is not set on offline support. This PR fixes it.

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


