### PR TITLE
fix: removing a reaction outside of the latest reactions causes to add it

### DIFF
--- a/examples/ExpoMessaging/yarn.lock
+++ b/examples/ExpoMessaging/yarn.lock
@@ -6670,10 +6670,10 @@ stream-buffers@2.2.x:
   version "0.0.0"
   uid ""
 
-stream-chat-react-native-core@5.11.2:
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.11.2.tgz#fc136917f481e44151819820fe475b49c45b06e3"
-  integrity sha512-tWEBxstr27znQMuAhxNucBrk/WfCPLUAwmSodkVKKtwA+2Roo8dn/6FVYNLoq6TgGVKbGvtTs+ZOaUsAxFlnkQ==
+stream-chat-react-native-core@5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.0.tgz#84fed9d65a24b4a92daa6793ac218078d56abdf1"
+  integrity sha512-CJ5gdf4mT+io44cWXkT2wy1kLnyzY05AFdGe2i+KBk4fqubpRpl1MFbgvnAjkcrwvMHnvh131tMxWzOlKkqkkw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gorhom/bottom-sheet" "4.4.5"

--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -7499,10 +7499,10 @@ stream-buffers@2.2.x:
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
   integrity sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==
 
-stream-chat-react-native-core@5.11.2:
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.11.2.tgz#fc136917f481e44151819820fe475b49c45b06e3"
-  integrity sha512-tWEBxstr27znQMuAhxNucBrk/WfCPLUAwmSodkVKKtwA+2Roo8dn/6FVYNLoq6TgGVKbGvtTs+ZOaUsAxFlnkQ==
+stream-chat-react-native-core@5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.0.tgz#84fed9d65a24b4a92daa6793ac218078d56abdf1"
+  integrity sha512-CJ5gdf4mT+io44cWXkT2wy1kLnyzY05AFdGe2i+KBk4fqubpRpl1MFbgvnAjkcrwvMHnvh131tMxWzOlKkqkkw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gorhom/bottom-sheet" "4.4.5"

--- a/examples/TypeScriptMessaging/yarn.lock
+++ b/examples/TypeScriptMessaging/yarn.lock
@@ -7114,10 +7114,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stream-chat-react-native-core@5.11.2:
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.11.2.tgz#fc136917f481e44151819820fe475b49c45b06e3"
-  integrity sha512-tWEBxstr27znQMuAhxNucBrk/WfCPLUAwmSodkVKKtwA+2Roo8dn/6FVYNLoq6TgGVKbGvtTs+ZOaUsAxFlnkQ==
+stream-chat-react-native-core@5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.0.tgz#84fed9d65a24b4a92daa6793ac218078d56abdf1"
+  integrity sha512-CJ5gdf4mT+io44cWXkT2wy1kLnyzY05AFdGe2i+KBk4fqubpRpl1MFbgvnAjkcrwvMHnvh131tMxWzOlKkqkkw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gorhom/bottom-sheet" "4.4.5"

--- a/package/expo-package/yarn.lock
+++ b/package/expo-package/yarn.lock
@@ -3006,10 +3006,10 @@ stream-buffers@2.2.x:
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
   integrity sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==
 
-stream-chat-react-native-core@5.11.2:
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.11.2.tgz#fc136917f481e44151819820fe475b49c45b06e3"
-  integrity sha512-tWEBxstr27znQMuAhxNucBrk/WfCPLUAwmSodkVKKtwA+2Roo8dn/6FVYNLoq6TgGVKbGvtTs+ZOaUsAxFlnkQ==
+stream-chat-react-native-core@5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.0.tgz#84fed9d65a24b4a92daa6793ac218078d56abdf1"
+  integrity sha512-CJ5gdf4mT+io44cWXkT2wy1kLnyzY05AFdGe2i+KBk4fqubpRpl1MFbgvnAjkcrwvMHnvh131tMxWzOlKkqkkw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gorhom/bottom-sheet" "4.4.5"

--- a/package/native-package/yarn.lock
+++ b/package/native-package/yarn.lock
@@ -4515,10 +4515,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stream-chat-react-native-core@5.11.2:
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.11.2.tgz#fc136917f481e44151819820fe475b49c45b06e3"
-  integrity sha512-tWEBxstr27znQMuAhxNucBrk/WfCPLUAwmSodkVKKtwA+2Roo8dn/6FVYNLoq6TgGVKbGvtTs+ZOaUsAxFlnkQ==
+stream-chat-react-native-core@5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.0.tgz#84fed9d65a24b4a92daa6793ac218078d56abdf1"
+  integrity sha512-CJ5gdf4mT+io44cWXkT2wy1kLnyzY05AFdGe2i+KBk4fqubpRpl1MFbgvnAjkcrwvMHnvh131tMxWzOlKkqkkw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gorhom/bottom-sheet" "4.4.5"


### PR DESCRIPTION
## 🎯 Goal

Fixing the following bug reported by teamworks

```
when toggling a reaction off, we get breaking behavior if there are more than 10 messages AND my reaction wasn't in the last 10 reactions

so if my reaction isn't in the last 10 reactions, it should remove, but instead it adds, which causes silly behavior
```

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


