### PR TITLE
docs: dont install a sepc. react-native-quick-sqlite version

### DIFF
--- a/docusaurus/docs/reactnative/basics/offline_support.mdx
+++ b/docusaurus/docs/reactnative/basics/offline_support.mdx
@@ -41,10 +41,10 @@ yarn remove stream-chat
 
 2. **Add `react-native-quick-sqlite` dependency**
 
-> If you are using v5.5.1 or lower version of `stream-chat-react-native`, then please install v4 of `react-native-quick-sqlite` instead.
+> Contemplate our dependency version compatibility [table](./getting_started.mdx#version-compatibilities) to make sure your `react-native-quick-sqlite` version is compatible with your `stream-chat-react-native` version.
 
 ```bash
-  yarn add react-native-quick-sqlite@5.1.0
+  yarn add react-native-quick-sqlite
   npx pod-install
 ```
 

--- a/docusaurus/docs/reactnative/customization/global_config.mdx
+++ b/docusaurus/docs/reactnative/customization/global_config.mdx
@@ -10,7 +10,7 @@ The new `Global Config` feature allows you to enable and disable features of the
 We will be gradually adding more features/options to the global config.
 In the future this will be the main way to alter the default behavior of the SDK and it's components.
 
-## When to use a Global Configt
+## When to use a Global Config
 
 When you want to alter the default behavior of the SDK or it's components.
 Please check the available options below to see if there is a config option that fits your needs.


### PR DESCRIPTION
## 🎯 Goal

- We support all `react-native-quick-sqlite` version so there is no need to install a spec. one.
- Spelling mistake removed

## 🛠 Implementation details

Remove pin point when installing

## 🎨 UI Changes

N/A

## 🧪 Testing

Read to see if you comprehend steps

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


