### PR TITLE
fix: hmr issue due to disconnect

### DIFF
--- a/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
@@ -17,6 +17,7 @@ import {
   ChannelsContextValue,
   useChannelsContext,
 } from '../../contexts/channelsContext/ChannelsContext';
+import { useChatContext } from '../../contexts/chatContext/ChatContext';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import type { DefaultStreamChatGenerics } from '../../types/types';
 import { vw } from '../../utils/utils';
@@ -127,12 +128,21 @@ const ChannelPreviewMessengerWithContext = <
     },
   } = useTheme();
 
+  const { client } = useChatContext<StreamChatGenerics>();
+
   const displayName = useChannelPreviewDisplayName(
     channel,
     Math.floor(maxWidth / ((title.fontSize || styles.title.fontSize) / 2)),
   );
 
-  const isChannelMuted = channel.muteStatus().muted;
+  const [isChannelMuted, setIsChannelMuted] = useState(() => channel.muteStatus().muted);
+
+  useEffect(() => {
+    const handleEvent = () => setIsChannelMuted(channel.muteStatus().muted);
+
+    client.on('notification.channel_mutes_updated', handleEvent);
+    return () => client.off('notification.channel_mutes_updated', handleEvent);
+  }, []);
 
   return (
     <TouchableOpacity


### PR DESCRIPTION
## 🎯 Goal

During hot module reload the app throws the following error 

```
 ERROR  Error: You can't use a channel after client.disconnect() was called

This error is located at:
    in ChannelPreviewMessengerWithContext (created by ChannelPreviewMessenger{channelPreview})
    in ChannelPreviewMessenger{channelPreview} (created by ChannelPreviewWithContext)
    in ChannelPreviewWithContext (created by ChannelPreview)
```

the HMR error was because the channel preview component rerendered during HMR of a global variable. This doesn't happen in our sample apps, but our awesome customer had made a repro at https://github.com/farmstrong8/stream-chat-rn-render

My theory is that due to some specific usage of react navigation the component rerenders. 

But anyway we should break HMRs. 

After this fix, if the customer doesn't rerender the channel list after disconnect this error shouldn't happen. If customers render this error makes sense anyway. 

## 🛠 Implementation details

NA

## 🎨 UI Changes

NA


## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [x] Expo iOS and Android


