### PR TITLE
chore: replace last_message_at with last_updated

### DIFF
--- a/docusaurus/docs/reactnative/common-content/core-components/channel-list/props/sort.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/channel-list/props/sort.mdx
@@ -4,7 +4,7 @@ You can sort a query on [built-in](https://getstream.io/chat/docs/javascript/que
 #### Example
 
 ```tsx
-const sort = { last_message_at: -1 };
+const sort = { last_updated: -1 };
 ```
 
 :::note

--- a/docusaurus/docs/reactnative/core-components/channel_list.mdx
+++ b/docusaurus/docs/reactnative/core-components/channel_list.mdx
@@ -60,7 +60,7 @@ import { ChannelList, Chat, OverlayProvider } from 'stream-chat-react-native';
 
 const client = StreamChat.getInstance('api_key');
 const filters = { members: { $in: [ 'vishal', 'lucas', 'neil' ] } };
-const sort = { last_message_at: -1 };
+const sort = { last_updated: -1 };
 const options = { limit: 20, messages_limit: 30 };
 
 export const App = () =>

--- a/docusaurus/reactnative_versioned_docs/version-3.x.x/common-content/core-components/channel-list/props/sort.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-3.x.x/common-content/core-components/channel-list/props/sort.mdx
@@ -4,7 +4,7 @@ You can sort a query on [built-in](https://getstream.io/chat/docs/javascript/que
 #### Example
 
 ```tsx
-const sort = { last_message_at: -1 };
+const sort = { last_updated: -1 };
 ```
 
 :::note

--- a/docusaurus/reactnative_versioned_docs/version-3.x.x/core-components/channel_list.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-3.x.x/core-components/channel_list.mdx
@@ -57,7 +57,7 @@ import { ChannelList, Chat, OverlayProvider } from 'stream-chat-react-native';
 
 const client = StreamChat.getInstance('api_key');
 const filters = { members: { $in: [ 'vishal', 'lucas', 'neil' ] } };
-const sort = { last_message_at: -1 };
+const sort = { last_updated: -1 };
 const options = { limit: 20, messages_limit: 30 };
 
 export const App = () =>

--- a/docusaurus/reactnative_versioned_docs/version-4.x.x/common-content/core-components/channel-list/props/sort.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-4.x.x/common-content/core-components/channel-list/props/sort.mdx
@@ -4,7 +4,7 @@ You can sort a query on [built-in](https://getstream.io/chat/docs/javascript/que
 #### Example
 
 ```tsx
-const sort = { last_message_at: -1 };
+const sort = { last_updated: -1 };
 ```
 
 :::note

--- a/docusaurus/reactnative_versioned_docs/version-4.x.x/core-components/channel_list.mdx
+++ b/docusaurus/reactnative_versioned_docs/version-4.x.x/core-components/channel_list.mdx
@@ -58,7 +58,7 @@ import { ChannelList, Chat, OverlayProvider } from 'stream-chat-react-native';
 
 const client = StreamChat.getInstance('api_key');
 const filters = { members: { $in: [ 'vishal', 'lucas', 'neil' ] } };
-const sort = { last_message_at: -1 };
+const sort = { last_updated: -1 };
 const options = { limit: 20, messages_limit: 30 };
 
 export const App = () =>

--- a/examples/ExpoMessaging/app/index.tsx
+++ b/examples/ExpoMessaging/app/index.tsx
@@ -11,7 +11,7 @@ const filters = {
   members: { $in: [user.id] },
   type: 'messaging',
 };
-const sort: ChannelSort<StreamChatGenerics> = { last_message_at: -1 };
+const sort: ChannelSort<StreamChatGenerics> = { last_updated: -1 };
 const options = {
   state: true,
   watch: true,

--- a/examples/SampleApp/src/screens/ChannelListScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelListScreen.tsx
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
 const baseFilters = {
   type: 'messaging',
 };
-const sort: ChannelSort<StreamChatGenerics> = { last_message_at: -1 };
+const sort: ChannelSort<StreamChatGenerics> = { last_updated: -1 };
 const options = {
   presence: true,
   state: true,

--- a/examples/SampleApp/src/screens/SharedGroupsScreen.tsx
+++ b/examples/SampleApp/src/screens/SharedGroupsScreen.tsx
@@ -191,7 +191,7 @@ export const SharedGroupsScreen: React.FC<SharedGroupsScreenProps> = ({
         }}
         Preview={CustomPreview}
         sort={{
-          last_message_at: -1,
+          last_updated: -1,
         }}
       />
     </View>

--- a/examples/TypeScriptMessaging/App.tsx
+++ b/examples/TypeScriptMessaging/App.tsx
@@ -65,7 +65,7 @@ const filters = {
   members: { $in: ['ron'] },
   type: 'messaging',
 };
-const sort: ChannelSort<StreamChatGenerics> = { last_message_at: -1 };
+const sort: ChannelSort<StreamChatGenerics> = { last_updated: -1 };
 
 /**
  * Start playing with streami18n instance here:

--- a/package/src/__tests__/offline-support/offline-feature.js
+++ b/package/src/__tests__/offline-support/offline-feature.js
@@ -195,7 +195,7 @@ export const Generic = () => {
       foo: 'bar',
       type: 'messaging',
     };
-    const sort = { last_message_at: 1 };
+    const sort = { last_updated: -1 };
 
     const renderComponent = () =>
       render(

--- a/package/src/components/docs/data.js
+++ b/package/src/components/docs/data.js
@@ -33,7 +33,7 @@ export const suggestionsContext = {
 };
 
 const filters = { example: 1, type: 'team' };
-const sort = { last_message_at: -1 };
+const sort = { last_updated: -1 };
 
 export const channels = client.queryChannels(filters, sort, {
   subscribe: true,


### PR DESCRIPTION
## 🎯 Goal

To avoid integrators getting [this issue](https://github.com/GetStream/stream-chat-react-native/issues/901#issuecomment-934199488)

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


