### PR TITLE
fix: unable to apply reaction list fill color

### DIFF
--- a/package/src/components/Message/MessageSimple/ReactionList.tsx
+++ b/package/src/components/Message/MessageSimple/ReactionList.tsx
@@ -147,7 +147,7 @@ const ReactionListWithContext = <
   }
 
   const alignmentLeft = alignment === 'left';
-  const fill = propFill || alignmentLeft ? grey_gainsboro : grey_whisper;
+  const fill = propFill || (alignmentLeft ? grey_gainsboro : grey_whisper);
   const radius = propRadius || themeRadius;
   const reactionSize = propReactionSize || themeReactionSize;
   const highlighted = message.pinned || targetedMessage === message.id;


### PR DESCRIPTION
Adding:

```tsx
ReactionList={({ messageContentWidth }) => {
          return <ReactionList messageContentWidth={messageContentWidth} fill='green' />;
        }}
```
to `Channel` doesn't add the fill color to ReactionList.

The PR tends to fix the issue.