### PR TITLE
fix: scrollToFirstUnreadMessage not working

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -850,7 +850,7 @@ const MessageListWithContext = <
         countUnread > scrollToFirstUnreadThreshold
       ) {
         // find the first unread message, if we have to initially scroll to an unread message
-        if (messageList.length > countUnread) {
+        if (messageList.length >= countUnread) {
           messageIdToScroll = messageList[countUnread - 1].id;
         }
       } else if (targetedMessage && messageIdLastScrolledToRef.current !== targetedMessage) {

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -360,13 +360,6 @@ const MessageListWithContext = <
   const [stickyHeaderDate, setStickyHeaderDate] = useState<Date | undefined>();
   const stickyHeaderDateRef = useRef<Date | undefined>();
 
-  const isUnreadMessageRef = useRef(
-    (
-      message: MessageType<StreamChatGenerics> | undefined,
-      lastRead?: ReturnType<StreamChannel<StreamChatGenerics>['lastRead']>,
-    ) => message && lastRead && message.created_at && lastRead < message.created_at,
-  );
-
   // ref for channel to use in useEffect without triggering it on channel change
   const channelRef = useRef(channel);
   channelRef.current = channel;
@@ -540,11 +533,11 @@ const MessageListWithContext = <
     const lastRead = channel.lastRead();
     const countUnread = channel.countUnread();
 
-    function isMessageUnread(messageArrayIndex: number) {
-      if (lastRead) {
-        return message.created_at && lastRead < message.created_at;
+    function isMessageUnread(messageArrayIndex: number): boolean {
+      if (lastRead && message.created_at) {
+        return lastRead < message.created_at;
       } else {
-        const isLatestMessageSetShown = channel.state.messageSets.find(
+        const isLatestMessageSetShown = !!channel.state.messageSets.find(
           (set) => set.isCurrent && set.isLatest,
         );
         return isLatestMessageSetShown && messageArrayIndex <= countUnread - 1;

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -540,21 +540,20 @@ const MessageListWithContext = <
     const lastRead = channel.lastRead();
     const countUnread = channel.countUnread();
 
-    const lastMessage = messageList?.[index + 1];
+    function isMessageUnread(messageArrayIndex: number) {
+      if (lastRead) {
+        return message.created_at && lastRead < message.created_at;
+      } else {
+        const isLatestMessageSetShown = channel.state.messageSets.find(
+          (set) => set.isCurrent && set.isLatest,
+        );
+        return isLatestMessageSetShown && messageArrayIndex <= countUnread - 1;
+      }
+    }
+    const isCurrentMessageUnread = isMessageUnread(index);
+    const isLastMessageUnread = isMessageUnread(index + 1);
 
-    const isLatestMessageSetShown = channel.state.messageSets.find(
-      (set) => set.isCurrent && set.isLatest,
-    );
-
-    const isMessageIndexUnread = (i: number) => isLatestMessageSetShown && i <= countUnread - 1;
-    const isUnreadMessage =
-      isMessageIndexUnread(index) || !!isUnreadMessageRef.current(message, lastRead);
-    const isLastMessageUnread =
-      isMessageIndexUnread(index + 1) || !!isUnreadMessageRef.current(lastMessage, lastRead);
-
-    const showUnreadUnderlay =
-      isUnreadMessage ||
-      (!!isUnreadMessageRef.current(message, lastRead) && scrollToBottomButtonVisible);
+    const showUnreadUnderlay = isCurrentMessageUnread && scrollToBottomButtonVisible;
     const insertInlineUnreadIndicator = showUnreadUnderlay && !isLastMessageUnread;
 
     if (message.type === 'system') {

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -367,6 +367,7 @@ const MessageListWithContext = <
     ) => message && lastRead && message.created_at && lastRead < message.created_at,
   );
 
+  // ref for channel to use in useEffect without triggering it on channel change
   const channelRef = useRef(channel);
   channelRef.current = channel;
 

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -541,14 +541,20 @@ const MessageListWithContext = <
 
     const lastMessage = messageList?.[index + 1];
 
-    const isFirstUnreadMessage =
-      countUnread > scrollToFirstUnreadThreshold && index === countUnread - 1;
+    const isLatestMessageSetShown = channel.state.messageSets.find(
+      (set) => set.isCurrent && set.isLatest,
+    );
+
+    const isMessageIndexUnread = (i: number) => isLatestMessageSetShown && i <= countUnread - 1;
+    const isUnreadMessage =
+      isMessageIndexUnread(index) || !!isUnreadMessageRef.current(message, lastRead);
+    const isLastMessageUnread =
+      isMessageIndexUnread(index + 1) || !!isUnreadMessageRef.current(lastMessage, lastRead);
 
     const showUnreadUnderlay =
-      isFirstUnreadMessage ||
+      isUnreadMessage ||
       (!!isUnreadMessageRef.current(message, lastRead) && scrollToBottomButtonVisible);
-    const insertInlineUnreadIndicator =
-      showUnreadUnderlay && !isUnreadMessageRef.current(lastMessage, lastRead);
+    const insertInlineUnreadIndicator = showUnreadUnderlay && !isLastMessageUnread;
 
     if (message.type === 'system') {
       return (

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -9,8 +9,6 @@ import {
   ViewToken,
 } from 'react-native';
 
-import type { Channel as StreamChannel } from 'stream-chat';
-
 import {
   isMessageWithStylesReadByAndDateSeparator,
   MessageType,


### PR DESCRIPTION
## 🎯 Goal

fixes #1989 

## 🛠 Implementation details

Uses countUnread method of chat-sdk if lastRead is unknown 

## 🧪 Testing

* Send more than 10 messages to a channel (make sure they are unread for the user who is seeing it)
* Open channel
* Should scroll to the first unread message

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


