### PR TITLE
fix: android picker loop on refuse permission

### DIFF
--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -304,7 +304,7 @@ export const AttachmentPicker = React.forwardRef(
             data={selectedPhotos}
             keyExtractor={(item) => item.asset.uri}
             numColumns={numberOfAttachmentPickerImageColumns ?? 3}
-            onEndReached={getMorePhotos}
+            onEndReached={photoError ? undefined : getMorePhotos}
             renderItem={renderAttachmentPickerItem}
           />
         </BottomSheet>


### PR DESCRIPTION
Fixes #2129 
## 🎯 Goal

- Fix loop on Android

<!-- Describe why we are making this change -->

## 🛠 Implementation details
- Avoid having the FlatList call `onEndReached` on error states, since that would either show the prompt again or enter a loop until the user gives permission.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->
N/A

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->
Call `toggleAttachmentPicker` from `useMessageInputContext` on an Android and either deny permission or click outside the Modal.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


