### PR TITLE
fix: crash when opening null url

### DIFF
--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -356,7 +356,7 @@ const GalleryThumbnail = <
   };
 
   const defaultOnPress = () => {
-    if (!thumbnail.url || !thumbnail.thumb_url) {
+    if ((thumbnail.type === 'video' && !thumbnail.thumb_url) || !thumbnail.url) {
       return;
     }
     if (thumbnail.type === 'video' && !isVideoPackageAvailable()) {

--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -356,6 +356,9 @@ const GalleryThumbnail = <
   };
 
   const defaultOnPress = () => {
+    if (!thumbnail.url || !thumbnail.thumb_url) {
+      return;
+    }
     if (thumbnail.type === 'video' && !isVideoPackageAvailable()) {
       // This condition is kinda unreachable, since we render videos as file attachment if the video
       // library is not installed. But doesn't hurt to have extra safeguard, in case of some customizations.


### PR DESCRIPTION
## 🎯 Goal
Fix the application crash that happens when opening a video attachment before the upload is finished.
<!-- Describe why we are making this change -->

## 🛠 Implementation details

Fixes #2133 
Avoids sending a null/undefined URL to the native video loader, which would cause a crash.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
               N/A
            </td>
            <td>
               N/A
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
               N/A
            </td>
            <td>
               N/A
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->
1- Open a chat
2- Open the attachment picker and select a video
3- Send the video
4- Immediately click on the new video thumbnail in the chat before the upload finishes (it'll be black)
Should not crash with this fix.

## ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [X] Documentation is updated
- [X] New code is tested in main example apps, including all possible scenarios
  - [X] SampleApp iOS and Android
  - [X] Expo iOS and Android


