### PR TITLE
fix: image compress logic when uploading image while offline support is enabled

### DIFF
--- a/package/src/contexts/messageInputContext/__tests__/__snapshots__/sendMessage.test.tsx.snap
+++ b/package/src/contexts/messageInputContext/__tests__/__snapshots__/sendMessage.test.tsx.snap
@@ -7,7 +7,7 @@ Object {
       "fallback": undefined,
       "image_url": undefined,
       "mime_type": undefined,
-      "originalFile": Object {
+      "originalImage": Object {
         "uri": "http://www.jackblack.com/tenac_iousd.bmp",
       },
       "original_height": undefined,
@@ -106,7 +106,7 @@ Object {
       "fallback": undefined,
       "image_url": undefined,
       "mime_type": undefined,
-      "originalFile": Object {
+      "originalImage": Object {
         "uri": "http://www.jackblack.com/tenac_iousd.bmp",
       },
       "original_height": undefined,
@@ -117,7 +117,7 @@ Object {
       "fallback": undefined,
       "image_url": undefined,
       "mime_type": undefined,
-      "originalFile": Object {
+      "originalImage": Object {
         "uri": "http://www.jackblack.com/tenac_iousd.bmp",
       },
       "original_height": undefined,

--- a/package/src/types/types.ts
+++ b/package/src/types/types.ts
@@ -48,6 +48,7 @@ export type DefaultAttachmentType = UnknownType & {
   file_size?: number;
   mime_type?: string;
   originalFile?: File;
+  originalImage?: Partial<Asset>;
 };
 
 interface DefaultUserType extends UnknownType {

--- a/package/src/utils/compressImage.ts
+++ b/package/src/utils/compressImage.ts
@@ -1,0 +1,32 @@
+import { compressImage } from '../native';
+import type { Asset } from '../types/types';
+
+/**
+ * Function to compress and Image and return the compressed Image URI
+ * @param image
+ * @param compressImageQuality
+ * @returns string
+ */
+export const compressedImageURI = async (image: Partial<Asset>, compressImageQuality?: number) => {
+  const uri = image.uri || '';
+  /**
+   * We skip compression if:
+   * - the file is from the camera as that should already be compressed
+   * - the file has no height/width value to maintain for compression
+   * - the compressImageQuality number is not present or is 1 (meaning no compression)
+   */
+  const compressedUri = await (image.source === 'camera' ||
+  !image.height ||
+  !image.width ||
+  typeof compressImageQuality !== 'number' ||
+  compressImageQuality === 1
+    ? uri
+    : compressImage({
+        compressImageQuality,
+        height: image.height,
+        uri,
+        width: image.width,
+      }));
+
+  return compressedUri;
+};


### PR DESCRIPTION
## 🎯 Goal

Fixes #2327 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


