### PR TITLE
fix: make takePhoto native handler compatible with latest expo versions

### DIFF
--- a/package/expo-package/package.json
+++ b/package/expo-package/package.json
@@ -32,7 +32,7 @@
     "expo-file-system": "^11.0.2",
     "expo-haptics": "^10.0.0",
     "expo-image-manipulator": "^9.1.0",
-    "expo-image-picker": "^10.1.4",
+    "expo-image-picker": "14.1.1",
     "expo-media-library": "^12.0.2",
     "expo-sharing": "^9.1.2"
   },

--- a/package/expo-package/package.json
+++ b/package/expo-package/package.json
@@ -19,7 +19,7 @@
     "expo-file-system": "*",
     "expo-haptics": "*",
     "expo-image-manipulator": "*",
-    "expo-image-picker": "*",
+    "expo-image-picker": ">=14.1.0",
     "expo-media-library": "*",
     "expo-sharing": "*"
   },

--- a/package/expo-package/src/handlers/takePhoto.ts
+++ b/package/expo-package/src/handlers/takePhoto.ts
@@ -16,11 +16,15 @@ export const takePhoto = async ({ compressImageQuality = 1 }) => {
         : await ImagePicker.requestCameraPermissionsAsync();
 
     if (permissionGranted?.status === 'granted' || permissionGranted?.granted === true) {
-      const photo = await ImagePicker.launchCameraAsync({
+      const imagePickerSuccessResult = await ImagePicker.launchCameraAsync({
         quality: Math.min(Math.max(0, compressImageQuality), 1),
       });
+      const canceled = imagePickerSuccessResult.canceled;
+      const assets = imagePickerSuccessResult.assets;
+      // since we only support single photo upload for now we will only be focusing on 0'th element.
+      const photo = assets && assets[0];
 
-      if (photo.cancelled === false && photo.height && photo.width && photo.uri) {
+      if (canceled === false && photo && photo.height && photo.width && photo.uri) {
         let size: Size = {};
         if (Platform.OS === 'android') {
           // Height and width returned by ImagePicker are incorrect on Android.

--- a/package/expo-package/yarn.lock
+++ b/package/expo-package/yarn.lock
@@ -1874,6 +1874,11 @@ expo-haptics@^10.0.0:
   resolved "https://registry.yarnpkg.com/expo-haptics/-/expo-haptics-10.1.0.tgz#2ef5f0c3442f57844f7a7a961d922872e4ea9a71"
   integrity sha512-2rpixkP3LSCwaJAmbbs0CSqbY7lSk7Ytay4UAYWg3YiJ05My7+MGMPbQJARyAMI5JQNuzcdsZN74btSusBvgYQ==
 
+expo-image-loader@~4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-4.1.1.tgz#efadbb17de1861106864820194900f336dd641b6"
+  integrity sha512-ciEHVokU0f6w0eTxdRxLCio6tskMsjxWIoV92+/ZD37qePUJYMfEphPhu1sruyvMBNR8/j5iyOvPFVGTfO8oxA==
+
 expo-image-manipulator@^9.1.0:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/expo-image-manipulator/-/expo-image-manipulator-9.2.2.tgz#0fc7d2032972961c0a5fb49511d230fe0788fa6f"
@@ -1881,14 +1886,12 @@ expo-image-manipulator@^9.1.0:
   dependencies:
     expo-modules-core "~0.2.0"
 
-expo-image-picker@^10.1.4:
-  version "10.2.3"
-  resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-10.2.3.tgz#204c83ba0731f2ccdbc42e13f9bf6e37be21c354"
-  integrity sha512-8VXLYjclXoQJHbdNLI21rdbnxFisBpZ6TgIifHf9kZ/momFBegUNqEKCjosvxVGVM8f7qaQxJV/znNtW0rDM/w==
+expo-image-picker@14.1.1:
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-14.1.1.tgz#181f1348ba6a43df7b87cee4a601d45c79b7c2d7"
+  integrity sha512-SvWtnkLW7jp5Ntvk3lVcRQmhFYja8psmiR7O6P/+7S6f4llt3vaFwb4I3+pUXqJxxpi7BHc2+95qOLf0SFOIag==
   dependencies:
-    "@expo/config-plugins" "^3.0.0"
-    expo-modules-core "~0.2.0"
-    uuid "7.0.2"
+    expo-image-loader "~4.1.0"
 
 expo-keep-awake@~10.0.2:
   version "10.0.2"
@@ -3174,11 +3177,6 @@ util@^0.10.3:
   integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
   dependencies:
     inherits "2.0.3"
-
-uuid@7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.2.tgz#7ff5c203467e91f5e0d85cfcbaaf7d2ebbca9be6"
-  integrity sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==
 
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
## 🎯 Goal

The `takePhotos` API was not working with the latest versions of the expo CLI. Therefore, to make this compatible this change was added.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The `ImagePickerResult` is dealt with appropriately.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

NA

## 🧪 Testing

- Try to upload a photo using the third tab on the attachment picker.

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


