### PR TITLE
fix: AutoCompleteInput setInputBoxRef typing

### DIFF
--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -1,8 +1,14 @@
-import React, { PropsWithChildren, useContext, useEffect, useRef, useState } from 'react';
-
-import { Alert, Keyboard, Platform } from 'react-native';
+import React, {
+  LegacyRef,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import type { TextInput, TextInputProps } from 'react-native';
+import { Alert, Keyboard, Platform } from 'react-native';
 
 import uniq from 'lodash/uniq';
 import { lookup } from 'mime-types';
@@ -190,7 +196,7 @@ export type LocalMessageInputContext<
   /**
    * Ref callback to set reference on input box
    */
-  setInputBoxRef: (ref: TextInput | null) => void;
+  setInputBoxRef: LegacyRef<TextInput> | undefined;
   setMentionedUsers: React.Dispatch<React.SetStateAction<string[]>>;
   setNumberOfUploads: React.Dispatch<React.SetStateAction<number>>;
   setSendThreadMessageInChannel: React.Dispatch<React.SetStateAction<boolean>>;


### PR DESCRIPTION
## 🎯 Goal

Fixes #1362 

## 🛠 Implementation details

Use correct type

## 🎨 UI Changes

N/A

## 🧪 Testing

To Reproduce
Steps to reproduce the behavior:

```
const messageInputRef = useRef<TextInput>(null)

return <AutoCompleteInput setInputBoxRef={messageInputRef}/>
```

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


