### PR TITLE
feat: allow to use different i18n library

### DIFF
--- a/examples/ExpoMessaging/yarn.lock
+++ b/examples/ExpoMessaging/yarn.lock
@@ -6649,10 +6649,10 @@ stream-buffers@2.2.x:
   version "0.0.0"
   uid ""
 
-stream-chat-react-native-core@5.12.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.0.tgz#84fed9d65a24b4a92daa6793ac218078d56abdf1"
-  integrity sha512-CJ5gdf4mT+io44cWXkT2wy1kLnyzY05AFdGe2i+KBk4fqubpRpl1MFbgvnAjkcrwvMHnvh131tMxWzOlKkqkkw==
+stream-chat-react-native-core@5.12.1:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.1.tgz#cd2b803ee0aa140164b827ca6dfd9f47e4435550"
+  integrity sha512-lRtyzFuAGJzZcHIJLbnJ0fp9qUQjVN6WBFhQFX9r9P78GAEj8B8WA6svR1O95YxSgf/IJj9qVyEqYQzorT5o5Q==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gorhom/bottom-sheet" "4.4.5"

--- a/examples/SampleApp/ios/Podfile.lock
+++ b/examples/SampleApp/ios/Podfile.lock
@@ -838,7 +838,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: a6454570f573a0f6f1d397e5a95c13e8e45d1700
   FBReactNativeSpec: 09e8dfba44487e5dc4882a9f5318cde67549549c
   Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
@@ -859,7 +859,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
   GoogleAds-IMA-iOS-SDK: b01284e3bf3d64ba948de6692ffda531452c3713
   GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
   GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f

--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -7499,10 +7499,10 @@ stream-buffers@2.2.x:
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
   integrity sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==
 
-stream-chat-react-native-core@5.12.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.0.tgz#84fed9d65a24b4a92daa6793ac218078d56abdf1"
-  integrity sha512-CJ5gdf4mT+io44cWXkT2wy1kLnyzY05AFdGe2i+KBk4fqubpRpl1MFbgvnAjkcrwvMHnvh131tMxWzOlKkqkkw==
+stream-chat-react-native-core@5.12.1:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.1.tgz#cd2b803ee0aa140164b827ca6dfd9f47e4435550"
+  integrity sha512-lRtyzFuAGJzZcHIJLbnJ0fp9qUQjVN6WBFhQFX9r9P78GAEj8B8WA6svR1O95YxSgf/IJj9qVyEqYQzorT5o5Q==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gorhom/bottom-sheet" "4.4.5"

--- a/examples/TypeScriptMessaging/yarn.lock
+++ b/examples/TypeScriptMessaging/yarn.lock
@@ -7114,10 +7114,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stream-chat-react-native-core@5.12.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.0.tgz#84fed9d65a24b4a92daa6793ac218078d56abdf1"
-  integrity sha512-CJ5gdf4mT+io44cWXkT2wy1kLnyzY05AFdGe2i+KBk4fqubpRpl1MFbgvnAjkcrwvMHnvh131tMxWzOlKkqkkw==
+stream-chat-react-native-core@5.12.1:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.1.tgz#cd2b803ee0aa140164b827ca6dfd9f47e4435550"
+  integrity sha512-lRtyzFuAGJzZcHIJLbnJ0fp9qUQjVN6WBFhQFX9r9P78GAEj8B8WA6svR1O95YxSgf/IJj9qVyEqYQzorT5o5Q==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gorhom/bottom-sheet" "4.4.5"

--- a/package/expo-package/yarn.lock
+++ b/package/expo-package/yarn.lock
@@ -2950,10 +2950,10 @@ stream-buffers@2.2.x:
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
   integrity sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==
 
-stream-chat-react-native-core@5.12.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.0.tgz#84fed9d65a24b4a92daa6793ac218078d56abdf1"
-  integrity sha512-CJ5gdf4mT+io44cWXkT2wy1kLnyzY05AFdGe2i+KBk4fqubpRpl1MFbgvnAjkcrwvMHnvh131tMxWzOlKkqkkw==
+stream-chat-react-native-core@5.12.1:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.1.tgz#cd2b803ee0aa140164b827ca6dfd9f47e4435550"
+  integrity sha512-lRtyzFuAGJzZcHIJLbnJ0fp9qUQjVN6WBFhQFX9r9P78GAEj8B8WA6svR1O95YxSgf/IJj9qVyEqYQzorT5o5Q==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gorhom/bottom-sheet" "4.4.5"

--- a/package/native-package/yarn.lock
+++ b/package/native-package/yarn.lock
@@ -4515,10 +4515,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stream-chat-react-native-core@5.12.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.0.tgz#84fed9d65a24b4a92daa6793ac218078d56abdf1"
-  integrity sha512-CJ5gdf4mT+io44cWXkT2wy1kLnyzY05AFdGe2i+KBk4fqubpRpl1MFbgvnAjkcrwvMHnvh131tMxWzOlKkqkkw==
+stream-chat-react-native-core@5.12.1:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-5.12.1.tgz#cd2b803ee0aa140164b827ca6dfd9f47e4435550"
+  integrity sha512-lRtyzFuAGJzZcHIJLbnJ0fp9qUQjVN6WBFhQFX9r9P78GAEj8B8WA6svR1O95YxSgf/IJj9qVyEqYQzorT5o5Q==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@gorhom/bottom-sheet" "4.4.5"

--- a/package/src/components/Chat/Chat.tsx
+++ b/package/src/components/Chat/Chat.tsx
@@ -157,7 +157,7 @@ const ChatWithContext = <
   /**
    * Setup translators
    */
-  const loadingTranslators = useStreami18n({ i18nInstance, setTranslators });
+  const loadingTranslators = useStreami18n(setTranslators, i18nInstance);
 
   /**
    * Setup connection event listeners

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -152,7 +152,7 @@ export const OverlayProvider = <
   const { height, width } = Dimensions.get('screen');
 
   // Setup translators
-  const loadingTranslators = useStreami18n({ i18nInstance, setTranslators });
+  const loadingTranslators = useStreami18n(setTranslators, i18nInstance);
 
   useEffect(() => {
     const backAction = () => {

--- a/package/src/utils/Streami18n.ts
+++ b/package/src/utils/Streami18n.ts
@@ -346,8 +346,20 @@ const defaultStreami18nOptions = {
 export class Streami18n {
   i18nInstance = i18n.createInstance();
   Dayjs = null;
-  setLanguageCallback: (t: TFunction) => void = () => null;
   initialized = false;
+  /* this promise is used to prevent simultaneous calls to init (happens in Overlay and Chat) */
+  private waitForInitializing: Promise<void> | undefined;
+  /* This is the callback to be fired when the language is changed */
+  private onLanguageChangeListeners: ((t: TFunction) => void)[] = [];
+  /* This is the callback to be fired when the tFunc is overridden
+   * This is useful when a different i18n library needs to be used
+   * The SDK uses this in useStreami18n hook to set the tFunc in the context
+   */
+  private onTFunctionOverrideListeners: ((t: TFunction) => void)[] = [];
+  /* We need to queue the overridden tFunction
+   * if the tFunction is overridden before the SDK has initialized the translations
+   */
+  private queuedTFunctionOverride: TFunction | undefined;
 
   t: TFunction = (key: string) => key;
   tDateTimeParser: TDateTimeParser;
@@ -518,7 +530,7 @@ export class Streami18n {
   /**
    * Initializes the i18next instance with configuration (which enables natural language as default keys)
    */
-  async init() {
+  private async init() {
     this.validateCurrentLanguage();
 
     try {
@@ -527,15 +539,17 @@ export class Streami18n {
         lng: this.currentLanguage,
         resources: this.translations,
       });
+      if (this.queuedTFunctionOverride) {
+        // special case where we have a override for tFunc before initialization
+        this.t = this.queuedTFunctionOverride;
+        this.queuedTFunctionOverride = undefined;
+        this.onTFunctionOverrideListeners.forEach((listener) => listener(this.t));
+      }
       this.initialized = true;
     } catch (error) {
       this.logger(`Something went wrong with init: ${JSON.stringify(error)}`);
     }
-
-    return {
-      t: this.t,
-      tDateTimeParser: this.tDateTimeParser,
-    };
+    this.waitForInitializing = undefined;
   }
 
   localeExists = (language: string) => {
@@ -571,16 +585,21 @@ export class Streami18n {
    */
   async getTranslators() {
     if (!this.initialized) {
-      if (this.dayjsLocales[this.currentLanguage]) {
-        this.addOrUpdateLocale(this.currentLanguage, this.dayjsLocales[this.currentLanguage]);
+      if (this.waitForInitializing) {
+        await this.waitForInitializing;
+      } else {
+        if (this.dayjsLocales[this.currentLanguage]) {
+          this.addOrUpdateLocale(this.currentLanguage, this.dayjsLocales[this.currentLanguage]);
+        }
+        const initPromise = this.init();
+        this.waitForInitializing = initPromise;
+        await initPromise;
       }
-      return await this.init();
-    } else {
-      return {
-        t: this.t,
-        tDateTimeParser: this.tDateTimeParser,
-      };
     }
+    return {
+      t: this.t,
+      tDateTimeParser: this.tDateTimeParser,
+    };
   }
 
   /**
@@ -631,6 +650,7 @@ export class Streami18n {
 
   /**
    * Changes the language.
+   * Note: if you are using overrideTFunction, you will need to call the override again after changing the language.
    */
   async setLanguage(language: string) {
     this.currentLanguage = language;
@@ -642,7 +662,8 @@ export class Streami18n {
       if (this.dayjsLocales[language]) {
         this.addOrUpdateLocale(this.currentLanguage, this.dayjsLocales[this.currentLanguage]);
       }
-      this.setLanguageCallback(t);
+      this.t = t;
+      this.onLanguageChangeListeners.forEach((listener) => listener(t));
 
       return t;
     } catch (error) {
@@ -651,7 +672,30 @@ export class Streami18n {
     }
   }
 
-  registerSetLanguageCallback(callback: (t: TFunction) => void) {
-    this.setLanguageCallback = callback;
+  addOnLanguageChangeListener(callback: (t: TFunction) => void) {
+    this.onLanguageChangeListeners.push(callback);
+    return {
+      unsubscribe: () => {
+        this.onLanguageChangeListeners.filter((listener) => listener !== callback);
+      },
+    };
+  }
+
+  addOnTFunctionOverrideListener(callback: (t: TFunction) => void) {
+    this.onTFunctionOverrideListeners.push(callback);
+    return {
+      unsubscribe: () => {
+        this.onTFunctionOverrideListeners.filter((listener) => listener !== callback);
+      },
+    };
+  }
+
+  overrideTFunction(tFunction: TFunction) {
+    if (!this.initialized) {
+      this.queuedTFunctionOverride = tFunction;
+    } else {
+      this.t = tFunction;
+      this.onTFunctionOverrideListeners.forEach((listener) => listener(tFunction));
+    }
   }
 }

--- a/package/src/utils/Streami18n.ts
+++ b/package/src/utils/Streami18n.ts
@@ -676,7 +676,9 @@ export class Streami18n {
     this.onLanguageChangeListeners.push(callback);
     return {
       unsubscribe: () => {
-        this.onLanguageChangeListeners.filter((listener) => listener !== callback);
+        this.onLanguageChangeListeners = this.onLanguageChangeListeners.filter(
+          (listener) => listener !== callback,
+        );
       },
     };
   }
@@ -685,7 +687,9 @@ export class Streami18n {
     this.onTFunctionOverrideListeners.push(callback);
     return {
       unsubscribe: () => {
-        this.onTFunctionOverrideListeners.filter((listener) => listener !== callback);
+        this.onTFunctionOverrideListeners = this.onTFunctionOverrideListeners.filter(
+          (listener) => listener !== callback,
+        );
       },
     };
   }


### PR DESCRIPTION
## 🎯 Goal

In order to use a different i18n library, the translator function needs to be overridden. Currently, the only way to do that is the children inside a translationProvider. But this doesn't override the tFunction for every components. Especially the Image Gallery.

In this PR, we add the ability to override the t function. 

This is the way to use it

```
streami18n.overrideTFunction((key, options) => {
   // the custom implementation
});
``` 

NOTE: If `setLanguage` is called, then override must be called after language is set using
 `await streami18n.setLanguage("nl")` for example


## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


