### PR TITLE
fix: ui issue when customizing unread count when there is no count

### DIFF
--- a/package/src/components/ChannelPreview/ChannelPreviewUnreadCount.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewUnreadCount.tsx
@@ -7,22 +7,6 @@ import { useTheme } from '../../contexts/themeContext/ThemeContext';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
 
-const styles = StyleSheet.create({
-  unreadContainer: {
-    alignItems: 'center',
-    borderRadius: 8,
-    flexShrink: 1,
-    justifyContent: 'center',
-  },
-  unreadText: {
-    color: '#FFFFFF',
-    fontSize: 11,
-    fontWeight: '700',
-    paddingHorizontal: 5,
-    paddingVertical: 1,
-  },
-});
-
 export type ChannelPreviewUnreadCountProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 > = Pick<ChannelPreviewProps<StreamChatGenerics>, 'channel'> & {
@@ -53,3 +37,19 @@ export const ChannelPreviewUnreadCount = <
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  unreadContainer: {
+    alignItems: 'center',
+    borderRadius: 8,
+    flexShrink: 1,
+    justifyContent: 'center',
+  },
+  unreadText: {
+    color: '#FFFFFF',
+    fontSize: 11,
+    fontWeight: '700',
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+  },
+});

--- a/package/src/components/ChannelPreview/ChannelPreviewUnreadCount.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewUnreadCount.tsx
@@ -43,13 +43,13 @@ export const ChannelPreviewUnreadCount = <
     },
   } = useTheme();
 
+  if (!unread) return null;
+
   return (
     <View style={[styles.unreadContainer, { backgroundColor: accent_red }, unreadContainer]}>
-      {!!unread && (
-        <Text numberOfLines={1} style={[styles.unreadText, unreadText]}>
-          {unread > maxUnreadCount ? `${maxUnreadCount}+` : unread}
-        </Text>
-      )}
+      <Text numberOfLines={1} style={[styles.unreadText, unreadText]}>
+        {unread > maxUnreadCount ? `${maxUnreadCount}+` : unread}
+      </Text>
     </View>
   );
 };


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


