### PR TITLE
Fix: Enable tap function on parent message of Thread

### DIFF
--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -1141,11 +1141,6 @@ exports[`Thread should match thread snapshot 1`] = `
                             </View>
                           </View>
                           <View
-                            accessibilityState={
-                              Object {
-                                "disabled": true,
-                              }
-                            }
                             accessible={true}
                             collapsable={false}
                             focusable={true}

--- a/package/src/components/Thread/components/ThreadFooterComponent.tsx
+++ b/package/src/components/Thread/components/ThreadFooterComponent.tsx
@@ -64,7 +64,7 @@ const ThreadFooterComponentWithContext = <
   return (
     <View style={styles.threadHeaderContainer} testID='thread-footer-component'>
       <View style={styles.messagePadding}>
-        <Message groupStyles={['single']} message={thread} preventPress threadList />
+        <Message groupStyles={['single']} message={thread} threadList />
       </View>
       <View style={[styles.newThread, newThread]}>
         <Svg height={newThread.height ?? 24} style={styles.absolute} width={vw(100)}>


### PR DESCRIPTION
## 🎯 Goal
- The parent message is enabled to execute press functions in a thread

## 🛠 Implementation details
- Currently, users can't execute press functions on the parent messages in a thread.
  - Can't open URL inside of parent messages in a thread
  - Can't add any reactions to parent messages in a thread
  - Can't quote parent messages in a thread
- Aimed for the same specs as Slack

https://github.com/GetStream/stream-chat-react-native/assets/17227480/d28f3f20-7a5f-41df-a926-f219d41d923c


## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>
<h3>Before</h3> 

https://github.com/GetStream/stream-chat-react-native/assets/17227480/bd1b0897-dd3c-4a59-8425-2881a8b5c919

<h3>After</h3> 

https://github.com/GetStream/stream-chat-react-native/assets/17227480/0d336129-5896-44f7-a8c4-758a7a488803     

</details>


<details>
<summary>Android</summary>

<h3>Before</h3> 

https://github.com/GetStream/stream-chat-react-native/assets/17227480/d7a1637c-f40b-4500-b411-ce58194c574e

<h3>After</h3> 
     
https://github.com/GetStream/stream-chat-react-native/assets/17227480/240b39b3-6efc-41d3-ab5e-a84c384a532e

</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


