### PR TITLE
fix: resolve mentioned user as user rather than link

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/generateMarkdownText.ts
+++ b/package/src/components/Message/MessageSimple/utils/generateMarkdownText.ts
@@ -1,0 +1,43 @@
+import truncate from 'lodash/truncate';
+
+import { parseLinksFromText } from './parseLinks';
+
+import type { DefaultStreamChatGenerics } from '../../../../types/types';
+import type { MessageType } from '../../../MessageList/hooks/useMessageList';
+
+export const generateMarkdownText = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+>(
+  message: MessageType<StreamChatGenerics>,
+) => {
+  const { text } = message;
+
+  if (!text) return null;
+
+  // Trim the extra spaces from the text.
+  let resultText = text.trim();
+
+  // List of all the links present in the text.
+  const linkInfos = parseLinksFromText(resultText);
+
+  for (const linkInfo of linkInfos) {
+    const displayLink = truncate(linkInfo.raw, {
+      length: 200,
+      omission: '...',
+    });
+    // Convert raw links/emails in the text to respective markdown syntax.
+    // Eg: Hi getstream.io -> Hi [getstream.io](getstream.io).
+    const normalRegEx = new RegExp(linkInfo.raw, 'g');
+    const markdown = `[${displayLink}](${linkInfo.encodedUrl})`;
+    resultText = text.replace(normalRegEx, markdown);
+
+    // After previous step, in some cases, the mentioned user after `@` might have a link/email so we convert it back to normal raw text.
+    // Eg: Hi, @[test.user@gmail.com](mailto:test.user@gmail.com) to @test.user@gmail.com.
+    const mentionsRegex = new RegExp(`@\\[${displayLink}\\]\\(${linkInfo.encodedUrl}\\)`, 'g');
+    resultText = resultText.replace(mentionsRegex, `@${displayLink}`);
+  }
+
+  resultText = resultText.replace(/[<&"'>]/g, '\\$&');
+
+  return resultText;
+};

--- a/package/src/components/Message/MessageSimple/utils/parseLinks.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.ts
@@ -12,13 +12,13 @@ interface LinkInfo {
 const removeMarkdownLinksFromText = (input: string) => input.replace(/\[[\w\s]+\]\(.*\)/g, '');
 
 /**
- * Hermes doesn't support lookbehind, so this is done separately to avoid
- * parsing user names as links.
- * */
-const removeUserNamesFromText = (input: string) => input.replace(/^@\w+\.?\w/, '');
+ * This is done to avoid parsing usernames with dot as well as an email address in it.
+ */
+const removeUserNamesWithEmailFromText = (input: string) =>
+  input.replace(/@(\w+(\.\w+)?)(@\w+\.\w+)/g, '');
 
 export const parseLinksFromText = (input: string): LinkInfo[] => {
-  const strippedInput = [removeMarkdownLinksFromText, removeUserNamesFromText].reduce(
+  const strippedInput = [removeMarkdownLinksFromText, removeUserNamesWithEmailFromText].reduce(
     (acc, fn) => fn(acc),
     input,
   );


### PR DESCRIPTION
## 🎯 Goal

Fixes #2285 

The code structure is also improved with this PR.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The regex is changed so that email type user names are removed when parsing links and then modifying the text accordingly.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

Before:
![simulator_screenshot_538674B8-5F54-4F93-A85B-6159B40C5B7D](https://github.com/GetStream/stream-chat-react-native/assets/39884168/0f1dcdf4-de20-42ab-802b-420a9976f8af)


After:
![simulator_screenshot_921EB24F-C087-4B3D-B471-D3597DF13FFD](https://github.com/GetStream/stream-chat-react-native/assets/39884168/d8a8bba0-6d3e-4882-81ae-21ed349dabe3)

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


