### PR TITLE
fix: initial scroll to first unread message was broken when there more than 55 unread messages

### DIFF
--- a/package/src/components/Channel/hooks/useTargetedMessage.ts
+++ b/package/src/components/Channel/hooks/useTargetedMessage.ts
@@ -14,7 +14,7 @@ export const useTargetedMessage = (messageId?: string) => {
     };
   }, []);
 
-  const setTargetedMessageTimeout = (messageId: string) => {
+  const setTargetedMessageTimeoutRef = useRef((messageId: string) => {
     clearTargetedMessageCall.current && clearTimeout(clearTargetedMessageCall.current);
 
     clearTargetedMessageCall.current = setTimeout(() => {
@@ -22,10 +22,10 @@ export const useTargetedMessage = (messageId?: string) => {
     }, 3000);
 
     setTargetedMessage(messageId);
-  };
+  });
 
   return {
-    setTargetedMessage: setTargetedMessageTimeout,
+    setTargetedMessage: setTargetedMessageTimeoutRef.current,
     targetedMessage,
   };
 };

--- a/package/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreview.tsx
@@ -53,6 +53,13 @@ const ChannelPreviewWithContext = <
   const channelLastMessageString = `${channelLastMessage?.id}${channelLastMessage?.updated_at}`;
 
   useEffect(() => {
+    const { unsubscribe } = client.on('notification.mark_read', () => {
+      setUnread(channel.countUnread());
+    });
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
     if (
       channelLastMessage &&
       (channelLastMessage.id !== lastMessage?.id ||

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -272,7 +272,6 @@ const MessageListWithContext = <
     overlay,
     reloadChannel,
     ScrollToBottomButton,
-    scrollToFirstUnreadThreshold,
     selectedPicker,
     setFlatListRef,
     setMessages,
@@ -332,14 +331,18 @@ const MessageListWithContext = <
    * If the prop `initialScrollToFirstUnreadMessage` was enabled, then we scroll to the unread msg and set it to true
    * If not, the default offset of 0 for flatList means that it has been set already
    */
-  const initialScrollSet = useRef<boolean>(!initialScrollToFirstUnreadMessage);
-
+  const [isInitialScrollDone, setInitialScrollDone] = useState(!initialScrollToFirstUnreadMessage);
   const channelResyncScrollSet = useRef<boolean>(true);
 
   /**
    * The timeout id used to debounce our scrollToIndex calls on messageList updates
    */
   const scrollToDebounceTimeoutRef = useRef<NodeJS.Timeout>();
+
+  /**
+   * The timeout id used to lazier load the initial scroll set flag
+   */
+  const initialScrollSettingTimeoutRef = useRef<NodeJS.Timeout>();
 
   /**
    * If a messageId was requested to scroll to but was unloaded,
@@ -361,6 +364,9 @@ const MessageListWithContext = <
   // ref for channel to use in useEffect without triggering it on channel change
   const channelRef = useRef(channel);
   channelRef.current = channel;
+  // ref for messageList to use in useEffect without triggering it on channel change
+  const messageListRef = useRef(messageList);
+  messageListRef.current = messageList;
 
   const updateStickyHeaderDateIfNeeded = (viewableItems: ViewToken[]) => {
     if (viewableItems.length) {
@@ -423,29 +429,39 @@ const MessageListWithContext = <
   }, [disabled]);
 
   useEffect(() => {
-    /**
-     * 1. !initialScrollToFirstUnreadMessage && channel.countUnread() > 0
-     *
-     *    In this case MessageList won't scroll to first unread message when opened, so we can mark
-     *    the channel as read right after opening.
-     *
-     * 2. initialScrollToFirstUnreadMessage && channel.countUnread() <= scrollToFirstUnreadThreshold
-     *
-     *    In this case MessageList will be opened to first unread message.
-     *    But if there are not enough (scrollToFirstUnreadThreshold) unread messages, then MessageList
-     *    won't need to scroll up. So we can safely mark the channel as read right after opening.
-     */
-    const shouldMarkReadOnFirstLoad =
-      !loading &&
-      channel &&
-      ((!initialScrollToFirstUnreadMessage && channel.countUnread() > 0) ||
-        (initialScrollToFirstUnreadMessage &&
-          channel.countUnread() <= scrollToFirstUnreadThreshold));
+    const getShouldMarkReadAutomatically = (): boolean => {
+      if (loading || !channel) {
+        // nothing to do
+        return false;
+      } else if (channel.countUnread() > 0) {
+        if (!initialScrollToFirstUnreadMessage) {
+          /*
+           * In this case MessageList won't scroll to first unread message when opened, so we can mark
+           * the channel as read right after opening.
+           * */
+          return true;
+        } else {
+          /*
+           * In this case MessageList will be opened to first unread message.
+           * But if there are were not enough unread messages, so that scrollToBottom button was not shown
+           * then MessageList won't need to scroll up. So we can safely mark the channel as read right after opening.
+           *
+           * NOTE: we must ensure that initial scroll is done, otherwise we do not wait till the unread scroll is finished
+           * */
+          if (scrollToBottomButtonVisible) return false;
+          /* if scrollToBottom button was not visible, wait till
+           * - initial scroll is done (indicates that if scrolling to index was needed it was triggered)
+           * */
+          return isInitialScrollDone;
+        }
+      }
+      return false;
+    };
 
-    if (shouldMarkReadOnFirstLoad) {
+    if (getShouldMarkReadAutomatically()) {
       markRead();
     }
-  }, [loading]);
+  }, [loading, scrollToBottomButtonVisible, isInitialScrollDone]);
 
   useEffect(() => {
     const lastReceivedMessage = getLastReceivedMessage(messageList);
@@ -492,7 +508,7 @@ const MessageListWithContext = <
 
     if (threadList || hasNoMoreRecentMessagesToLoad) {
       scrollToBottomIfNeeded();
-    } else if (!scrollToBottomButtonVisible) {
+    } else {
       setScrollToBottomButtonVisible(true);
     }
 
@@ -529,23 +545,17 @@ const MessageListWithContext = <
     if (!channel || (!channel.initialized && !channel.offlineMode)) return null;
 
     const lastRead = channel.lastRead();
-    const countUnread = channel.countUnread();
 
     function isMessageUnread(messageArrayIndex: number): boolean {
-      if (lastRead && message.created_at) {
-        return lastRead < message.created_at;
-      } else {
-        const isLatestMessageSetShown = !!channel.state.messageSets.find(
-          (set) => set.isCurrent && set.isLatest,
-        );
-        return isLatestMessageSetShown && messageArrayIndex <= countUnread - 1;
+      const msg = messageList?.[messageArrayIndex];
+      if (lastRead && msg?.created_at) {
+        return lastRead < msg.created_at;
       }
+      return false;
     }
     const isCurrentMessageUnread = isMessageUnread(index);
-    const isLastMessageUnread = isMessageUnread(index + 1);
-
     const showUnreadUnderlay = isCurrentMessageUnread && scrollToBottomButtonVisible;
-    const insertInlineUnreadIndicator = showUnreadUnderlay && !isLastMessageUnread;
+    const insertInlineUnreadIndicator = showUnreadUnderlay && !isMessageUnread(index + 1); // show only if previous message is read
 
     if (message.type === 'system') {
       return (
@@ -742,8 +752,8 @@ const MessageListWithContext = <
       maybeCallOnEndReached();
     }
 
-    // Show scrollToBottom button once scroll position goes beyond 300.
-    const isScrollAtBottom = offset <= 300;
+    // Show scrollToBottom button once scroll position goes beyond 150.
+    const isScrollAtBottom = offset <= 150;
     const showScrollToBottomButton = !isScrollAtBottom || !hasNoMoreRecentMessagesToLoad;
 
     const shouldMarkRead =
@@ -824,32 +834,23 @@ const MessageListWithContext = <
     [messageList],
   );
 
+  // console.log({ lastRead: channel.lastRead()?.toLocaleString() });
+
   /**
    * Check if a messageId needs to be scrolled to after list loads, and scroll to it
    * Note: This effect fires on every list change with a small debounce so that scrolling isnt abrupted by an immediate rerender
    */
   useEffect(() => {
-    if (scrollToDebounceTimeoutRef.current) clearTimeout(scrollToDebounceTimeoutRef.current);
     scrollToDebounceTimeoutRef.current = setTimeout(() => {
       // goToMessage method might have requested to scroll to a message
       let messageIdToScroll: string | undefined = messageIdToScrollToRef.current;
-      const countUnread = channelRef.current?.countUnread();
-      if (
-        !initialScrollSet.current &&
-        initialScrollToFirstUnreadMessage &&
-        countUnread > scrollToFirstUnreadThreshold
-      ) {
-        // find the first unread message, if we have to initially scroll to an unread message
-        if (messageList.length >= countUnread) {
-          messageIdToScroll = messageList[countUnread - 1].id;
-        }
-      } else if (targetedMessage && messageIdLastScrolledToRef.current !== targetedMessage) {
+      if (targetedMessage && messageIdLastScrolledToRef.current !== targetedMessage) {
         // if some messageId was targeted but not scrolledTo yet
         // we have scroll to there after loading completes
         messageIdToScroll = targetedMessage;
       }
       if (!messageIdToScroll) return;
-      const indexOfParentInMessageList = messageList.findIndex(
+      const indexOfParentInMessageList = messageListRef.current.findIndex(
         (message) => message?.id === messageIdToScroll,
       );
       if (indexOfParentInMessageList !== -1 && flatListRef.current) {
@@ -858,18 +859,23 @@ const MessageListWithContext = <
           index: indexOfParentInMessageList,
           viewPosition: 0.5, // try to place message in the center of the screen
         });
+        if (initialScrollToFirstUnreadMessage) {
+          initialScrollSettingTimeoutRef.current = setTimeout(() => {
+            // small timeout to ensure that handleScroll is called after scrollToIndex to set this flag
+            setInitialScrollDone(true);
+          }, 500);
+        }
         // reset the messageId tracker to not scroll to that again
         messageIdToScrollToRef.current = undefined;
         // keep track of this messageId, so that we dont scroll to again for targeted message change
         messageIdLastScrolledToRef.current = messageIdToScroll;
-        if (!initialScrollSet.current && initialScrollToFirstUnreadMessage) {
-          initialScrollSet.current = true;
-        } else {
-          setTargetedMessage(messageIdToScroll);
-        }
       }
     }, 150);
-  }, [channel.initialized, messageList, targetedMessage, initialScrollToFirstUnreadMessage]);
+    return () => {
+      clearTimeout(scrollToDebounceTimeoutRef.current);
+      clearTimeout(initialScrollSettingTimeoutRef.current);
+    };
+  }, [targetedMessage, initialScrollToFirstUnreadMessage]);
 
   const messagesWithImages =
     legacyImageViewerSwipeBehaviour &&

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -839,6 +839,12 @@ const MessageListWithContext = <
    */
   useEffect(() => {
     scrollToDebounceTimeoutRef.current = setTimeout(() => {
+      if (initialScrollToFirstUnreadMessage) {
+        initialScrollSettingTimeoutRef.current = setTimeout(() => {
+          // small timeout to ensure that handleScroll is called after scrollToIndex to set this flag
+          setInitialScrollDone(true);
+        }, 500);
+      }
       // goToMessage method might have requested to scroll to a message
       let messageIdToScroll: string | undefined = messageIdToScrollToRef.current;
       if (targetedMessage && messageIdLastScrolledToRef.current !== targetedMessage) {
@@ -856,12 +862,6 @@ const MessageListWithContext = <
           index: indexOfParentInMessageList,
           viewPosition: 0.5, // try to place message in the center of the screen
         });
-        if (initialScrollToFirstUnreadMessage) {
-          initialScrollSettingTimeoutRef.current = setTimeout(() => {
-            // small timeout to ensure that handleScroll is called after scrollToIndex to set this flag
-            setInitialScrollDone(true);
-          }, 500);
-        }
         // reset the messageId tracker to not scroll to that again
         messageIdToScrollToRef.current = undefined;
         // keep track of this messageId, so that we dont scroll to again for targeted message change

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -364,9 +364,6 @@ const MessageListWithContext = <
   // ref for channel to use in useEffect without triggering it on channel change
   const channelRef = useRef(channel);
   channelRef.current = channel;
-  // ref for messageList to use in useEffect without triggering it on channel change
-  const messageListRef = useRef(messageList);
-  messageListRef.current = messageList;
 
   const updateStickyHeaderDateIfNeeded = (viewableItems: ViewToken[]) => {
     if (viewableItems.length) {
@@ -850,7 +847,7 @@ const MessageListWithContext = <
         messageIdToScroll = targetedMessage;
       }
       if (!messageIdToScroll) return;
-      const indexOfParentInMessageList = messageListRef.current.findIndex(
+      const indexOfParentInMessageList = messageList.findIndex(
         (message) => message?.id === messageIdToScroll,
       );
       if (indexOfParentInMessageList !== -1 && flatListRef.current) {
@@ -875,7 +872,7 @@ const MessageListWithContext = <
       clearTimeout(scrollToDebounceTimeoutRef.current);
       clearTimeout(initialScrollSettingTimeoutRef.current);
     };
-  }, [targetedMessage, initialScrollToFirstUnreadMessage]);
+  }, [targetedMessage, initialScrollToFirstUnreadMessage, messageList]);
 
   const messagesWithImages =
     legacyImageViewerSwipeBehaviour &&

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -831,8 +831,6 @@ const MessageListWithContext = <
     [messageList],
   );
 
-  // console.log({ lastRead: channel.lastRead()?.toLocaleString() });
-
   /**
    * Check if a messageId needs to be scrolled to after list loads, and scroll to it
    * Note: This effect fires on every list change with a small debounce so that scrolling isnt abrupted by an immediate rerender

--- a/package/src/components/MessageList/utils/getReadStates.ts
+++ b/package/src/components/MessageList/utils/getReadStates.ts
@@ -6,7 +6,7 @@ import type { DefaultStreamChatGenerics } from '../../../types/types';
 export const getReadStates = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 >(
-  clientUserId: string | undefined,
+  _clientUserId: string | undefined,
   messages:
     | PaginatedMessageListContextValue<StreamChatGenerics>['messages']
     | ThreadContextValue<StreamChatGenerics>['threadMessages'],
@@ -26,7 +26,7 @@ export const getReadStates = <
      * Channel read state is stored by user and we only care about users who aren't the client
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { clientUserId: ignore, ...filteredRead } = read;
+    const { _clientUserId: ignore, ...filteredRead } = read;
     const members = Object.values(filteredRead);
 
     /**

--- a/package/src/components/MessageList/utils/getReadStates.ts
+++ b/package/src/components/MessageList/utils/getReadStates.ts
@@ -6,7 +6,7 @@ import type { DefaultStreamChatGenerics } from '../../../types/types';
 export const getReadStates = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 >(
-  _clientUserId: string | undefined,
+  clientUserId: string | undefined,
   messages:
     | PaginatedMessageListContextValue<StreamChatGenerics>['messages']
     | ThreadContextValue<StreamChatGenerics>['threadMessages'],
@@ -26,7 +26,7 @@ export const getReadStates = <
      * Channel read state is stored by user and we only care about users who aren't the client
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { _clientUserId: ignore, ...filteredRead } = read;
+    const { [clientUserId ?? '']: _ignore, ...filteredRead } = read;
     const members = Object.values(filteredRead);
 
     /**

--- a/package/src/components/MessageList/utils/getReadStates.ts
+++ b/package/src/components/MessageList/utils/getReadStates.ts
@@ -25,10 +25,9 @@ export const getReadStates = <
     /**
      * Channel read state is stored by user and we only care about users who aren't the client
      */
-    if (clientUserId) {
-      delete read[clientUserId];
-    }
-    const members = Object.values(read);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { clientUserId: ignore, ...filteredRead } = read;
+    const members = Object.values(filteredRead);
 
     /**
      * Track number of members who have read previous messages


### PR DESCRIPTION
## 🎯 Goal

While @khushal87 investigated #2004, he found that when there were large number of unread messages, the scroll to first unread was broken

## 🛠 Implementation details

The main fix is f35b4486ad098ed1f0e5b7fd1fd4918e80d11252. This fixed a lot of issues

## Demo

https://user-images.githubusercontent.com/3846977/226427987-1af0b8e5-d0fc-4389-aec4-5a1f42967ec4.mp4

## 🧪 Testing

- Open sample app
- Login as "vir"

### Case 1
- Load 7 unread messages - `for i in {1..7}; do stream-cli chat send-message --user "25100e34-4450-3dcb-82eb-fbc34d2b421b" --channel-id "c1ece5ff-a5b1-4e4c-305c-4313fbc2e876" --channel-type "messaging"  --text `date +"%T"`; done`
- open the channel, should highlight the unread message, but should NOT show the unread banner on top of the message
- after 1 or 2 seconds the channel's unread count must become 0

### Case 2
- Go to homepage
-  Load 80 unread messages - `for i in {1..80}; do stream-cli chat send-message --user "25100e34-4450-3dcb-82eb-fbc34d2b421b" --channel-id "c1ece5ff-a5b1-4e4c-305c-4313fbc2e876" --channel-type "messaging"  --text `date +"%T"`; done`
- open the channel, should highlight the unread message, and SHOULD show the unread banner on top of the message
- scroll to bottom
- after 1 or 2 seconds the channel's unread count must become 0

And there should be no unnecessary blank list when this happens. This was a rerender issue before!

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


