### PR TITLE
fix: typo in i18n string about cannot flag message

### DIFF
--- a/package/src/i18n/en.json
+++ b/package/src/i18n/en.json
@@ -6,7 +6,7 @@
   "Are you sure you want to permanently delete this message?": "Are you sure you want to permanently delete this message?",
   "Block User": "Block User",
   "Cancel": "Cancel",
-  "Cannot Flag Message": "Cannot Flat Message",
+  "Cannot Flag Message": "Cannot Flag Message",
   "Copy Message": "Copy Message",
   "Delete": "Delete",
   "Delete Message": "Delete Message",


### PR DESCRIPTION
Changing "Cannot Flag Message": "Cannot Flat Message" to "Cannot Flag Message": "Cannot Flag Message"

## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


