### PR TITLE
fix: do not render message list items when channel is disconnected

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -541,7 +541,8 @@ const MessageListWithContext = <
     index: number;
     item: MessageType<StreamChatGenerics>;
   }) => {
-    if (!channel || (!channel.initialized && !channel.offlineMode)) return null;
+    if (!channel || channel.disconnected || (!channel.initialized && !channel.offlineMode))
+      return null;
 
     const lastRead = channel.lastRead();
 


### PR DESCRIPTION
## 🎯 Goal

A quick dirty fix for HMR issue with react navigation on cleanup as described in #2169. This should be looked at later to turn the last read state to be more reactive

## 🛠 Implementation details

NA

## 🎨 UI Changes

NA

## 🧪 Testing

NA

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


