### PR TITLE
fix: update editing and quoted state within context correctly

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -1587,15 +1587,16 @@ const ChannelWithContext = <
       : client.updateMessage(updatedMessage);
 
   const setEditingState: MessagesContextValue<StreamChatGenerics>['setEditingState'] = (
-    message,
+    messageOrBoolean,
   ) => {
-    setEditing(message);
+    clearQuotedMessageState();
+    setEditing(messageOrBoolean);
   };
 
   const setQuotedMessageState: MessagesContextValue<StreamChatGenerics>['setQuotedMessageState'] = (
-    message,
+    messageOrBoolean,
   ) => {
-    setQuotedMessage(message);
+    setQuotedMessage(messageOrBoolean);
   };
 
   const clearEditingState: InputMessageInputContextValue<StreamChatGenerics>['clearEditingState'] =

--- a/package/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
+++ b/package/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
@@ -53,7 +53,7 @@ export const useCreateInputMessageInputContext = <
    */
   channelId?: string;
 }) => {
-  const editingExists = !!editing;
+  const editingDep = typeof editing === 'boolean' ? editing : editing?.id;
   const quotedMessageId = quotedMessage
     ? typeof quotedMessage === 'boolean'
       ? ''
@@ -103,14 +103,7 @@ export const useCreateInputMessageInputContext = <
       ShowThreadMessageInChannelButton,
       UploadProgressIndicator,
     }),
-    [
-      compressImageQuality,
-      channelId,
-      editingExists,
-      initialValue,
-      maxMessageLength,
-      quotedMessageId,
-    ],
+    [compressImageQuality, channelId, editingDep, initialValue, maxMessageLength, quotedMessageId],
   );
 
   return inputMessageInputContext;

--- a/package/src/contexts/messageInputContext/hooks/useCreateMessageInputContext.ts
+++ b/package/src/contexts/messageInputContext/hooks/useCreateMessageInputContext.ts
@@ -95,7 +95,7 @@ export const useCreateMessageInputContext = <
   UploadProgressIndicator,
 }: MessageInputContextValue<StreamChatGenerics> &
   Pick<ThreadContextValue<StreamChatGenerics>, 'thread'>) => {
-  const editingExists = !!editing;
+  const editingdep = typeof editing === 'boolean' ? editing : editing?.id;
   const fileUploadsValue = fileUploads
     .map(({ duration, paused, progress, state }) => `${state},${paused},${progress},${duration}`)
     .join();
@@ -198,7 +198,7 @@ export const useCreateMessageInputContext = <
     }),
     [
       cooldownEndsAt,
-      editingExists,
+      editingdep,
       fileUploadsValue,
       giphyActive,
       imageUploadsValue,

--- a/package/src/contexts/messagesContext/MessagesContext.tsx
+++ b/package/src/contexts/messagesContext/MessagesContext.tsx
@@ -234,8 +234,8 @@ export type MessagesContextValue<
    */
   ScrollToBottomButton: React.ComponentType<ScrollToBottomButtonProps>;
   sendReaction: (type: string, messageId: string) => Promise<void>;
-  setEditingState: (message: MessageType<StreamChatGenerics>) => void;
-  setQuotedMessageState: (message: MessageType<StreamChatGenerics>) => void;
+  setEditingState: (message: MessageType<StreamChatGenerics> | boolean) => void;
+  setQuotedMessageState: (message: MessageType<StreamChatGenerics> | boolean) => void;
   supportedReactions: ReactionData[];
   /**
    * UI component for TypingIndicator


### PR DESCRIPTION
## Fixes following issues

- Start editing a message, and without sending the message - try editing some other message. In that case you will see previous message not getting cleared from input box
- Same thing with combination of quoted reply and editing state as well. 
