### PR TITLE
fix: require of expo-document-picker version v11

### DIFF
--- a/package/expo-package/src/optionalDependencies/pickDocument.ts
+++ b/package/expo-package/src/optionalDependencies/pickDocument.ts
@@ -1,7 +1,7 @@
 let DocumentPicker;
 
 try {
-  DocumentPicker = require('expo-document-picker').default;
+  DocumentPicker = require('expo-document-picker');
 } catch (error) {
   console.log('expo-document-picker is not installed');
 }


### PR DESCRIPTION
## 🎯 Goal

The goal is to fix the file picker. It stopped working when I upgraded to version 11.2.2 of expo-document-picker. The require('expo-documentpicker').default would simply return undefined. It seems the default export is removed from the package, hence the require has to be done without the .default. Then it would work again for me.

## 🛠 Implementation details

I have removed the .default from  require('expo-documentpicker').default. It would simply return undefined.

## 🎨 UI Changes

There are none.

## 🧪 Testing

I haven't done any other testing besides running the app and using the file picker with this change included.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


