### PR TITLE
feat: add theme to override the reaction list icon color

### DIFF
--- a/package/src/components/Message/MessageSimple/ReactionList.tsx
+++ b/package/src/components/Message/MessageSimple/ReactionList.tsx
@@ -121,6 +121,7 @@ const ReactionListWithContext = <
         avatarWrapper: { leftAlign, spacer },
         reactionList: {
           container,
+          iconFillColor,
           middleIcon,
           radius: themeRadius,
           reactionBubble,
@@ -263,7 +264,7 @@ const ReactionListWithContext = <
             {reactions.map((reaction) => (
               <Icon
                 key={reaction.type}
-                pathFill={reaction.own ? accent_blue : grey}
+                pathFill={reaction.own ? iconFillColor || accent_blue : grey}
                 size={reactionSize / 2}
                 style={middleIcon}
                 supportedReactions={supportedReactions}

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -480,6 +480,7 @@ export type Theme = {
     };
     reactionList: {
       container: ViewStyle;
+      iconFillColor: Color;
       middleIcon: ViewStyle;
       radius: number;
       reactionBubble: ViewStyle;
@@ -1019,6 +1020,7 @@ export const defaultTheme: Theme = {
     },
     reactionList: {
       container: {},
+      iconFillColor: '',
       middleIcon: {},
       radius: 2, // not recommended to change this
       reactionBubble: {},


### PR DESCRIPTION
## 🎯 Goal

Fixes #1863 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


