### PR TITLE
refactor: change filename and fileSize to name and size respectively for Asset type

### DIFF
--- a/package/expo-package/src/handlers/getPhotos.ts
+++ b/package/expo-package/src/handlers/getPhotos.ts
@@ -32,9 +32,9 @@ export const getPhotos = async ({
     });
     const assets = results.assets.map((asset) => ({
       duration: asset.duration,
-      filename: asset.filename,
       height: asset.height,
       id: asset.id,
+      name: asset.filename,
       source: 'picker' as const,
       type: asset.mediaType,
       uri: asset.uri,

--- a/package/native-package/src/handlers/getPhotos.ts
+++ b/package/native-package/src/handlers/getPhotos.ts
@@ -78,8 +78,8 @@ export const getPhotos = async ({
       ...edge.node.image,
       duration: edge.node.image.playableDuration,
       // since we include filename, fileSize in the query, we can safely assume it will be defined
-      filename: edge.node.image.filename as string,
-      fileSize: edge.node.image.fileSize as number,
+      name: edge.node.image.filename as string,
+      size: edge.node.image.fileSize as number,
       source: 'picker' as const,
       type: edge.node.type,
     }));

--- a/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
@@ -71,15 +71,15 @@ const AttachmentVideo: React.FC<AttachmentVideoProps> = (props) => {
     const localAssetURI = Platform.OS === 'ios' && asset.id && (await getLocalAssetUri(asset.id));
     const uri = localAssetURI || asset.uri || '';
     // We need a mime-type to upload a video file.
-    const mimeType = lookup(asset.filename) || 'multipart/form-data';
+    const mimeType = lookup(asset.name) || 'multipart/form-data';
     return [
       ...files,
       {
         duration: durationLabel,
         id: asset.id,
         mimeType,
-        name: asset.filename,
-        size: asset.fileSize,
+        name: asset.name,
+        size: asset.size,
         uri,
       },
     ];

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -288,7 +288,7 @@ const MessageInputWithContext = <
     // Check if the file size of the image exceeds the threshold of 100MB
     if (
       imageToUpload &&
-      Number(imageToUpload.fileSize) / MEGA_BYTES_TO_BYTES > MAX_FILE_SIZE_TO_UPLOAD_IN_MB
+      Number(imageToUpload.size) / MEGA_BYTES_TO_BYTES > MAX_FILE_SIZE_TO_UPLOAD_IN_MB
     ) {
       Alert.alert(
         t(

--- a/package/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/package/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -39,12 +39,12 @@ describe('MessageInput', () => {
       selectedImages: [
         generateImageAttachment({
           file: { height: 100, uri: 'https://picsum.photos/200/300', width: 100 },
-          fileSize: 500000000,
+          size: 500000000,
           uri: 'https://picsum.photos/200/300',
         }),
         generateImageAttachment({
           file: { height: 100, uri: 'https://picsum.photos/200/300', width: 100 },
-          fileSize: 600000000,
+          size: 600000000,
           uri: 'https://picsum.photos/200/300',
         }),
       ],

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -641,7 +641,7 @@ export const MessageInputProvider = <
   };
 
   const mapImageUploadToAttachment = (image: ImageUpload) => {
-    const mime_type: string | boolean = lookup(image.file.filename as string);
+    const mime_type: string | boolean = lookup(image.file.name as string);
     return {
       fallback: image.file.name,
       image_url: image.url,
@@ -1006,7 +1006,7 @@ export const MessageInputProvider = <
             uri,
             width: file.width,
           }));
-      const filename = file.filename ?? uri.replace(/^(file:\/\/|content:\/\/)/, '');
+      const filename = file.name ?? uri.replace(/^(file:\/\/|content:\/\/)/, '');
       const contentType = lookup(filename) || 'multipart/form-data';
       if (value.doImageUploadRequest) {
         response = await value.doImageUploadRequest(file, channel);

--- a/package/src/types/types.ts
+++ b/package/src/types/types.ts
@@ -2,32 +2,28 @@ import type { ExtendableGenerics, LiteralStringForUnion } from 'stream-chat';
 
 export type Asset = {
   duration: number | null;
-  filename: string;
   height: number;
+  name: string;
   source: 'camera' | 'picker';
   type: string;
   uri: string;
   width: number;
-  fileSize?: number;
   id?: string;
-  size?: number | string;
+  size?: number;
 };
 
-export type FileAssetType = {
+export type File = {
   name: string;
+  duration?: string | null;
+  id?: string;
   mimeType?: string;
-  size?: number | string;
+  size?: number;
   // The uri should be of type `string`. But is `string|undefined` because the same type is used for the response from Stream's Attachment. This shall be fixed.
   uri?: string;
 };
 
-export type File = FileAssetType & {
-  duration?: string | null;
-  id?: string;
-};
-
 export type DefaultAttachmentType = UnknownType & {
-  file_size?: number | string;
+  file_size?: number;
   mime_type?: string;
   originalFile?: File;
 };


### PR DESCRIPTION
## 🎯 Goal

Currently, the key for file name and size are `filename` and `fileSize`. We change it to `name` and `size` so that it stays in line with the `Asset` type.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


