### PR TITLE
fix: image/video picker upload issue from expo apps and getLocalAssetURI improvements

### DIFF
--- a/examples/TypeScriptMessaging/App.tsx
+++ b/examples/TypeScriptMessaging/App.tsx
@@ -158,7 +158,7 @@ const ThreadScreen: React.FC<ThreadScreenProps> = ({ navigation }) => {
     });
   }, [overlay]);
 
-  if (!channel) return;
+  if (!channel) return null;
 
   return (
     <SafeAreaView>

--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -209,9 +209,14 @@ export const AttachmentPicker = React.forwardRef(
       maxNumberOfFiles,
       numberOfAttachmentPickerImageColumns,
       numberOfUploads: selectedFiles.length + selectedImages.length,
+      // `id` is available for Expo MediaLibrary while Cameraroll doesn't share id therefore we use `uri`
       selected:
-        selectedImages.some((image) => image.uri === asset.uri) ||
-        selectedFiles.some((file) => file.uri === asset.uri),
+        selectedImages.some((image) =>
+          image.id ? image.id === asset.id : image.uri === asset.uri,
+        ) ||
+        selectedFiles.some((file) => (file.id ? file.id === asset.id : file.uri === asset.uri)),
+      selectedFiles,
+      selectedImages,
       setSelectedFiles,
       setSelectedImages,
     }));

--- a/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
@@ -64,16 +64,13 @@ const AttachmentVideo: React.FC<AttachmentVideoProps> = (props) => {
 
   const size = vw(100) / (numberOfAttachmentPickerImageColumns || 3) - 2;
 
-  const fetchUpdatedFiles = async (files: File[]) => {
+  /* Patches video files with uri and mimetype */
+  const patchVideoFile = async (files: File[]) => {
     // For the case of Expo CLI where you need to fetch the file uri from file id. Here it is only done for iOS since for android the file.uri is fine.
     const localAssetURI = Platform.OS === 'ios' && asset.id && (await getLocalAssetUri(asset.id));
     const uri = localAssetURI || asset.uri || '';
     // We need a mime-type to upload a video file.
     const mimeType = lookup(asset.filename) || 'multipart/form-data';
-    if (numberOfUploads >= maxNumberOfFiles) {
-      Alert.alert('Maximum number of files reached');
-      return files;
-    }
     return [
       ...files,
       {
@@ -88,7 +85,11 @@ const AttachmentVideo: React.FC<AttachmentVideoProps> = (props) => {
   };
 
   const updateSelectedFiles = async () => {
-    const files = await fetchUpdatedFiles(selectedFiles);
+    if (numberOfUploads >= maxNumberOfFiles) {
+      Alert.alert('Maximum number of files reached');
+      return;
+    }
+    const files = await patchVideoFile(selectedFiles);
     setSelectedFiles(files);
   };
 
@@ -156,14 +157,11 @@ const AttachmentImage: React.FC<AttachmentImageProps> = (props) => {
 
   const { uri } = asset;
 
-  const fetchUpdatedImages = async (images: Asset[]) => {
+  /* Patches image files with uri */
+  const patchImageFile = async (images: Asset[]) => {
     // For the case of Expo CLI where you need to fetch the file uri from file id. Here it is only done for iOS since for android the file.uri is fine.
     const localAssetURI = Platform.OS === 'ios' && asset.id && (await getLocalAssetUri(asset.id));
     const uri = localAssetURI || asset.uri || '';
-    if (numberOfUploads >= maxNumberOfFiles) {
-      Alert.alert('Maximum number of files reached');
-      return images;
-    }
     return [
       ...images,
       {
@@ -174,7 +172,11 @@ const AttachmentImage: React.FC<AttachmentImageProps> = (props) => {
   };
 
   const updateSelectedImages = async () => {
-    const images = await fetchUpdatedImages(selectedImages);
+    if (numberOfUploads >= maxNumberOfFiles) {
+      Alert.alert('Maximum number of files reached');
+      return;
+    }
+    const images = await patchImageFile(selectedImages);
     setSelectedImages(images);
   };
 

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
-import { KeyboardAvoidingViewProps, Platform, StyleSheet, Text, View } from 'react-native';
+import { KeyboardAvoidingViewProps, StyleSheet, Text, View } from 'react-native';
 
 import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
@@ -74,7 +74,7 @@ import {
   ThumbsUpReaction,
   WutReaction,
 } from '../../icons';
-import { FlatList as FlatListDefault, getLocalAssetUri, pickDocument } from '../../native';
+import { FlatList as FlatListDefault, pickDocument } from '../../native';
 import * as dbApi from '../../store/apis';
 import type { DefaultStreamChatGenerics } from '../../types/types';
 import { addReactionToLocalState } from '../../utils/addReactionToLocalState';
@@ -1295,16 +1295,12 @@ const ChannelWithContext = <
           attachment.image_url &&
           isLocalUrl(attachment.image_url)
         ) {
-          // For the case of Expo CLI where you need to fetch the file uri from file id. Here it is only done for iOS since for android the file.uri is fine.
-          const localAssetURI =
-            Platform.OS === 'ios' && file.id && (await getLocalAssetUri(file.id));
-          const uri = localAssetURI || file.uri || '';
-          const filename = file.name ?? uri.replace(/^(file:\/\/|content:\/\/)/, '');
+          const filename = file.name ?? file.uri.replace(/^(file:\/\/|content:\/\/)/, '');
           const contentType = lookup(filename) || 'multipart/form-data';
 
           const uploadResponse = doImageUploadRequest
             ? await doImageUploadRequest(file, channel)
-            : await channel.sendImage(uri, filename, contentType);
+            : await channel.sendImage(file.uri, filename, contentType);
 
           attachment.image_url = uploadResponse.file;
           delete attachment.originalFile;

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -1,7 +1,7 @@
 import type { LegacyRef } from 'react';
 import React, { PropsWithChildren, useContext, useEffect, useRef, useState } from 'react';
 import type { TextInput, TextInputProps } from 'react-native';
-import { Alert, Keyboard, Platform } from 'react-native';
+import { Alert, Keyboard } from 'react-native';
 
 import uniq from 'lodash/uniq';
 import { lookup } from 'mime-types';
@@ -35,7 +35,7 @@ import type { MoreOptionsButtonProps } from '../../components/MessageInput/MoreO
 import type { SendButtonProps } from '../../components/MessageInput/SendButton';
 import type { UploadProgressIndicatorProps } from '../../components/MessageInput/UploadProgressIndicator';
 import type { MessageType } from '../../components/MessageList/hooks/useMessageList';
-import { compressImage, getLocalAssetUri, pickDocument } from '../../native';
+import { compressImage, pickDocument } from '../../native';
 import type { Asset, DefaultStreamChatGenerics, File, UnknownType } from '../../types/types';
 import { removeReservedFields } from '../../utils/removeReservedFields';
 import {
@@ -984,9 +984,7 @@ export const MessageInputProvider = <
     let response = {} as SendFileAPIResponse;
 
     try {
-      // For the case of Expo CLI where you need to fetch the file uri from file id. Here it is only done for iOS since for android the file.uri is fine.
-      const localAssetURI = Platform.OS === 'ios' && file.id && (await getLocalAssetUri(file.id));
-      const uri = localAssetURI || file.uri || '';
+      const uri = file.uri || '';
       /**
        * We skip compression if:
        * - the file is from the camera as that should already be compressed


### PR DESCRIPTION
## 🎯 Goal

This PR focuses on fixing the images/video upload through expo apps and native CLI. This also streamlines the usage of `getLocalAssetUri` by optimizing its usage where we select an attachment rather than using it before actually uploading an attachment.

Moreover, the expo media library sends the `id` for every photo/video while the camera roll mostly deals with the `URI` of the attachment. Hence, the check should happen in the same way.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


