### PR TITLE
fix: Add style prop to Bullet component

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -327,7 +327,10 @@ export const ListOutput = ({ node, output, state, styles }: ListOutputProps) => 
         if (item === null) {
           return (
             <ListRow key={index} style={styles?.listRow} testID='list-item'>
-              <Bullet index={node.ordered && indexAfterStart} />
+              <Bullet
+                index={node.ordered && indexAfterStart}
+                style={node.ordered ? styles?.listItemNumber : styles?.listItemBullet}
+              />
             </ListRow>
           );
         }
@@ -338,7 +341,10 @@ export const ListOutput = ({ node, output, state, styles }: ListOutputProps) => 
 
         return (
           <ListRow key={index} style={styles?.listRow} testID='list-item'>
-            <Bullet index={node.ordered && indexAfterStart} />
+            <Bullet
+              index={node.ordered && indexAfterStart}
+              style={node.ordered ? styles?.listItemNumber : styles?.listItemBullet}
+            />
             <ListItem key={1} style={[styles?.listItemText, style]}>
               {output(item, state)}
             </ListItem>
@@ -354,13 +360,13 @@ interface BulletProps extends TextProps {
 }
 
 const Bullet = ({ index, style }: BulletProps) => (
-  <Text key={0} style={[style, defaultMarkdownStyles.listItemNumber]}>
+  <Text key={0} style={style}>
     {index ? `${index}. ` : '\u2022 '}
   </Text>
 );
 
-const ListRow = (props: PropsWithChildren<ViewProps>) => (
-  <Text style={[props.style, defaultMarkdownStyles.listRow]}>{props.children}</Text>
+const ListRow = ({ children, style }: PropsWithChildren<ViewProps>) => (
+  <Text style={style}>{children}</Text>
 );
 
 const ListItem = ({ children, style }: PropsWithChildren<TextProps>) => (


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

Style was never added to `Bullet` so was always using the default `defaultMarkdownStyles`. This closes #2007 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

- Pass the correct markdown style to the `Bullet` component
- Updated `Bullet` and `ListRow` to use the main style object as that already has all the `defaultMarkdownStyles` and then allows for full customisation. 

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

- Open the Sample App, send a message that contains an ordered or unordered list
- See you have all the default markdown styles
- Update the `useStreamChatTheme` to provide a custom colour to the list
- See the list is now updated with the custom colour

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


