### PR TITLE
fix: reduce-unneeded-syncing

### DIFF
--- a/examples/TypeScriptMessaging/ios/Podfile.lock
+++ b/examples/TypeScriptMessaging/ios/Podfile.lock
@@ -708,7 +708,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: a7c83b31436843459a1961bfd74b96033dc77234
+  boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: a89a0525bc7ca174675045c2b492b5280d5a2470
@@ -729,7 +729,7 @@ SPEC CHECKSUMS:
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
   PromisesSwift: cf9eb58666a43bbe007302226e510b16c1e10959
-  RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
+  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 5a4a30ac20c86eeadd6844a9328f78d4168cf9b2
   RCTTypeSafety: 279fc5861a89f0f37db3a585f27f971485b4b734
   React: 88307a9be3bd0e71a6822271cf28b84a587fb97f

--- a/package/src/store/apis/index.ts
+++ b/package/src/store/apis/index.ts
@@ -17,7 +17,7 @@ export * from './upsertAppSettings';
 export * from './upsertChannelData';
 export * from './upsertChannels';
 export * from './upsertCidsForQuery';
-export * from './upsertLastSyncedAt';
+export * from './upsertUserSyncStatus';
 export * from './upsertMembers';
 export * from './upsertMessages';
 export * from './upsertReads';

--- a/package/src/store/apis/upsertUserSyncStatus.ts
+++ b/package/src/store/apis/upsertUserSyncStatus.ts
@@ -1,7 +1,7 @@
 import { QuickSqliteClient } from '../QuickSqliteClient';
 import { createUpsertQuery } from '../sqlite-utils/createUpsertQuery';
 
-export const upsertLastSyncedAt = ({
+export const upsertUserSyncStatus = ({
   currentUserId,
   lastSyncedAt,
 }: {

--- a/package/src/utils/DBSyncManager.ts
+++ b/package/src/utils/DBSyncManager.ts
@@ -1,5 +1,4 @@
 import type { AxiosError } from 'axios';
-import { isEmpty } from 'lodash';
 import type { APIErrorResponse, StreamChat } from 'stream-chat';
 
 import { handleEventToSyncDB } from '../components/Chat/hooks/handleEventToSyncDB';
@@ -12,6 +11,7 @@ import { getPendingTasks } from '../store/apis/getPendingTasks';
 import { QuickSqliteClient } from '../store/QuickSqliteClient';
 import type { PendingTask, PreparedQueries } from '../store/types';
 import type { DefaultStreamChatGenerics } from '../types/types';
+
 /**
  * DBSyncManager has the responsibility to sync the channel states
  * within local database whenever possible.
@@ -97,7 +97,7 @@ export class DBSyncManager {
     });
     const cids = getAllChannelIds();
     // If there are no channels, then there is no need to sync.
-    if (!isEmpty(cids)) return;
+    if (cids.length === 0) return;
 
     if (lastSyncedAt) {
       try {

--- a/package/src/utils/DBSyncManager.ts
+++ b/package/src/utils/DBSyncManager.ts
@@ -1,8 +1,9 @@
 import type { AxiosError } from 'axios';
+import { isEmpty } from 'lodash';
 import type { APIErrorResponse, StreamChat } from 'stream-chat';
 
 import { handleEventToSyncDB } from '../components/Chat/hooks/handleEventToSyncDB';
-import { getAllChannelIds, getLastSyncedAt, upsertLastSyncedAt } from '../store/apis';
+import { getAllChannelIds, getLastSyncedAt, upsertUserSyncStatus } from '../store/apis';
 
 import { addPendingTask } from '../store/apis/addPendingTask';
 
@@ -95,6 +96,8 @@ export class DBSyncManager {
       currentUserId: this.client.user.id,
     });
     const cids = getAllChannelIds();
+    // If there are no channels, then there is no need to sync.
+    if (!isEmpty(cids)) return;
 
     if (lastSyncedAt) {
       try {
@@ -113,7 +116,7 @@ export class DBSyncManager {
         QuickSqliteClient.resetDB();
       }
     }
-    upsertLastSyncedAt({
+    upsertUserSyncStatus({
       currentUserId: this.client.user.id,
       lastSyncedAt: new Date().toString(),
     });


### PR DESCRIPTION
## 🎯 Goal

We discovered that we receive api calls with status 400 when hitting the sync endpoint when the user does not have channels. 
There is no need in making a sync call when there aren't any channels.

This PR aims to aliminate those above mentioned unneded calls.

## 🛠 Implementation details

Early exit before syncing

## 🎨 UI Changes

N/A

## 🧪 Testing

We should inspect that there's no regression.
- User 1: Go offline and send, react delete messages.
- User 2: Send messages to user 1.
- User 1: Return online.
- Check whether all messages are updated by both users.
- 
## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


