### PR TITLE
fix: add pointerEvents to ReactionList

### DIFF
--- a/package/src/components/Message/MessageSimple/ReactionList.tsx
+++ b/package/src/components/Message/MessageSimple/ReactionList.tsx
@@ -200,7 +200,6 @@ const ReactionListWithContext = <
             <Circle cx={x2} cy={y2} fill={alignmentLeft ? fill : white} r={radius * 2} />
           </Svg>
           <View
-            pointerEvents='none'
             style={[
               styles.reactionBubbleBackground,
               {

--- a/package/src/components/Message/MessageSimple/ReactionList.tsx
+++ b/package/src/components/Message/MessageSimple/ReactionList.tsx
@@ -178,6 +178,7 @@ const ReactionListWithContext = <
 
   return (
     <View
+      pointerEvents='box-none'
       style={[
         styles.container,
         {
@@ -189,8 +190,8 @@ const ReactionListWithContext = <
       testID='reaction-list'
     >
       {reactions.length ? (
-        <View style={[StyleSheet.absoluteFill]}>
-          <Svg>
+        <View pointerEvents='box-none' style={[StyleSheet.absoluteFill]}>
+          <Svg pointerEvents='none'>
             <Circle cx={x1} cy={y1} fill={stroke} r={radius + strokeSize * 3} />
             <Circle cx={x2} cy={y2} fill={stroke} r={radius * 2 + strokeSize * 3} />
             <Circle cx={x1} cy={y1} fill={fill} r={radius + strokeSize} />
@@ -199,6 +200,7 @@ const ReactionListWithContext = <
             <Circle cx={x2} cy={y2} fill={alignmentLeft ? fill : white} r={radius * 2} />
           </Svg>
           <View
+            pointerEvents='none'
             style={[
               styles.reactionBubbleBackground,
               {
@@ -213,7 +215,7 @@ const ReactionListWithContext = <
               reactionBubbleBackground,
             ]}
           />
-          <View style={[StyleSheet.absoluteFill]}>
+          <View pointerEvents='none' style={[StyleSheet.absoluteFill]}>
             <Svg>
               <Circle cx={x2} cy={y2} fill={alignmentLeft ? fill : white} r={radius * 2} />
             </Svg>


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

Currently `ReactionList` has several Views that are take up basically the full screen width. These views have a height that is based on the reactionSize. Using the default reactionSize, these take up roughly half the size of the `MessageContent` size if the message is a single line of text. 

This absolute overlay then blocks the `MessageContent` components `TouchableOpacity`. Thus, the goal is to fix #2021 by making `ReactionList` not block the `TouchableOpacity` in `MessageContent`. FYI I couldn't repo the hit box moving when adding a reaction, only the blocking of long press on both iOS and Android. 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

Update the `View` and `Svg` to have `pointerEvents` that don't block the underlying `TouchableOpacity` from `MessageContnet` while maintaining the `TouchOpacity` of the `ReactionList` functionality.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS & Android</summary>

https://github.com/GetStream/stream-chat-react-native/assets/45667737/ed84eebd-37b7-4c38-88dd-40de4c0eac5e


</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


