### PR TITLE
fix: android list is inverted when custom flatlist style is used

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -1012,6 +1012,17 @@ const MessageListWithContext = <
     return null;
   };
 
+  // We need to omit the style related props from the additionalFlatListProps and add them directly instead of spreading
+  let additionalFlatListPropsExcludingStyle:
+    | Omit<NonNullable<typeof additionalFlatListProps>, 'style' | 'contentContainerStyle'>
+    | undefined;
+
+  if (additionalFlatListProps) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { contentContainerStyle, style, ...rest } = additionalFlatListProps;
+    additionalFlatListPropsExcludingStyle = rest;
+  }
+
   return (
     <View
       style={[styles.container, { backgroundColor: white_snow }, container]}
@@ -1021,7 +1032,11 @@ const MessageListWithContext = <
         CellRendererComponent={
           shouldApplyAndroidWorkaround ? InvertedCellRendererComponent : undefined
         }
-        contentContainerStyle={[styles.contentContainer, contentContainer]}
+        contentContainerStyle={[
+          styles.contentContainer,
+          additionalFlatListProps?.contentContainerStyle,
+          contentContainer,
+        ]}
         data={messageList}
         /** Disables the MessageList UI. Which means, message actions, reactions won't work. */
         extraData={disabled || !hasNoMoreRecentMessagesToLoad}
@@ -1049,11 +1064,12 @@ const MessageListWithContext = <
         style={[
           styles.listContainer,
           listContainer,
+          additionalFlatListProps?.style,
           shouldApplyAndroidWorkaround ? styles.invertAndroid : undefined,
         ]}
         testID='message-flat-list'
         viewabilityConfig={flatListViewabilityConfig}
-        {...additionalFlatListProps}
+        {...additionalFlatListPropsExcludingStyle}
       />
       {!loading && (
         <>

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -43,6 +43,7 @@ exports[`Thread should match thread snapshot 1`] = `
               "flexGrow": 1,
               "paddingBottom": 4,
             },
+            undefined,
             Object {},
           ]
         }
@@ -179,6 +180,7 @@ exports[`Thread should match thread snapshot 1`] = `
                 "width": "100%",
               },
               Object {},
+              undefined,
               undefined,
             ],
           ]


### PR DESCRIPTION
## 🎯 Goal

fixes #2012 

## 🧪 Testing

Add the following prop

```
        <MessageList
              additionalFlatListProps={{
                style: { backgroundColor: '#ffffff' },
              }}
            />
```

the list should behave normally

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


