### PR TITLE
fix: parsing links from message text having links in markdown format

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/parseLinks.test.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.test.ts
@@ -27,6 +27,8 @@ describe('parseLinksFromText', () => {
       'https://help.apple.com/xcode/mac/current/#/devba7f53ad4',
       'https://help.apple.com/xcode/mac/current/#/devba7f53ad4',
     ],
+    ['[google.com](https://www.google.com)', undefined],
+    ['[https://www.google.com](https://www.google.com)', undefined],
   ])('Returns the encoded value of %p as %p', (link, expected) => {
     const result = parseLinksFromText(link);
     expect(result[0]?.url).toBe(expected);

--- a/package/src/components/Message/MessageSimple/utils/parseLinks.test.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.test.ts
@@ -29,6 +29,8 @@ describe('parseLinksFromText', () => {
     ],
     ['[google.com](https://www.google.com)', undefined],
     ['[https://www.google.com](https://www.google.com)', undefined],
+    ['[abc]()', undefined],
+    ['[](https://www.google.com)', undefined],
   ])('Returns the encoded value of %p as %p', (link, expected) => {
     const result = parseLinksFromText(link);
     expect(result[0]?.url).toBe(expected);

--- a/package/src/components/Message/MessageSimple/utils/parseLinks.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.ts
@@ -6,7 +6,7 @@ interface LinkInfo {
 }
 
 /**
- * This is done to avoid parsing section with text []() in message texts.
+ * This is done to remove all markdown formatted links.
  * eg: [google.com](https://www.google.com), [Google](https://www.google.com), [https://www.google.com](https://www.google.com)
  * */
 const removeMarkdownLinksFromText = (input: string) => input.replace(/\[.*\]\(.*\)/g, '');

--- a/package/src/components/Message/MessageSimple/utils/parseLinks.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.ts
@@ -9,7 +9,7 @@ interface LinkInfo {
  * This is done to avoid parsing section with text []() in message texts.
  * eg: [google.com](https://www.google.com), [Google](https://www.google.com), [https://www.google.com](https://www.google.com)
  * */
-const removeMarkdownLinksFromText = (input: string) => input.replace(/\[.+\]\(.*\)/g, '');
+const removeMarkdownLinksFromText = (input: string) => input.replace(/\[.*\]\(.*\)/g, '');
 
 /**
  * This is done to avoid parsing usernames with dot as well as an email address in it.

--- a/package/src/components/Message/MessageSimple/utils/parseLinks.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.ts
@@ -6,10 +6,10 @@ interface LinkInfo {
 }
 
 /**
- * This is done separately because of the version of javascript run
- * for expo
+ * This is done to avoid parsing section with text []() in message texts.
+ * eg: [google.com](https://www.google.com), [Google](https://www.google.com), [https://www.google.com](https://www.google.com)
  * */
-const removeMarkdownLinksFromText = (input: string) => input.replace(/\[[\w\s]+\]\(.*\)/g, '');
+const removeMarkdownLinksFromText = (input: string) => input.replace(/\[.+\]\(.*\)/g, '');
 
 /**
  * This is done to avoid parsing usernames with dot as well as an email address in it.


### PR DESCRIPTION
## 🎯 Goal

Previously, special characters inside [] where not taken into account while parsing links from message text. This PR tends to fix the issue by changing the regex.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


