### PR TITLE
fix: double check whether we scroll to an existing index when messageId is…

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -808,16 +808,20 @@ const MessageListWithContext = <
         index: info.index,
         viewPosition: 0.5, // try to place message in the center of the screen
       });
-
       if (messageIdLastScrolledToRef.current) {
         setTargetedMessage(messageIdLastScrolledToRef.current);
       }
+      scrollToIndexFailedRetryCountRef.current = 0;
     } catch (e) {
       if (
         !onScrollToIndexFailedRef.current ||
         scrollToIndexFailedRetryCountRef.current > MAX_RETRIES_AFTER_SCROLL_FAILURE
       ) {
-        console.log(`Scrolling to index failed after ${MAX_RETRIES_AFTER_SCROLL_FAILURE} retries`, e);
+        console.log(
+          `Scrolling to index failed after ${MAX_RETRIES_AFTER_SCROLL_FAILURE} retries`,
+          e,
+        );
+        scrollToIndexFailedRetryCountRef.current = 0;
         return;
       }
       // At some cases the index we're trying to scroll to, doesn't exist yet in the messageList

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -818,6 +818,7 @@ const MessageListWithContext = <
         scrollToIndexFailedRetryCountRef.current > MAX_RETRIES_AFTER_SCROLL_FAILURE
       ) {
         console.log('Scrolling to index failed after 10 retries', e);
+        return;
       }
       // At some cases the index we're trying to scroll to, doesn't exist yet in the messageList
       // Scrolling to an index not in range of the Flatlist's data will result in a crash that

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -817,7 +817,7 @@ const MessageListWithContext = <
         !onScrollToIndexFailedRef.current ||
         scrollToIndexFailedRetryCountRef.current > MAX_RETRIES_AFTER_SCROLL_FAILURE
       ) {
-        throw e;
+        console.log('Scrolling to index failed after 10 retries', e);
       }
       // At some cases the index we're trying to scroll to, doesn't exist yet in the messageList
       // Scrolling to an index not in range of the Flatlist's data will result in a crash that

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -552,6 +552,7 @@ const MessageListWithContext = <
       }
       return false;
     }
+
     const isCurrentMessageUnread = isMessageUnread(index);
     const showUnreadUnderlay = isCurrentMessageUnread && scrollToBottomButtonVisible;
     const insertInlineUnreadIndicator = showUnreadUnderlay && !isMessageUnread(index + 1); // show only if previous message is read
@@ -786,9 +787,10 @@ const MessageListWithContext = <
   };
 
   const scrollToIndexFailedRetryCountRef = useRef<number>(0);
+  const failScrollTimeoutId = useRef<NodeJS.Timeout>();
   const onScrollToIndexFailedRef = useRef<
     FlatListProps<MessageType<StreamChatGenerics>>['onScrollToIndexFailed']
-  >(async (info) => {
+  >((info) => {
     // We got a failure as we tried to scroll to an item that was outside the render length
     if (!flatListRef.current) return;
     // we don't know the actual size of all items but we can see the average, so scroll to the closest offset
@@ -798,39 +800,40 @@ const MessageListWithContext = <
     });
     // since we used only an average offset... we won't go to the center of the item yet
     // with a little delay to wait for scroll to offset to complete, we can then scroll to the index
-    await new Promise((resolve) => setTimeout(resolve, WAIT_FOR_SCROLL_TO_OFFSET_TIMEOUT));
+    failScrollTimeoutId.current = setTimeout(() => {
+      try {
+        flatListRef.current?.scrollToIndex({
+          animated: false,
+          index: info.index,
+          viewPosition: 0.5, // try to place message in the center of the screen
+        });
+        if (messageIdLastScrolledToRef.current) {
+          setTargetedMessage(messageIdLastScrolledToRef.current);
+        }
+        scrollToIndexFailedRetryCountRef.current = 0;
+      } catch (e) {
+        if (
+          !onScrollToIndexFailedRef.current ||
+          scrollToIndexFailedRetryCountRef.current > MAX_RETRIES_AFTER_SCROLL_FAILURE
+        ) {
+          console.log(
+            `Scrolling to index failed after ${MAX_RETRIES_AFTER_SCROLL_FAILURE} retries`,
+            e,
+          );
+          scrollToIndexFailedRetryCountRef.current = 0;
+          return;
+        }
+        // At some cases the index we're trying to scroll to, doesn't exist yet in the messageList
+        // Scrolling to an index not in range of the Flatlist's data will result in a crash that
+        // won't call onScrollToIndexFailed.
+        // By catching this error we retry scrolling by calling onScrollToIndexFailedRef
+        scrollToIndexFailedRetryCountRef.current += 1;
+        onScrollToIndexFailedRef.current(info);
+      }
+    }, WAIT_FOR_SCROLL_TO_OFFSET_TIMEOUT);
 
     // Only when index is greater than 0 and in range of items in FlatList
     // this onScrollToIndexFailed will be called again
-    try {
-      flatListRef.current?.scrollToIndex({
-        animated: false,
-        index: info.index,
-        viewPosition: 0.5, // try to place message in the center of the screen
-      });
-      if (messageIdLastScrolledToRef.current) {
-        setTargetedMessage(messageIdLastScrolledToRef.current);
-      }
-      scrollToIndexFailedRetryCountRef.current = 0;
-    } catch (e) {
-      if (
-        !onScrollToIndexFailedRef.current ||
-        scrollToIndexFailedRetryCountRef.current > MAX_RETRIES_AFTER_SCROLL_FAILURE
-      ) {
-        console.log(
-          `Scrolling to index failed after ${MAX_RETRIES_AFTER_SCROLL_FAILURE} retries`,
-          e,
-        );
-        scrollToIndexFailedRetryCountRef.current = 0;
-        return;
-      }
-      // At some cases the index we're trying to scroll to, doesn't exist yet in the messageList
-      // Scrolling to an index not in range of the Flatlist's data will result in a crash that
-      // won't call onScrollToIndexFailed.
-      // By catching this error we retry scrolling by calling onScrollToIndexFailedRef
-      scrollToIndexFailedRetryCountRef.current += 1;
-      onScrollToIndexFailedRef.current(info);
-    }
   });
 
   const goToMessage = useCallback(
@@ -839,6 +842,8 @@ const MessageListWithContext = <
         (message) => message?.id === messageId,
       );
       if (indexOfParentInMessageList !== -1 && flatListRef.current) {
+        clearTimeout(failScrollTimeoutId.current);
+        scrollToIndexFailedRetryCountRef.current = 0;
         flatListRef.current.scrollToIndex({
           animated: true,
           index: indexOfParentInMessageList,
@@ -880,6 +885,9 @@ const MessageListWithContext = <
         (message) => message?.id === messageIdToScroll,
       );
       if (indexOfParentInMessageList !== -1 && flatListRef.current) {
+        // By a fresh scroll we should clear the retries for the previous failed scroll
+        clearTimeout(failScrollTimeoutId.current);
+        scrollToIndexFailedRetryCountRef.current = 0;
         flatListRef.current.scrollToIndex({
           animated: false,
           index: indexOfParentInMessageList,

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -817,7 +817,7 @@ const MessageListWithContext = <
         !onScrollToIndexFailedRef.current ||
         scrollToIndexFailedRetryCountRef.current > MAX_RETRIES_AFTER_SCROLL_FAILURE
       ) {
-        console.log('Scrolling to index failed after 10 retries', e);
+        console.log(`Scrolling to index failed after ${MAX_RETRIES_AFTER_SCROLL_FAILURE} retries`, e);
         return;
       }
       // At some cases the index we're trying to scroll to, doesn't exist yet in the messageList


### PR DESCRIPTION
fixes #2092 

## 🎯 Goal
Adding an extra layer of protection when scrolling to a specific `messageId`

## 🛠 Implementation details
Check whether index exists in flat list's data (message list) in order to prevent crashes

## 🎨 UI Changes
N/A

## 🧪 Testing
I haven't found a way to particularly reproduce this error, when testing please ensure that there is no regression by:
- fill in `messageId` param on `Channel` component with value `vir-c5155f18-cae5-4ba6-2686-06bdcd3427eb`
- run SampleApp
- open a channel with more than 100 messages
- click on user avatar and click on pinned messages and choose a pinned message
- validate that scrolling function and the chosen pinned message is visible

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


