### PR TITLE
feat: customize message padding

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -84,9 +84,6 @@ const styles = StyleSheet.create({
     flex: 1,
     width: '100%',
   },
-  messagePadding: {
-    paddingHorizontal: 8,
-  },
   stickyHeader: {
     position: 'absolute',
     top: 0,
@@ -292,7 +289,8 @@ const MessageListWithContext = <
 
   const {
     colors: { white_snow },
-    messageList: { container, contentContainer, listContainer },
+    messageList: { container, contentContainer, listContainer, messageContainer },
+    screenPadding,
   } = theme;
 
   const modifiedTheme = useMemo(
@@ -562,7 +560,10 @@ const MessageListWithContext = <
       return (
         <>
           <View testID={`message-list-item-${index}`}>
-            <MessageSystem message={message} style={styles.messagePadding} />
+            <MessageSystem
+              message={message}
+              style={[{ paddingHorizontal: screenPadding }, messageContainer]}
+            />
           </View>
           {insertInlineUnreadIndicator && <InlineUnreadIndicator />}
         </>
@@ -587,7 +588,7 @@ const MessageListWithContext = <
               message={message}
               onThreadSelect={onThreadSelect}
               showUnreadUnderlay={showUnreadUnderlay}
-              style={styles.messagePadding}
+              style={[{ paddingHorizontal: screenPadding }, messageContainer]}
               threadList={threadList}
             />
           </View>
@@ -618,7 +619,7 @@ const MessageListWithContext = <
             message={message}
             onThreadSelect={onThreadSelect}
             showUnreadUnderlay={showUnreadUnderlay}
-            style={styles.messagePadding}
+            style={[{ paddingHorizontal: screenPadding }, messageContainer]}
             threadList={threadList}
           />
         </View>

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -248,9 +248,12 @@ exports[`Thread should match thread snapshot 1`] = `
                 <View
                   style={
                     Array [
-                      Object {
-                        "paddingHorizontal": 8,
-                      },
+                      Array [
+                        Object {
+                          "paddingHorizontal": 8,
+                        },
+                        Object {},
+                      ],
                       Object {
                         "backgroundColor": undefined,
                       },
@@ -497,9 +500,12 @@ exports[`Thread should match thread snapshot 1`] = `
                 <View
                   style={
                     Array [
-                      Object {
-                        "paddingHorizontal": 8,
-                      },
+                      Array [
+                        Object {
+                          "paddingHorizontal": 8,
+                        },
+                        Object {},
+                      ],
                       Object {
                         "backgroundColor": undefined,
                       },
@@ -746,9 +752,12 @@ exports[`Thread should match thread snapshot 1`] = `
                 <View
                   style={
                     Array [
-                      Object {
-                        "paddingHorizontal": 8,
-                      },
+                      Array [
+                        Object {
+                          "paddingHorizontal": 8,
+                        },
+                        Object {},
+                      ],
                       Object {
                         "backgroundColor": undefined,
                       },

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -1090,7 +1090,7 @@ export const defaultTheme: Theme = {
       image: {},
     },
   },
-  screenPadding: 32,
+  screenPadding: 8,
   spinner: {},
   thread: {
     newThread: {

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -338,6 +338,7 @@ export type Theme = {
       text: TextStyle;
     };
     listContainer: ViewStyle;
+    messageContainer: ViewStyle;
     messageSystem: {
       container: ViewStyle;
       dateText: TextStyle;
@@ -840,6 +841,7 @@ export const defaultTheme: Theme = {
       text: {},
     },
     listContainer: {},
+    messageContainer: {},
     messageSystem: {
       container: {},
       dateText: {},
@@ -1088,7 +1090,7 @@ export const defaultTheme: Theme = {
       image: {},
     },
   },
-  screenPadding: 8,
+  screenPadding: 32,
   spinner: {},
   thread: {
     newThread: {


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

Fixes #2158 by allowing a user to customize the horizontal padding for `MessageList`.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

- Remove the default styling in `MessageList` to use the default in `theme.ts`. This means the reactions alignment is always in sync rather than having to update both `screenPadding` and the `MessageList`.
- Added a new theme property called `messageContainer` so we can apply further custom styling beyond just the padding

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>

Proof of working with an extreme 32 horizontal padding -

![Simulator Screenshot - iPhone 14 Plus - 2023-07-27 at 10 44 10](https://github.com/GetStream/stream-chat-react-native/assets/45667737/a015dbe3-715c-42c7-aed1-8582cc4c0dbe)


</details>


<details>
<summary>Android</summary>

Proof of working with an extreme 32 horizontal padding -

![Screenshot_1690451040](https://github.com/GetStream/stream-chat-react-native/assets/45667737/e1ec7a3e-1cb6-47f8-9a69-4543ed0d5da3)

</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


