### PR TITLE
refactor: width and height passed to ImageResizer were reversed

### DIFF
--- a/package/native-package/src/handlers/compressImage.ts
+++ b/package/native-package/src/handlers/compressImage.ts
@@ -17,8 +17,8 @@ export const compressImage = async ({
   try {
     const { uri: compressedUri } = await ImageResizer.createResizedImage(
       uri,
-      height,
       width,
+      height,
       'JPEG',
       Math.min(Math.max(0, compressImageQuality), 1) * 100,
       0,


### PR DESCRIPTION
At least based on the latest documentation, the width should come before height: https://github.com/bamlab/react-native-image-resizer?tab=readme-ov-file#usage-example

## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


