### PR TITLE
fix: do not send two upload requests when offline support is enabled

### DIFF
--- a/package/src/components/Attachment/AudioAttachment.tsx
+++ b/package/src/components/Attachment/AudioAttachment.tsx
@@ -4,7 +4,7 @@ import { I18nManager, StyleSheet, Text, TouchableOpacity, View } from 'react-nat
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 
-import { FileUpload, useTheme } from '../../contexts';
+import { useTheme } from '../../contexts';
 import { Pause, Play } from '../../icons';
 import {
   PlaybackStatus,
@@ -13,6 +13,7 @@ import {
   VideoPayloadData,
   VideoProgressData,
 } from '../../native';
+import type { FileUpload } from '../../types/types';
 import { ProgressControl } from '../ProgressControl/ProgressControl';
 
 dayjs.extend(duration);

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -1306,6 +1306,7 @@ const ChannelWithContext = <
           isLocalUrl(attachment.image_url)
         ) {
           const filename = file.name ?? file.uri.replace(/^(file:\/\/|content:\/\/)/, '');
+          // if any upload is in progress, cancel it
           const controller = uploadAbortControllerRef.current.get(filename);
           if (controller) {
             controller.abort();
@@ -1313,7 +1314,6 @@ const ChannelWithContext = <
           }
           const contentType = lookup(filename) || 'multipart/form-data';
 
-          // if any upload is in progress, cancel it
           const uploadResponse = doImageUploadRequest
             ? await doImageUploadRequest(file, channel)
             : await channel.sendImage(file.uri, filename, contentType);

--- a/package/src/components/Channel/hooks/useCreateChannelContext.ts
+++ b/package/src/components/Channel/hooks/useCreateChannelContext.ts
@@ -36,6 +36,7 @@ export const useCreateChannelContext = <
   StickyHeader,
   targetedMessage,
   threadList,
+  uploadAbortControllerRef,
   watcherCount,
   watchers,
 }: ChannelContextValue<StreamChatGenerics>) => {
@@ -79,6 +80,7 @@ export const useCreateChannelContext = <
       StickyHeader,
       targetedMessage,
       threadList,
+      uploadAbortControllerRef,
       watcherCount,
       watchers,
     }),

--- a/package/src/components/MessageInput/FileUploadPreview.tsx
+++ b/package/src/components/MessageInput/FileUploadPreview.tsx
@@ -7,7 +7,6 @@ import { UploadProgressIndicator } from './UploadProgressIndicator';
 
 import { ChatContextValue, useChatContext } from '../../contexts';
 import {
-  FileUpload,
   MessageInputContextValue,
   useMessageInputContext,
 } from '../../contexts/messageInputContext/MessageInputContext';
@@ -20,7 +19,7 @@ import { useTranslationContext } from '../../contexts/translationContext/Transla
 import { Close } from '../../icons/Close';
 import { Warning } from '../../icons/Warning';
 import { isAudioPackageAvailable } from '../../native';
-import type { DefaultStreamChatGenerics } from '../../types/types';
+import type { DefaultStreamChatGenerics, FileUpload } from '../../types/types';
 import { FileState, getIndicatorTypeForFileState, ProgressIndicatorTypes } from '../../utils/utils';
 import { getFileSizeDisplayText } from '../Attachment/FileAttachment';
 import { WritingDirectionAwareText } from '../RTLComponents/WritingDirectionAwareText';

--- a/package/src/components/MessageInput/ImageUploadPreview.tsx
+++ b/package/src/components/MessageInput/ImageUploadPreview.tsx
@@ -13,7 +13,6 @@ import { UploadProgressIndicator } from './UploadProgressIndicator';
 
 import { ChatContextValue, useChatContext } from '../../contexts';
 import {
-  ImageUpload,
   MessageInputContextValue,
   useMessageInputContext,
 } from '../../contexts/messageInputContext/MessageInputContext';
@@ -21,7 +20,7 @@ import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
 import { Close } from '../../icons/Close';
 import { Warning } from '../../icons/Warning';
-import type { DefaultStreamChatGenerics } from '../../types/types';
+import type { DefaultStreamChatGenerics, ImageUpload } from '../../types/types';
 import { getIndicatorTypeForFileState, ProgressIndicatorTypes } from '../../utils/utils';
 
 const IMAGE_PREVIEW_SIZE = 100;

--- a/package/src/components/MessageInput/__tests__/AudioAttachmentUploadPreviewExpo.test.tsx
+++ b/package/src/components/MessageInput/__tests__/AudioAttachmentUploadPreviewExpo.test.tsx
@@ -5,7 +5,6 @@ import { act } from 'react-test-renderer';
 import { fireEvent, render } from '@testing-library/react-native';
 
 import {
-  FileUpload,
   MessageInputContext,
   MessageInputContextValue,
 } from '../../../contexts/messageInputContext/MessageInputContext';
@@ -13,6 +12,7 @@ import { ThemeProvider } from '../../../contexts/themeContext/ThemeContext';
 import { defaultTheme } from '../../../contexts/themeContext/utils/theme';
 
 import { generateFileUploadPreview } from '../../../mock-builders/generator/attachment';
+import type { FileUpload } from '../../../types/types';
 import { AudioAttachment, AudioAttachmentProps } from '../../Attachment/AudioAttachment';
 
 jest.mock('../../../native.ts', () => ({

--- a/package/src/components/MessageInput/__tests__/AudioAttachmentUploadPreviewNative.test.tsx
+++ b/package/src/components/MessageInput/__tests__/AudioAttachmentUploadPreviewNative.test.tsx
@@ -5,7 +5,6 @@ import { act } from 'react-test-renderer';
 import { fireEvent, render } from '@testing-library/react-native';
 
 import {
-  FileUpload,
   MessageInputContext,
   MessageInputContextValue,
 } from '../../../contexts/messageInputContext/MessageInputContext';
@@ -13,6 +12,7 @@ import { ThemeProvider } from '../../../contexts/themeContext/ThemeContext';
 import { defaultTheme } from '../../../contexts/themeContext/utils/theme';
 
 import { generateFileUploadPreview } from '../../../mock-builders/generator/attachment';
+import type { FileUpload } from '../../../types/types';
 import { AudioAttachment, AudioAttachmentProps } from '../../Attachment/AudioAttachment';
 
 jest.mock('../../../native.ts', () => {

--- a/package/src/contexts/channelContext/ChannelContext.tsx
+++ b/package/src/contexts/channelContext/ChannelContext.tsx
@@ -138,6 +138,11 @@ export type ChannelContextValue<
   setLastRead: React.Dispatch<React.SetStateAction<Date | undefined>>;
   setTargetedMessage: (messageId: string) => void;
   /**
+   * Abort controller for cancelling async requests made for uploading images/files
+   * Its a map of filename and AbortController
+   */
+  uploadAbortControllerRef: React.MutableRefObject<Map<string, AbortController>>;
+  /**
    *
    * ```json
    * {

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -984,7 +984,10 @@ export const MessageInputProvider = <
       const extraData: Partial<FileUpload> = { thumb_url: response.thumb_url, url: response.file };
       setFileUploads(getUploadSetStateAction(id, FileState.UPLOADED, extraData));
     } catch (error: unknown) {
-      if (error instanceof Error && error.name === 'AbortError') {
+      if (
+        error instanceof Error &&
+        (error.name === 'AbortError' || error.name === 'CanceledError')
+      ) {
         // nothing to do
         uploadAbortControllerRef.current.delete(file.name);
         return;
@@ -1081,7 +1084,10 @@ export const MessageInputProvider = <
         setImageUploads(newImageUploads);
       }
     } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
+      if (
+        error instanceof Error &&
+        (error.name === 'AbortError' || error.name === 'CanceledError')
+      ) {
         // nothing to do
         uploadAbortControllerRef.current.delete(filename);
         return;

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -641,20 +641,25 @@ export const MessageInputProvider = <
     setText('');
   };
 
-  const mapImageUploadToAttachment = (image: ImageUpload) => {
+  const mapImageUploadToAttachment = (image: ImageUpload): Attachment<StreamChatGenerics> => {
     const mime_type: string | boolean = lookup(image.file.filename as string);
+    const name = image.file.name ?? (image.file.filename as string);
     return {
-      fallback: image.file.name,
+      fallback: name,
       image_url: image.url,
       mime_type: mime_type ? mime_type : undefined,
       original_height: image.height,
       original_width: image.width,
-      originalFile: image.file,
+      originalFile: {
+        ...image.file,
+        duration: image.file.duration ? `${image.file.duration}` : undefined,
+        name,
+      },
       type: 'image',
-    } as Attachment;
+    };
   };
 
-  const mapFileUploadToAttachment = (file: FileUpload) => {
+  const mapFileUploadToAttachment = (file: FileUpload): Attachment<StreamChatGenerics> => {
     if (file.file.mimeType?.startsWith('image/')) {
       return {
         fallback: file.file.name,

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -36,7 +36,14 @@ import type { SendButtonProps } from '../../components/MessageInput/SendButton';
 import type { UploadProgressIndicatorProps } from '../../components/MessageInput/UploadProgressIndicator';
 import type { MessageType } from '../../components/MessageList/hooks/useMessageList';
 import { compressImage, pickDocument } from '../../native';
-import type { Asset, DefaultStreamChatGenerics, File, UnknownType } from '../../types/types';
+import type {
+  Asset,
+  DefaultStreamChatGenerics,
+  File,
+  FileUpload,
+  ImageUpload,
+  UnknownType,
+} from '../../types/types';
 import { removeReservedFields } from '../../utils/removeReservedFields';
 import {
   ACITriggerSettings,
@@ -57,28 +64,6 @@ import { DEFAULT_BASE_CONTEXT_VALUE } from '../utils/defaultBaseContextValue';
 
 import { getDisplayName } from '../utils/getDisplayName';
 import { isTestEnvironment } from '../utils/isTestEnvironment';
-
-export type FileUpload = {
-  file: File;
-  id: string;
-  state: FileStateValue;
-  duration?: number;
-  paused?: boolean;
-  progress?: number;
-  thumb_url?: string;
-  url?: string;
-};
-
-export type ImageUpload = {
-  file: Partial<Asset> & {
-    name?: string;
-  };
-  id: string;
-  state: FileStateValue;
-  height?: number;
-  url?: string;
-  width?: number;
-};
 
 export type MentionAllAppUsersQuery<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,

--- a/package/src/contexts/messageInputContext/__tests__/__snapshots__/sendMessage.test.tsx.snap
+++ b/package/src/contexts/messageInputContext/__tests__/__snapshots__/sendMessage.test.tsx.snap
@@ -7,7 +7,7 @@ Object {
       "fallback": undefined,
       "image_url": undefined,
       "mime_type": undefined,
-      "originalFile": Object {
+      "originalImage": Object {
         "uri": "http://www.jackblack.com/tenac_iousd.bmp",
       },
       "original_height": undefined,
@@ -106,7 +106,7 @@ Object {
       "fallback": undefined,
       "image_url": undefined,
       "mime_type": undefined,
-      "originalFile": Object {
+      "originalImage": Object {
         "uri": "http://www.jackblack.com/tenac_iousd.bmp",
       },
       "original_height": undefined,
@@ -117,7 +117,7 @@ Object {
       "fallback": undefined,
       "image_url": undefined,
       "mime_type": undefined,
-      "originalFile": Object {
+      "originalImage": Object {
         "uri": "http://www.jackblack.com/tenac_iousd.bmp",
       },
       "original_height": undefined,

--- a/package/src/contexts/messageInputContext/hooks/useMessageDetailsForState.ts
+++ b/package/src/contexts/messageInputContext/hooks/useMessageDetailsForState.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 
-import type { DefaultStreamChatGenerics } from '../../../types/types';
+import type { DefaultStreamChatGenerics, FileUpload, ImageUpload } from '../../../types/types';
 import { generateRandomId } from '../../../utils/utils';
 
-import type { FileUpload, ImageUpload, MessageInputContextValue } from '../MessageInputContext';
+import type { MessageInputContextValue } from '../MessageInputContext';
 
 export const isEditingBoolean = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,

--- a/package/src/types/types.ts
+++ b/package/src/types/types.ts
@@ -1,5 +1,7 @@
 import type { ExtendableGenerics, LiteralStringForUnion } from 'stream-chat';
 
+import type { FileStateValue } from '../utils/utils';
+
 export type Asset = {
   duration: number;
   height: number;
@@ -20,6 +22,26 @@ export type File = {
   size?: number;
   // The uri should be of type `string`. But is `string|undefined` because the same type is used for the response from Stream's Attachment. This shall be fixed.
   uri?: string;
+};
+
+export type FileUpload = {
+  file: File;
+  id: string;
+  state: FileStateValue;
+  duration?: number;
+  paused?: boolean;
+  progress?: number;
+  thumb_url?: string;
+  url?: string;
+};
+
+export type ImageUpload = {
+  file: Partial<Asset>;
+  id: string;
+  state: FileStateValue;
+  height?: number;
+  url?: string;
+  width?: number;
 };
 
 export type DefaultAttachmentType = UnknownType & {

--- a/package/src/types/types.ts
+++ b/package/src/types/types.ts
@@ -48,6 +48,7 @@ export type DefaultAttachmentType = UnknownType & {
   file_size?: number;
   mime_type?: string;
   originalFile?: File;
+  originalImage?: Partial<Asset>;
 };
 
 interface DefaultUserType extends UnknownType {

--- a/package/src/utils/compressImage.ts
+++ b/package/src/utils/compressImage.ts
@@ -1,0 +1,32 @@
+import { compressImage } from '../native';
+import type { Asset } from '../types/types';
+
+/**
+ * Function to compress and Image and return the compressed Image URI
+ * @param image
+ * @param compressImageQuality
+ * @returns string
+ */
+export const compressedImageURI = async (image: Partial<Asset>, compressImageQuality?: number) => {
+  const uri = image.uri || '';
+  /**
+   * We skip compression if:
+   * - the file is from the camera as that should already be compressed
+   * - the file has no height/width value to maintain for compression
+   * - the compressImageQuality number is not present or is 1 (meaning no compression)
+   */
+  const compressedUri = await (image.source === 'camera' ||
+  !image.height ||
+  !image.width ||
+  typeof compressImageQuality !== 'number' ||
+  compressImageQuality === 1
+    ? uri
+    : compressImage({
+        compressImageQuality,
+        height: image.height,
+        uri,
+        width: image.width,
+      }));
+
+  return compressedUri;
+};


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


