### PR TITLE
fix: keyboard transition issue when switching from attachment picker to keyboard

### DIFF
--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -181,8 +181,14 @@ export const AttachmentPicker = React.forwardRef(
     }, [selectedPicker, closePicker]);
 
     useEffect(() => {
+      const onKeyboardOpenHandler = () => {
+        if (selectedPicker) {
+          setSelectedPicker(undefined);
+        }
+        closePicker();
+      };
       const keyboardShowEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
-      const keyboardSubscription = Keyboard.addListener(keyboardShowEvent, closePicker);
+      const keyboardSubscription = Keyboard.addListener(keyboardShowEvent, onKeyboardOpenHandler);
 
       return () => {
         if (keyboardSubscription?.remove) {
@@ -193,7 +199,7 @@ export const AttachmentPicker = React.forwardRef(
         // To keep compatibility with older versions of React Native, where `remove()` is not available
         Keyboard.removeListener(keyboardShowEvent, closePicker);
       };
-    }, [closePicker]);
+    }, [closePicker, selectedPicker]);
 
     useEffect(() => {
       if (currentIndex < 0) {

--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -197,7 +197,7 @@ export const AttachmentPicker = React.forwardRef(
         }
 
         // To keep compatibility with older versions of React Native, where `remove()` is not available
-        Keyboard.removeListener(keyboardShowEvent, closePicker);
+        Keyboard.removeListener(keyboardShowEvent, onKeyboardOpenHandler);
       };
     }, [closePicker, selectedPicker]);
 


### PR DESCRIPTION
## 🎯 Goal

Fixes #2024 

Before:

https://github.com/GetStream/stream-chat-react-native/assets/39884168/4215f48d-126c-4a60-ae06-533a64cbbc78

After:

https://github.com/GetStream/stream-chat-react-native/assets/39884168/bb7540a8-a854-4e9e-9d70-c6ed877395cc

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


