### PR TITLE
fix: incorrect message list state when non recent messages are loaded

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -588,6 +588,24 @@ const ChannelWithContext = <
    */
   const [hasNoMoreRecentMessagesToLoad, setHasNoMoreRecentMessagesToLoad] = useState(true);
 
+  /**
+   * hasNoMoreRecentMessagesToLoad flag is tracked in ref so that
+   * functions can be passed to message list context without any change due to dependency
+   */
+  const hasNoMoreRecentMessagesToLoadRef = useRef(true);
+  hasNoMoreRecentMessagesToLoadRef.current = hasNoMoreRecentMessagesToLoad;
+
+  /**
+   * messages array is tracked in ref so that
+   * functions can be passed to message list context without any change due to dependency
+   */
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+
+  useEffect(() => {
+    hasNoMoreRecentMessagesToLoadRef.current = hasNoMoreRecentMessagesToLoad;
+  }, [hasNoMoreRecentMessagesToLoad]);
+
   const { setTargetedMessage, targetedMessage } = useTargetedMessage();
 
   /**
@@ -879,13 +897,14 @@ const ChannelWithContext = <
    * @param messageId If undefined, channel will be loaded at most recent message.
    */
   const loadChannelAroundMessage: ChannelContextValue<StreamChatGenerics>['loadChannelAroundMessage'] =
-    ({ messageId }) =>
+    ({ messageId: messageIdToLoadAround }) =>
       channelQueryCallRef.current(
         async () => {
-          setHasNoMoreRecentMessagesToLoad(false); // we are jumping to a message, hence we do not know for sure anymore if there are no more recent messages
           setLoading(true);
-          if (messageId) {
-            await channel.state.loadMessageIntoState(messageId);
+          if (messageIdToLoadAround) {
+            setHasNoMoreRecentMessagesToLoad(false); // we are jumping to a message, hence we do not know for sure anymore if there are no more recent messages
+            channel.state.setIsUpToDate(false);
+            await channel.state.loadMessageIntoState(messageIdToLoadAround);
           } else {
             await channel.state.loadMessageIntoState('latest');
             channel.state.setIsUpToDate(true);
@@ -893,8 +912,8 @@ const ChannelWithContext = <
           setLoading(false);
         },
         () => {
-          if (messageId) {
-            setTargetedMessage(messageId);
+          if (messageIdToLoadAround) {
+            setTargetedMessage(messageIdToLoadAround);
           }
         },
       );
@@ -1509,55 +1528,70 @@ const ChannelWithContext = <
     ),
   ).current;
 
-  const loadMore: PaginatedMessageListContextValue<StreamChatGenerics>['loadMore'] = async (
-    limit = 20,
-  ) => {
-    if (loadingMore || hasMore === false) {
-      return;
-    }
-    setLoadingMore(true);
-
-    if (!messages.length) {
-      return setLoadingMore(false);
-    }
-
-    const oldestMessage = messages && messages[0];
-
-    if (oldestMessage && oldestMessage.status !== MessageStatusTypes.RECEIVED) {
-      return setLoadingMore(false);
-    }
-
-    const oldestID = oldestMessage && oldestMessage.id;
-
-    try {
-      if (channel) {
-        const queryResponse = await channel.query({
-          messages: { id_lt: oldestID, limit },
-        });
-
-        const updatedHasMore = queryResponse.messages.length === limit;
-        loadMoreFinished(updatedHasMore, channel.state.messages);
+  /**
+   * This function loads more messages before the first message in current channel state.
+   */
+  const loadMore = useCallback<PaginatedMessageListContextValue<StreamChatGenerics>['loadMore']>(
+    async (limit = 20) => {
+      if (loadingMore || hasMore === false) {
+        return;
       }
-    } catch (err) {
-      if (err instanceof Error) {
-        setError(err);
-      } else {
-        setError(true);
-      }
-      setLoadingMore(false);
-      throw err;
-    }
-  };
+      setLoadingMore(true);
 
-  const loadMoreRecent: PaginatedMessageListContextValue<StreamChatGenerics>['loadMoreRecent'] =
+      const currentMessages = messagesRef.current;
+
+      if (!currentMessages.length) {
+        return setLoadingMore(false);
+      }
+
+      const oldestMessage = currentMessages && currentMessages[0];
+
+      if (oldestMessage && oldestMessage.status !== MessageStatusTypes.RECEIVED) {
+        return setLoadingMore(false);
+      }
+
+      const oldestID = oldestMessage && oldestMessage.id;
+
+      try {
+        if (channel) {
+          const queryResponse = await channel.query({
+            messages: { id_lt: oldestID, limit },
+          });
+
+          const updatedHasMore = queryResponse.messages.length === limit;
+          loadMoreFinished(updatedHasMore, channel.state.messages);
+        }
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err);
+        } else {
+          setError(true);
+        }
+        setLoadingMore(false);
+        throw err;
+      }
+    },
+    /*
+     * This function is passed to useCreatePaginatedMessageListContext
+     * Where the deps are [channelId, hasMore, loadingMoreRecent, loadingMore]
+     * and only those deps should be used here because of that
+     */
+    [channelId, hasMore, loadingMore],
+  );
+
+  /**
+   * This function loads more messages after the most recent message in current channel state.
+   */
+  const loadMoreRecent = useCallback<
+    PaginatedMessageListContextValue<StreamChatGenerics>['loadMoreRecent']
+  >(
     async (limit = 5) => {
       if (hasNoMoreRecentMessagesToLoad) {
         return;
       }
-
       setLoadingMoreRecent(true);
-
-      const recentMessage = messages[messages.length - 1];
+      const currentMessages = messagesRef.current;
+      const recentMessage = currentMessages[currentMessages.length - 1];
 
       if (recentMessage?.status !== MessageStatusTypes.RECEIVED) {
         setLoadingMoreRecent(false);
@@ -1566,14 +1600,14 @@ const ChannelWithContext = <
 
       try {
         if (channel) {
-          const state = await channel.query({
+          const queryResponse = await channel.query({
             messages: {
               id_gte: recentMessage.id,
               limit,
             },
             watch: true,
           });
-          setHasNoMoreRecentMessagesToLoad(state.messages.length < limit);
+          setHasNoMoreRecentMessagesToLoad(queryResponse.messages.length < limit);
           loadMoreRecentFinished(channel.state.messages);
         }
       } catch (err) {
@@ -1586,7 +1620,14 @@ const ChannelWithContext = <
         setLoadingMoreRecent(false);
         throw err;
       }
-    };
+    },
+    /*
+     * This function is passed to useCreatePaginatedMessageListContext
+     * Where the deps are [channelId, hasMore, loadingMoreRecent, loadingMore, hasNoMoreRecentMessagesToLoad]
+     * and and only those deps should be used here because of that
+     */
+    [channelId, hasNoMoreRecentMessagesToLoad],
+  );
 
   // hard limit to prevent you from scrolling faster than 1 page per 2 seconds
   const loadMoreRecentFinished = useRef(

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -589,22 +589,11 @@ const ChannelWithContext = <
   const [hasNoMoreRecentMessagesToLoad, setHasNoMoreRecentMessagesToLoad] = useState(true);
 
   /**
-   * hasNoMoreRecentMessagesToLoad flag is tracked in ref so that
-   * functions can be passed to message list context without any change due to dependency
-   */
-  const hasNoMoreRecentMessagesToLoadRef = useRef(true);
-  hasNoMoreRecentMessagesToLoadRef.current = hasNoMoreRecentMessagesToLoad;
-
-  /**
    * messages array is tracked in ref so that
    * functions can be passed to message list context without any change due to dependency
    */
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
-
-  useEffect(() => {
-    hasNoMoreRecentMessagesToLoadRef.current = hasNoMoreRecentMessagesToLoad;
-  }, [hasNoMoreRecentMessagesToLoad]);
 
   const { setTargetedMessage, targetedMessage } = useTargetedMessage();
 

--- a/package/src/components/Channel/hooks/useCreatePaginatedMessageListContext.ts
+++ b/package/src/components/Channel/hooks/useCreatePaginatedMessageListContext.ts
@@ -34,7 +34,14 @@ export const useCreatePaginatedMessageListContext = <
       setLoadingMore,
       setLoadingMoreRecent,
     }),
-    [channelId, hasMore, loadingMoreRecent, loadingMore, messagesStr],
+    [
+      channelId,
+      hasMore,
+      loadingMoreRecent,
+      loadingMore,
+      hasNoMoreRecentMessagesToLoad,
+      messagesStr,
+    ],
   );
 
   return paginatedMessagesContext;


### PR DESCRIPTION
## 🎯 Goal

When we would load the channel around a message ID the state was broken. This was mainly due to memoization misses. This PR also adds scroll drag event listening. This is particularly seen if the channel is loaded around a message.

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


