### PR TITLE
chore: relax frozen lockfile requirements

### DIFF
--- a/.github/actions/install-and-build-sdk/action.yml
+++ b/.github/actions/install-and-build-sdk/action.yml
@@ -14,15 +14,12 @@ runs:
     - name: Install & Build the Native Package
       run: |
         cd package/native-package/
-        yarn --frozen-lockfile
       shell: bash
     - name: Install & Build the Expo Package
       run: |
         cd package/expo-package/
-        yarn --frozen-lockfile
       shell: bash
     - name: Install & Build the Sample App
       run: |
         cd examples/SampleApp/
-        yarn --frozen-lockfile
       shell: bash


### PR DESCRIPTION
## 🎯 Goal

Many PRs are unncessarily stalled due to the requirements that lockfiles of native/expo packages need to be updated. But the only change in most case is the core version. So requiring that in core is actually enough.

## 🛠 Implementation details

NA

## 🎨 UI Changes

NA

## 🧪 Testing

NA

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


