### PR TITLE
fix: long message content overflowing issue in overlay

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -198,11 +198,27 @@ export const renderText = <
     );
   };
 
-  const paragraphText: ReactNodeOutput = (node, output, { ...state }) => (
-    <Text key={state.key} numberOfLines={messageTextNumberOfLines} style={styles.paragraph}>
-      {output(node.content, state)}
-    </Text>
-  );
+  const paragraphText: ReactNodeOutput = (node, output, { ...state }) => {
+    if (messageTextNumberOfLines !== undefined) {
+      // If we want to truncate the message text, lets only truncate the first paragraph
+      // and simply not render rest of the paragraphs.
+      if (state.key === '0' || state.key === 0) {
+        return (
+          <Text key={state.key} numberOfLines={messageTextNumberOfLines} style={styles.paragraph}>
+            {output(node.content, state)}
+          </Text>
+        );
+      } else {
+        return null;
+      }
+    }
+
+    return (
+      <Text key={state.key} style={styles.paragraph}>
+        {output(node.content, state)}
+      </Text>
+    );
+  };
 
   const mentionedUsers = Array.isArray(mentioned_users)
     ? mentioned_users.reduce((acc, cur) => {

--- a/package/src/components/MessageOverlay/OverlayReactionList.tsx
+++ b/package/src/components/MessageOverlay/OverlayReactionList.tsx
@@ -239,6 +239,7 @@ export type OverlayReactionListPropsWithContext<
       y: number;
     }>;
     ownReactionTypes: string[];
+    setReactionListHeight: React.Dispatch<React.SetStateAction<number>>;
     showScreen: Animated.SharedValue<number>;
     fill?: FillProps['fill'];
   };
@@ -254,6 +255,7 @@ const OverlayReactionListWithContext = <
     handleReaction,
     messageLayout,
     ownReactionTypes,
+    setReactionListHeight,
     showScreen,
     setOverlay,
     supportedReactions = reactionData,
@@ -354,6 +356,7 @@ const OverlayReactionListWithContext = <
           }) => {
             reactionListLayout.value = { height, width: layoutWidth };
             reactionListHeight.value = height;
+            setReactionListHeight(height);
           }}
           style={[
             styles.reactionList,


### PR DESCRIPTION
## 🎯 Goal

This PR fixes two UX issues:
- https://github.com/GetStream/stream-chat-react-native/issues/1734
- https://github.com/GetStream/stream-chat-react-native/issues/2188

## 🛠 Implementation details

## Issue 1

There are two types of message overlay. One where we show message actions and another one where we show reactions from all the users. The overflowing content can only be resolved by adding ScrollView on message overlay. At some point we [decided to remove](https://github.com/GetStream/stream-chat-react-native/pull/953/files#diff-5ddd01157638d81c5bd88ac5488fe90520647956e3a861da3e6ce07c95fe47d0) `ScrollView` because we already have a `FlatList` in OverlayReactions component (as shown in 2nd screenshot below). FlatList inside ScrollView results into red warning from RN

<img width="300" alt="Screenshot 2023-09-28 at 16 35 07" src="https://github.com/GetStream/stream-chat-react-native/assets/11586388/9f30a128-2954-4928-97b6-3d13ee57fdb8">

<img width="300" alt="Screenshot 2023-09-28 at 16 32 33" src="https://github.com/GetStream/stream-chat-react-native/assets/11586388/7278d18b-5f63-4aae-8341-a97d5753e190">

## Solution

- Add the ScrollView on the message overlay, but only when we show message actions.
- For this screen, there won't be any text truncation
- Text truncation only works when we show reactions within message overlay. Message will be truncated to number of lines provided by `messageTextNumberOfLines` prop.


https://github.com/GetStream/stream-chat-react-native/assets/11586388/7dd36039-35aa-4799-b54f-af032647931b


## Issue 2

First issue is about `messageTextNumberOfLines` not working as expected. The reason being, this prop was added to every paragraph's Text node, which would result in each paragraph being truncated to given number of lines.

## Solution

There is no perfect solution for this at the moment. But we can improve this, by adding this prop only to the first paragraph. But keep in mind that this would also mean that if first paragraph only contains 2 lines and `messageTextNumberOfLines` is set to 3 - we will show the first paragraph completely and hide rest of the paragraphs without any truncation suffix (`...`). But I think its a worthy tradeoff.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


