### PR TITLE
feat: upgrade bottom-sheet to 4.4.8

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@gorhom/bottom-sheet": "4.4.5",
+    "@gorhom/bottom-sheet": "4.4.8",
     "dayjs": "1.10.5",
     "file-loader": "6.2.0",
     "i18next": "20.2.4",

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -1432,10 +1432,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gorhom/bottom-sheet@4.4.5":
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-4.4.5.tgz#b9041b01ce1af9a936e7c0fc1d78f026d759eebe"
-  integrity sha512-Z5Z20wshLUB8lIdtMKoJaRnjd64wBR/q8EeVPThrg+skrcBwBPHfUwZJ2srB0rEszA/01ejSJy/ixyd7Ra7vUA==
+"@gorhom/bottom-sheet@4.4.8":
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-4.4.8.tgz#cfc1b342e9151acecbb846bd67638211382a350e"
+  integrity sha512-5QgM91NJjbqKxI8RjZ9ujjynaPzAM1iQKExK3+L+ZbEnziIq8tgOekhiBUut9sBZAQA4nhLxWV6Rt/HGpgCldQ==
   dependencies:
     "@gorhom/portal" "1.0.14"
     invariant "^2.2.4"


### PR DESCRIPTION
## 🎯 Goal

This upgrade ensures feasible upgrade to reanimated v3. The issues with reanimated v3 were fixed between 4.4.6 and 4.4.8.

https://getstream.slack.com/archives/C0404PASF45/p1689082793392139
