### PR TITLE
feat: Moderation: show Blocked messages in SDK

### DIFF
--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -44,7 +44,7 @@ import {
 
 import { isVideoPackageAvailable, triggerHaptic } from '../../native';
 import type { DefaultStreamChatGenerics } from '../../types/types';
-import { hasOnlyEmojis, MessageStatusTypes } from '../../utils/utils';
+import { hasOnlyEmojis, isBlockedMessage, MessageStatusTypes } from '../../utils/utils';
 
 import {
   isMessageWithStylesReadByAndDateSeparator,
@@ -319,6 +319,9 @@ const MessageWithContext = <
     }
     const quotedMessage = message.quoted_message as MessageType<StreamChatGenerics>;
     if (error) {
+      if (isBlockedMessage(message)) {
+        return;
+      }
       showMessageOverlay(false, true);
     } else if (quotedMessage) {
       onPressQuotedMessage(quotedMessage);
@@ -598,7 +601,7 @@ const MessageWithContext = <
   };
 
   const onLongPressMessage =
-    disabled || hasAttachmentActions
+    disabled || hasAttachmentActions || isBlockedMessage(message)
       ? () => null
       : onLongPressMessageProp
       ? (payload?: TouchableHandlerPayload) =>

--- a/package/src/components/Message/MessageSimple/MessageStatus.tsx
+++ b/package/src/components/Message/MessageSimple/MessageStatus.tsx
@@ -48,7 +48,7 @@ const MessageStatusWithContext = <
     },
   } = useTheme();
 
-  if (message.status === MessageStatusTypes.SENDING) {
+  if (message.status === MessageStatusTypes.SENDING || message.type === 'error') {
     return (
       <View style={[styles.statusContainer, statusContainer]} testID='sending-container'>
         <Time {...timeIcon} />

--- a/package/src/components/Message/MessageSimple/MessageStatus.tsx
+++ b/package/src/components/Message/MessageSimple/MessageStatus.tsx
@@ -48,7 +48,7 @@ const MessageStatusWithContext = <
     },
   } = useTheme();
 
-  if (message.status === MessageStatusTypes.SENDING || message.type === 'error') {
+  if (message.status === MessageStatusTypes.SENDING) {
     return (
       <View style={[styles.statusContainer, statusContainer]} testID='sending-container'>
         <Time {...timeIcon} />
@@ -69,11 +69,13 @@ const MessageStatusWithContext = <
             {message.readBy}
           </Text>
         ) : null}
-        {typeof message.readBy === 'number' || message.readBy === true ? (
-          <CheckAll pathFill={accent_blue} {...checkAllIcon} />
-        ) : (
-          <Check pathFill={grey_dark} {...checkIcon} />
-        )}
+        {message.type !== 'error' ? (
+          typeof message.readBy === 'number' || message.readBy === true ? (
+            <CheckAll pathFill={accent_blue} {...checkAllIcon} />
+          ) : (
+            <Check pathFill={grey_dark} {...checkIcon} />
+          )
+        ) : null}
       </View>
     );
   }

--- a/package/src/store/apis/getChannelMessages.ts
+++ b/package/src/store/apis/getChannelMessages.ts
@@ -5,6 +5,7 @@ import { selectMessagesForChannels } from './queries/selectMessagesForChannels';
 import { selectReactionsForMessages } from './queries/selectReactionsForMessages';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
+import { isBlockedMessage } from '../../utils/utils';
 import { mapStorableToMessage } from '../mappers/mapStorableToMessage';
 import type { TableRowJoinedUser } from '../types';
 
@@ -37,13 +38,15 @@ export const getChannelMessages = <
       cidVsMessages[m.cid] = [];
     }
 
-    cidVsMessages[m.cid].push(
-      mapStorableToMessage<StreamChatGenerics>({
-        currentUserId,
-        messageRow: m,
-        reactionRows: messageIdVsReactions[m.id],
-      }),
-    );
+    if (!isBlockedMessage(m)) {
+      cidVsMessages[m.cid].push(
+        mapStorableToMessage<StreamChatGenerics>({
+          currentUserId,
+          messageRow: m,
+          reactionRows: messageIdVsReactions[m.id],
+        }),
+      );
+    }
   });
 
   return cidVsMessages;

--- a/package/src/utils/utils.ts
+++ b/package/src/utils/utils.ts
@@ -13,6 +13,7 @@ import type {
   UserResponse,
 } from 'stream-chat';
 
+import type { MessageType } from '../components/MessageList/hooks/useMessageList';
 import type { MentionAllAppUsersQuery } from '../contexts/messageInputContext/MessageInputContext';
 import type {
   SuggestionCommand,
@@ -21,6 +22,7 @@ import type {
 } from '../contexts/suggestionsContext/SuggestionsContext';
 import { compiledEmojis, Emoji } from '../emoji-data/compiled';
 import type { IconProps } from '../icons/utils/base';
+import type { TableRowJoinedUser } from '../store/types';
 import type { DefaultStreamChatGenerics, ValueOf } from '../types/types';
 
 export type ReactionData = {
@@ -80,6 +82,16 @@ export const getIndicatorTypeForFileState = (
   };
 
   return indicatorMap[fileState];
+};
+
+export const isBlockedMessage = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+>(
+  message: MessageType<StreamChatGenerics> | TableRowJoinedUser<'messages'>,
+) => {
+  // The only indicator for the blocked message is its message type is error and that the message text contains "Message was blocked by moderation policies".
+  const pattern = /\bMessage was blocked by moderation policies\b/;
+  return message.type === 'error' && message.text && pattern.test(message.text);
 };
 
 const defaultAutoCompleteSuggestionsLimit = 10;


### PR DESCRIPTION
## 🎯 Goal

The Goal of the PR is to show blocked messages in the MessageList UI. This is a feature part of moderation.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The blocked messages are represented by message type as error and the message text having `Message was blocked by moderation policies`.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

https://github.com/GetStream/stream-chat-react-native/assets/39884168/a18d2aa2-9a97-4a05-a1d2-5ba1e9be78aa


## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


