### PR TITLE
fix: date separators were not visible if prev msg was same day of the week

### DIFF
--- a/package/src/components/MessageList/utils/getDateSeparators.ts
+++ b/package/src/components/MessageList/utils/getDateSeparators.ts
@@ -45,9 +45,11 @@ export const getDateSeparators = <
     const previousMessage = messagesWithoutDeleted[i - 1];
     const message = messagesWithoutDeleted[i];
 
-    const messageDate = message.created_at.getDay();
+    const messageDate = message.created_at.toDateString();
 
-    const prevMessageDate = previousMessage ? previousMessage.created_at.getDay() : messageDate;
+    const prevMessageDate = previousMessage
+      ? previousMessage.created_at.toDateString()
+      : messageDate;
 
     if (i === 0 || messageDate !== prevMessageDate) {
       dateSeparators[message.id] = message.created_at;


### PR DESCRIPTION
## 🎯 Goal

If previous message was sent on Friday of last week and the new message is also Friday but of current week. We don't render a date separator. This PR aims to fix it.

## 🛠 Implementation details

NA

