### PR TITLE
fix: do not skip initialisation when querying channels

### DIFF
--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -2,8 +2,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { Channel, ChannelFilters, ChannelOptions, ChannelSort } from 'stream-chat';
 
-import { useActiveChannelsRefContext } from '../../../contexts/activeChannelsRefContext/ActiveChannelsRefContext';
-
 import { useChatContext } from '../../../contexts/chatContext/ChatContext';
 import { useIsMountedRef } from '../../../hooks/useIsMountedRef';
 

--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -112,9 +112,7 @@ export const usePaginatedChannels = <
       }
 
       // TODO: Think about the implications of this.
-      const channelQueryResponse = await client.queryChannels(filters, sort, newOptions, {
-        skipInitialization: enableOfflineSupport ? activeChannelIds : activeChannels.current,
-      });
+      const channelQueryResponse = await client.queryChannels(filters, sort, newOptions);
       if (isQueryStale() || !isMountedRef.current) {
         return;
       }

--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -52,8 +52,6 @@ export const usePaginatedChannels = <
   const [staticChannelsActive, setStaticChannelsActive] = useState<boolean>(false);
   const [activeQueryType, setActiveQueryType] = useState<QueryType | null>('queryLocalDB');
   const [hasNextPage, setHasNextPage] = useState<boolean>(false);
-
-  const activeChannels = useActiveChannelsRefContext();
   const isMountedRef = useIsMountedRef();
   const { client } = useChatContext<StreamChatGenerics>();
 
@@ -111,7 +109,6 @@ export const usePaginatedChannels = <
         }
       }
 
-      // TODO: Think about the implications of this.
       const channelQueryResponse = await client.queryChannels(filters, sort, newOptions);
       if (isQueryStale() || !isMountedRef.current) {
         return;

--- a/package/src/utils/DBSyncManager.ts
+++ b/package/src/utils/DBSyncManager.ts
@@ -80,6 +80,7 @@ export class DBSyncManager {
    */
   static onSyncStatusChange = (listener: (status: boolean) => void) => {
     this.listeners.push(listener);
+    listener(this.syncStatus);
 
     return {
       unsubscribe: () => {


### PR DESCRIPTION
## 🎯 Goal

When passing a different filter channel list as header the channel state gets into non initialised state randomly. This PR aims to fix it

## 🛠 Implementation details

Not skipping initialisation when querying channels at all times 

## 🎨 UI Changes

None

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


