### PR TITLE
fix: outdated unread count on offline support

### DIFF
--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -168,7 +168,7 @@ export const usePaginatedChannels = <
     await queryChannels('refresh');
   };
 
-  const reloadList = () => queryChannels('reload');
+  const reloadList = async () => { await queryChannels('reload'); }
 
   /**
    * Equality check using stringified filters/sort ensure that we don't make un-necessary queryChannels api calls
@@ -222,7 +222,8 @@ export const usePaginatedChannels = <
       listener = DBSyncManager.onSyncStatusChange((syncStatus) => {
         if (syncStatus) {
           loadOfflineChannels();
-          reloadList();
+          await reloadList();
+          setForceUpdate((u) => u + 1);
         }
       });
       // On start, load the channels from local db.

--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -168,7 +168,9 @@ export const usePaginatedChannels = <
     await queryChannels('refresh');
   };
 
-  const reloadList = async () => { await queryChannels('reload'); }
+  const reloadList = async () => {
+    await queryChannels('reload');
+  };
 
   /**
    * Equality check using stringified filters/sort ensure that we don't make un-necessary queryChannels api calls
@@ -219,7 +221,7 @@ export const usePaginatedChannels = <
     if (enableOfflineSupport) {
       // Any time DB is synced, we need to update the UI with local DB channels first,
       // and then call queryChannels to ensure any new channels are added to UI.
-      listener = DBSyncManager.onSyncStatusChange((syncStatus) => {
+      listener = DBSyncManager.onSyncStatusChange(async (syncStatus) => {
         if (syncStatus) {
           loadOfflineChannels();
           await reloadList();

--- a/package/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreview.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
+import { Platform } from 'react-native';
+
 import type { Channel, ChannelState, Event, MessageResponse } from 'stream-chat';
 
 import { useLatestMessagePreview } from './hooks/useLatestMessagePreview';
@@ -16,7 +18,7 @@ import type { DefaultStreamChatGenerics } from '../../types/types';
 export type ChannelPreviewPropsWithContext<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 > = Pick<ChatContextValue<StreamChatGenerics>, 'client'> &
-  Pick<ChannelsContextValue<StreamChatGenerics>, 'Preview'> & {
+  Pick<ChannelsContextValue<StreamChatGenerics>, 'Preview' | 'forceUpdate'> & {
     /**
      * The previewed channel
      */
@@ -32,7 +34,7 @@ const ChannelPreviewWithContext = <
 >(
   props: ChannelPreviewPropsWithContext<StreamChatGenerics>,
 ) => {
-  const { channel, client, Preview } = props;
+  const { channel, client, forceUpdate: channelListForceUpdate, Preview } = props;
 
   const [lastMessage, setLastMessage] = useState<
     | ReturnType<ChannelState<StreamChatGenerics>['formatMessage']>
@@ -70,7 +72,7 @@ const ChannelPreviewWithContext = <
 
     const newUnreadCount = channel.countUnread();
     setUnread(newUnreadCount);
-  }, [channelLastMessageString]);
+  }, [channelLastMessageString, channelListForceUpdate]);
 
   useEffect(() => {
     const handleNewMessageEvent = (event: Event<StreamChatGenerics>) => {
@@ -126,7 +128,11 @@ export const ChannelPreview = <
   props: ChannelPreviewProps<StreamChatGenerics>,
 ) => {
   const { client } = useChatContext<StreamChatGenerics>();
-  const { Preview } = useChannelsContext<StreamChatGenerics>();
+  const { forceUpdate, Preview } = useChannelsContext<StreamChatGenerics>();
 
-  return <ChannelPreviewWithContext {...{ client, Preview }} {...props} />;
+  if (Platform.OS === 'ios') {
+    // console.log({ forceUpdate });
+  }
+
+  return <ChannelPreviewWithContext {...{ client, forceUpdate, Preview }} {...props} />;
 };

--- a/package/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreview.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from 'react';
 
-import { Platform } from 'react-native';
-
 import type { Channel, ChannelState, Event, MessageResponse } from 'stream-chat';
 
 import { useLatestMessagePreview } from './hooks/useLatestMessagePreview';
@@ -129,10 +127,6 @@ export const ChannelPreview = <
 ) => {
   const { client } = useChatContext<StreamChatGenerics>();
   const { forceUpdate, Preview } = useChannelsContext<StreamChatGenerics>();
-
-  if (Platform.OS === 'ios') {
-    // console.log({ forceUpdate });
-  }
 
   return <ChannelPreviewWithContext {...{ client, forceUpdate, Preview }} {...props} />;
 };


### PR DESCRIPTION
## 🎯 Goal

fixes #2377 #1996

Fixes a race condition between unread count update and channel query update while being on offline support

the issue is that channel preview does not update after query channels on offline support.. and this force update causes it to

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


