### PR TITLE
fix: do not sync if last sync is too old

### DIFF
--- a/package/src/utils/DBSyncManager.ts
+++ b/package/src/utils/DBSyncManager.ts
@@ -1,5 +1,5 @@
 import type { AxiosError } from 'axios';
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import type { APIErrorResponse, StreamChat } from 'stream-chat';
 
 import { handleEventToSyncDB } from '../components/Chat/hooks/handleEventToSyncDB';

--- a/package/src/utils/DBSyncManager.ts
+++ b/package/src/utils/DBSyncManager.ts
@@ -1,4 +1,5 @@
 import type { AxiosError } from 'axios';
+import dayjs, { Dayjs } from 'dayjs';
 import type { APIErrorResponse, StreamChat } from 'stream-chat';
 
 import { handleEventToSyncDB } from '../components/Chat/hooks/handleEventToSyncDB';
@@ -91,29 +92,39 @@ export class DBSyncManager {
 
   static sync = async () => {
     if (!this.client?.user) return;
-
-    const lastSyncedAt = getLastSyncedAt({
-      currentUserId: this.client.user.id,
-    });
     const cids = getAllChannelIds();
     // If there are no channels, then there is no need to sync.
     if (cids.length === 0) return;
 
-    if (lastSyncedAt) {
-      try {
-        const result = await this.client.sync(cids, new Date(lastSyncedAt).toISOString());
-        const queries = result.events.reduce<PreparedQueries[]>((queries, event) => {
-          queries = queries.concat(handleEventToSyncDB(event, false));
-          return queries;
-        }, []);
+    const lastSyncedAt = getLastSyncedAt({
+      currentUserId: this.client.user.id,
+    });
 
-        if (queries.length) {
-          QuickSqliteClient.executeSqlBatch(queries);
-        }
-      } catch (e) {
-        // Error will be raised by the sync API if there are too many events.
+    if (lastSyncedAt) {
+      const lastSyncedAtDate = new Date(lastSyncedAt);
+      const lastSyncedAtDayJs = dayjs(lastSyncedAtDate);
+      const nowDayJs = dayjs();
+      const diff = nowDayJs.diff(lastSyncedAtDayJs, 'days');
+      if (diff > 30) {
+        // stream backend will send an error if we try to sync after 30 days.
         // In that case reset the entire DB and start fresh.
         QuickSqliteClient.resetDB();
+      } else {
+        try {
+          const result = await this.client.sync(cids, lastSyncedAtDate.toISOString());
+          const queries = result.events.reduce<PreparedQueries[]>((queries, event) => {
+            queries = queries.concat(handleEventToSyncDB(event, false));
+            return queries;
+          }, []);
+
+          if (queries.length) {
+            QuickSqliteClient.executeSqlBatch(queries);
+          }
+        } catch (e) {
+          // Error will be raised by the sync API if there are too many events.
+          // In that case reset the entire DB and start fresh.
+          QuickSqliteClient.resetDB();
+        }
       }
     }
     upsertUserSyncStatus({


### PR DESCRIPTION
## 🎯 Goal

backend does not accept too old sync dates and sends us a 400 error back.  - `Sync failed with error: \"Too old last_sync_at time, please have last_sync_at argument no later than 30 days ago`

This PR aligns the behavior with other SDKs where we don't execute sync if its too old and also clear out the DB

## 🛠 Implementation details

Used the solution as per [this discussion on Slack](https://getstream.slack.com/archives/CE5N802GP/p1664455487856019)

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


