### PR TITLE
fix: incorrect typing of getPhotos between expo and native

### DIFF
--- a/package/expo-package/src/handlers/getPhotos.ts
+++ b/package/expo-package/src/handlers/getPhotos.ts
@@ -27,7 +27,7 @@ export const getPhotos = async ({
       filename: asset.filename,
       height: asset.height,
       id: asset.id,
-      source: 'picker',
+      source: 'picker' as const,
       type: asset.mediaType,
       uri: asset.uri,
       width: asset.width,

--- a/package/expo-package/src/handlers/getPhotos.ts
+++ b/package/expo-package/src/handlers/getPhotos.ts
@@ -1,6 +1,16 @@
 import * as MediaLibrary from 'expo-media-library';
+import type { Asset } from 'stream-chat-react-native-core';
 
-export const getPhotos = async ({ after, first }: MediaLibrary.AssetsOptions) => {
+type ReturnType = {
+  assets: Array<Omit<Asset, 'source'> & { source: 'picker' }>;
+  endCursor: string | undefined;
+  hasNextPage: boolean;
+};
+
+export const getPhotos = async ({
+  after,
+  first,
+}: MediaLibrary.AssetsOptions): Promise<ReturnType> => {
   try {
     const { status } = await MediaLibrary.requestPermissionsAsync();
     if (status !== 'granted') {

--- a/package/native-package/src/handlers/getPhotos.ts
+++ b/package/native-package/src/handlers/getPhotos.ts
@@ -1,6 +1,13 @@
 import { PermissionsAndroid, Platform } from 'react-native';
 
 import { CameraRoll, GetPhotosParams } from '@react-native-camera-roll/camera-roll';
+import type { Asset } from 'stream-chat-react-native-core';
+
+type ReturnType = {
+  assets: Array<Omit<Asset, 'source'> & { source: 'picker' }>;
+  endCursor: string | undefined;
+  hasNextPage: boolean;
+};
 
 const verifyAndroidPermissions = async () => {
   const isRN71orAbove = Platform.constants.reactNativeVersion?.minor >= 71;
@@ -49,7 +56,10 @@ const verifyAndroidPermissions = async () => {
   return true;
 };
 
-export const getPhotos = async ({ after, first }: Pick<GetPhotosParams, 'after' | 'first'>) => {
+export const getPhotos = async ({
+  after,
+  first,
+}: Pick<GetPhotosParams, 'after' | 'first'>): Promise<ReturnType> => {
   try {
     if (Platform.OS === 'android') {
       const granted = await verifyAndroidPermissions();
@@ -65,7 +75,9 @@ export const getPhotos = async ({ after, first }: Pick<GetPhotosParams, 'after' 
     });
     const assets = results.edges.map((edge) => ({
       ...edge.node.image,
+      duration: edge.node.image.playableDuration,
       source: 'picker',
+      type: edge.node.type,
     }));
     const hasNextPage = results.page_info.has_next_page;
     const endCursor = results.page_info.end_cursor;

--- a/package/native-package/src/handlers/getPhotos.ts
+++ b/package/native-package/src/handlers/getPhotos.ts
@@ -76,7 +76,10 @@ export const getPhotos = async ({
     const assets = results.edges.map((edge) => ({
       ...edge.node.image,
       duration: edge.node.image.playableDuration,
-      source: 'picker',
+      // since we include filename, fileSize in the query, we can safely assume it will be defined
+      filename: edge.node.image.filename as string,
+      fileSize: edge.node.image.fileSize as number,
+      source: 'picker' as const,
       type: edge.node.type,
     }));
     const hasNextPage = results.page_info.has_next_page;

--- a/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
@@ -44,9 +44,7 @@ const AttachmentVideo: React.FC<AttachmentVideoProps> = (props) => {
     },
   } = useTheme();
 
-  const { duration, playableDuration, uri } = asset;
-
-  const videoDuration = duration ? duration : playableDuration;
+  const { duration: videoDuration, uri } = asset;
 
   const ONE_HOUR_IN_SECONDS = 3600;
 

--- a/package/src/types/types.ts
+++ b/package/src/types/types.ts
@@ -2,8 +2,8 @@ import type { ExtendableGenerics, LiteralStringForUnion } from 'stream-chat';
 
 export type Asset = {
   duration: number | null;
-  filename: string;
-  fileSize: string;
+  filename: string | null;
+  fileSize: string | null | undefined;
   height: number;
   playableDuration: number | null;
   source: 'camera' | 'picker';

--- a/package/src/types/types.ts
+++ b/package/src/types/types.ts
@@ -5,7 +5,6 @@ export type Asset = {
   filename: string;
   fileSize: number | undefined;
   height: number;
-  playableDuration: number | null;
   source: 'camera' | 'picker';
   type: string;
   uri: string;

--- a/package/src/types/types.ts
+++ b/package/src/types/types.ts
@@ -3,7 +3,7 @@ import type { ExtendableGenerics, LiteralStringForUnion } from 'stream-chat';
 export type Asset = {
   duration: number | null;
   filename: string;
-  fileSize: number | undefined;
+  fileSize?: number;
   height: number;
   source: 'camera' | 'picker';
   type: string;

--- a/package/src/types/types.ts
+++ b/package/src/types/types.ts
@@ -3,12 +3,12 @@ import type { ExtendableGenerics, LiteralStringForUnion } from 'stream-chat';
 export type Asset = {
   duration: number | null;
   filename: string;
-  fileSize?: number;
   height: number;
   source: 'camera' | 'picker';
   type: string;
   uri: string;
   width: number;
+  fileSize?: number;
   id?: string;
   size?: number | string;
 };

--- a/package/src/types/types.ts
+++ b/package/src/types/types.ts
@@ -2,8 +2,8 @@ import type { ExtendableGenerics, LiteralStringForUnion } from 'stream-chat';
 
 export type Asset = {
   duration: number | null;
-  filename: string | null;
-  fileSize: string | null | undefined;
+  filename: string;
+  fileSize: number | undefined;
   height: number;
   playableDuration: number | null;
   source: 'camera' | 'picker';


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


