### PR TITLE
fix: iPad landscape mode broke the height reactions list

### DIFF
--- a/examples/TypeScriptMessaging/ios/TypeScriptMessaging.xcodeproj/project.pbxproj
+++ b/examples/TypeScriptMessaging/ios/TypeScriptMessaging.xcodeproj/project.pbxproj
@@ -500,8 +500,12 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = TypeScriptMessaging;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -526,7 +530,11 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = TypeScriptMessaging;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/package/src/components/MessageOverlay/OverlayReactions.tsx
+++ b/package/src/components/MessageOverlay/OverlayReactions.tsx
@@ -69,6 +69,10 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     paddingTop: 16,
   },
+  unseenItemContainer: {
+    opacity: 0,
+    position: 'absolute',
+  },
 });
 
 const reactionData: ReactionData[] = [
@@ -138,6 +142,8 @@ export const OverlayReactions: React.FC<OverlayReactionsProps> = (props) => {
   const layoutHeight = useSharedValue(0);
   const layoutWidth = useSharedValue(0);
 
+  const [itemHeight, setItemHeight] = React.useState(0);
+
   const {
     theme: {
       colors: { accent_blue, black, grey_gainsboro, white },
@@ -159,7 +165,6 @@ export const OverlayReactions: React.FC<OverlayReactionsProps> = (props) => {
   } = useTheme();
 
   const width = useWindowDimensions().width;
-  const height = useWindowDimensions().height;
 
   const supportedReactionTypes = supportedReactions.map(
     (supportedReaction) => supportedReaction.type,
@@ -177,15 +182,6 @@ export const OverlayReactions: React.FC<OverlayReactionsProps> = (props) => {
         (Number(avatarContainer.padding || 0) || styles.avatarContainer.padding)) *
         2) /
       (avatarSize + (Number(avatarContainer.padding || 0) || styles.avatarContainer.padding) * 2),
-  );
-
-  const maxHeight = Math.floor(
-    height -
-      overlayPadding * 2 -
-      ((Number(flatListContainer.paddingVertical || 0) ||
-        styles.flatListContainer.paddingVertical) +
-        (Number(avatarContainer.padding || 0) || styles.avatarContainer.padding)) *
-        2,
   );
 
   const renderItem = ({ item }: { item: Reaction }) => {
@@ -305,23 +301,48 @@ export const OverlayReactions: React.FC<OverlayReactionsProps> = (props) => {
   );
 
   return (
-    <Animated.View
-      onLayout={({ nativeEvent: { layout } }) => {
-        layoutWidth.value = layout.width;
-        layoutHeight.value = layout.height;
-      }}
-      style={[styles.container, { backgroundColor: white }, container, showScreenStyle]}
-    >
-      <Text style={[styles.title, { color: black }, titleStyle]}>{title}</Text>
-      <FlatList
-        contentContainerStyle={styles.flatListContentContainer}
-        data={filteredReactions}
-        keyExtractor={({ name }, index) => `${name}_${index}`}
-        numColumns={numColumns}
-        renderItem={renderItem}
-        style={[styles.flatListContainer, flatListContainer, { maxHeight: maxHeight / numColumns }]}
-      />
-    </Animated.View>
+    <>
+      <Animated.View
+        onLayout={({ nativeEvent: { layout } }) => {
+          layoutWidth.value = layout.width;
+          layoutHeight.value = layout.height;
+        }}
+        style={[
+          styles.container,
+          { backgroundColor: white, opacity: itemHeight ? 1 : 0 },
+          container,
+          showScreenStyle,
+        ]}
+      >
+        <Text style={[styles.title, { color: black }, titleStyle]}>{title}</Text>
+        <FlatList
+          contentContainerStyle={styles.flatListContentContainer}
+          data={filteredReactions}
+          key={numColumns}
+          keyExtractor={({ name }, index) => `${name}_${index}`}
+          numColumns={numColumns}
+          renderItem={renderItem}
+          style={[
+            styles.flatListContainer,
+            flatListContainer,
+            {
+              // we show the item height plus a little extra to tease for scrolling if there are more than one row
+              maxHeight:
+                itemHeight + (filteredReactions.length / numColumns > 1 ? itemHeight / 8 : 0),
+            },
+          ]}
+        />
+        {/* The below view is unseen by the user, we use it to compute the height that the item must be */}
+        <View
+          onLayout={({ nativeEvent: { layout } }) => {
+            setItemHeight(layout.height);
+          }}
+          style={[styles.unseenItemContainer, styles.flatListContentContainer]}
+        >
+          {renderItem({ item: filteredReactions[0] })}
+        </View>
+      </Animated.View>
+    </>
   );
 };
 


### PR DESCRIPTION
## 🎯 Goal

on Ipad landscape mode, the reaction list was cut off as below..

![image](https://github.com/GetStream/stream-chat-react-native/assets/3846977/5aee0b44-4b98-4ed7-bf77-bd087ee96c5a)

additionally, I have enabled iPad support in TS messaging app 

this PR aims to fix this

## 🛠 Implementation details

We set the max height based on the item height. The item height is now computed.

## 🧪 Testing

Use iPad landscape mode and open the list

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [ ] Expo iOS and Android


