### PR TITLE
fix: myMessageTheme prop change did not cause a rerender

### DIFF
--- a/docusaurus/docs/reactnative/common-content/core-components/channel/props/my_message_theme.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/channel/props/my_message_theme.mdx
@@ -1,4 +1,4 @@
-[Theme](/reactnative/customization/theming/) applied to messages of the current user. 
+[Theme](/reactnative/customization/theming/) applied to messages of the current user.
 
 | Type   |
 | ------ |

--- a/docusaurus/docs/reactnative/common-content/core-components/channel/props/my_message_theme.mdx
+++ b/docusaurus/docs/reactnative/common-content/core-components/channel/props/my_message_theme.mdx
@@ -1,5 +1,9 @@
-[Theme](/reactnative/customization/theming/) applied to messages of the current user.
+[Theme](/reactnative/customization/theming/) applied to messages of the current user. 
 
 | Type   |
 | ------ |
 | object |
+
+:::caution
+Please make sure to memoize or pass static reference for this object.
+:::

--- a/package/src/components/Channel/hooks/useCreateMessagesContext.ts
+++ b/package/src/components/Channel/hooks/useCreateMessagesContext.ts
@@ -194,6 +194,7 @@ export const useCreateMessagesContext = <
       markdownRulesLength,
       messageContentOrderValue,
       supportedReactionsLength,
+      myMessageTheme,
       targetedMessage,
     ],
   );

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -297,9 +297,11 @@ const MessageListWithContext = <
     screenPadding,
   } = theme;
 
+  const myMessageThemeString = useMemo(() => JSON.stringify(myMessageTheme), [myMessageTheme]);
+
   const modifiedTheme = useMemo(
     () => mergeThemes({ style: myMessageTheme, theme }),
-    [myMessageTheme, theme],
+    [myMessageThemeString, theme],
   );
 
   /**

--- a/package/src/components/MessageOverlay/MessageOverlay.tsx
+++ b/package/src/components/MessageOverlay/MessageOverlay.tsx
@@ -160,14 +160,9 @@ const MessageOverlayWithContext = <
   const myMessageTheme = messagesContext?.myMessageTheme;
   const wrapMessageInTheme = clientId === message?.user?.id && !!myMessageTheme;
 
-  const [myMessageThemeString, setMyMessageThemeString] = useState(JSON.stringify(myMessageTheme));
   const [reactionListHeight, setReactionListHeight] = useState(0);
 
-  useEffect(() => {
-    if (myMessageTheme) {
-      setMyMessageThemeString(JSON.stringify(myMessageTheme));
-    }
-  }, [myMessageTheme]);
+  const myMessageThemeString = useMemo(() => JSON.stringify(myMessageTheme), [myMessageTheme]);
 
   const modifiedTheme = useMemo(
     () => mergeThemes({ style: myMessageTheme, theme }),


### PR DESCRIPTION
## 🎯 Goal

myMessageTheme prop was not used in memoisation and so changing it did not cause a rerender

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


