### PR TITLE
feat: add ability to autoplay videos in gallery

### DIFF
--- a/docusaurus/docs/reactnative/core-components/overlay_provider.mdx
+++ b/docusaurus/docs/reactnative/core-components/overlay_provider.mdx
@@ -154,6 +154,14 @@ This can also be set via the `setBottomInset` function provided by the `useAttac
 | ------ | ------- |
 | number | 0       |
 
+### autoPlayVideo
+
+Enables or disables auto play of videos in the overlay.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
 ### giphyVersion
 
 <GiphyVersion />

--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -131,6 +131,7 @@ type Props<StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamC
       | 'imageGalleryGridSnapPoints'
       | 'imageGalleryGridHandleHeight'
       | 'numberOfImageGalleryGridColumns'
+      | 'autoPlayVideo'
     >;
 
 export const ImageGallery = <
@@ -139,6 +140,7 @@ export const ImageGallery = <
   props: Props<StreamChatGenerics>,
 ) => {
   const {
+    autoPlayVideo = false,
     giphyVersion = 'fixed_height',
     imageGalleryCustomComponents,
     imageGalleryGridHandleHeight,
@@ -273,6 +275,7 @@ export const ImageGallery = <
     const attachmentPhotos = attachmentImages.map((a) => {
       const imageUrl = getUrlOfImageAttachment(a) as string;
       const giphyURL = a.giphy?.[giphyVersion]?.url || a.thumb_url || a.image_url;
+      const isInitiallyPaused = !autoPlayVideo;
 
       return {
         channelId: cur.cid,
@@ -283,7 +286,7 @@ export const ImageGallery = <
         mime_type: a.type === 'giphy' ? getGiphyMimeType(giphyURL ?? '') : a.mime_type,
         original_height: a.original_height,
         original_width: a.original_width,
-        paused: true,
+        paused: isInitiallyPaused,
         progress: 0,
         type: a.type,
         uri:

--- a/package/src/contexts/overlayContext/OverlayContext.tsx
+++ b/package/src/contexts/overlayContext/OverlayContext.tsx
@@ -58,6 +58,7 @@ export type OverlayProviderProps<
     >
   > &
   Pick<OverlayContextValue, 'translucentStatusBar'> & {
+    autoPlayVideo?: boolean;
     /**
      * The giphy version to render - check the keys of the [Image Object](https://developers.giphy.com/docs/api/schema#image-object) for possible values. Uses 'fixed_height' by default
      * */

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -64,6 +64,7 @@ export const OverlayProvider = <
 ) => {
   const bottomSheetCloseTimeoutRef = useRef<NodeJS.Timeout>();
   const {
+    autoPlayVideo,
     AttachmentPickerBottomSheetHandle = DefaultAttachmentPickerBottomSheetHandle,
     attachmentPickerBottomSheetHandleHeight,
     attachmentPickerBottomSheetHeight,
@@ -237,6 +238,7 @@ export const OverlayProvider = <
                 )}
                 {overlay === 'gallery' && (
                   <ImageGallery<StreamChatGenerics>
+                    autoPlayVideo={autoPlayVideo}
                     giphyVersion={giphyVersion}
                     imageGalleryCustomComponents={imageGalleryCustomComponents}
                     imageGalleryGridHandleHeight={imageGalleryGridHandleHeight}


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->
Add the ability to autoplay videos in the gallery. Fixes #2186 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->
Adds a new prop to the `OverlayProvider` called `autoPlayVideo` - the default is false to match current behaviour. This prop is used to define whether the video should start paused or not. 

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>

https://github.com/GetStream/stream-chat-react-native/assets/45667737/c4f1d56d-96f7-4d70-8758-05caee02e404

</details>


<details>
<summary>Android</summary>

https://github.com/GetStream/stream-chat-react-native/assets/45667737/51a4a839-ffb8-405d-8a6d-d6ed98ef56fa

</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

- Open the Sample App on iOS or Android
- Go to a Channel with a video and photos being shared
- Tap on a video and see it maintains the current behaviour of not autoplaying
- Update the App.tsx in Sample App with the prop `autoPlayVideo` to `true` in the `OverlayProvider`
- Go back to the channel with photos and videos
- Open video and see it autoplays, open a photo and see no regression.



## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


