### PR TITLE
feat: add a way to  insert a custom field into a message through message input context

### DIFF
--- a/package/src/components/MessageInput/SendButton.tsx
+++ b/package/src/components/MessageInput/SendButton.tsx
@@ -35,7 +35,7 @@ const SendButtonWithContext = <
   return (
     <Pressable
       disabled={disabled}
-      onPress={disabled ? () => null : sendMessage}
+      onPress={disabled ? () => null : () => sendMessage(undefined)}
       style={[sendButton]}
       testID='send-button'
     >

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -8,6 +8,7 @@ import { lookup } from 'mime-types';
 import {
   Attachment,
   logChatPromiseExecution,
+  Message,
   SendFileAPIResponse,
   StreamChat,
   Message as StreamMessage,
@@ -159,7 +160,7 @@ export type LocalMessageInputContext<
   resetInput: (pendingAttachments?: Attachment<StreamChatGenerics>[]) => void;
   selectedPicker: string | undefined;
   sending: React.MutableRefObject<boolean>;
-  sendMessage: () => Promise<void>;
+  sendMessage: (customMessageData?: Partial<Message<StreamChatGenerics>>) => Promise<void>;
   sendMessageAsync: (id: string) => void;
   sendThreadMessageInChannel: boolean;
   setAsyncIds: React.Dispatch<React.SetStateAction<string[]>>;
@@ -696,7 +697,7 @@ export const MessageInputProvider = <
 
   // TODO: Figure out why this is async, as it doesn't await any promise.
   // eslint-disable-next-line require-await
-  const sendMessage = async () => {
+  const sendMessage = async (customMessageData?: Message<StreamChatGenerics>) => {
     if (sending.current) {
       return;
     }
@@ -790,6 +791,7 @@ export const MessageInputProvider = <
         mentioned_users: mentionedUsers,
         quoted_message: undefined,
         text: prevText,
+        ...customMessageData,
       } as Parameters<StreamChat<StreamChatGenerics>['updateMessage']>[0];
 
       // TODO: Remove this line and show an error when submit fails
@@ -822,6 +824,7 @@ export const MessageInputProvider = <
             typeof value.quotedMessage === 'boolean' ? undefined : value.quotedMessage.id,
           show_in_channel: sendThreadMessageInChannel || undefined,
           text: prevText,
+          ...customMessageData,
         } as unknown as StreamMessage<StreamChatGenerics>);
 
         value.clearQuotedMessageState();

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -697,7 +697,7 @@ export const MessageInputProvider = <
 
   // TODO: Figure out why this is async, as it doesn't await any promise.
   // eslint-disable-next-line require-await
-  const sendMessage = async (customMessageData?: Message<StreamChatGenerics>) => {
+  const sendMessage = async (customMessageData?: Partial<Message<StreamChatGenerics>>) => {
     if (sending.current) {
       return;
     }


### PR DESCRIPTION
## 🎯 Goal

fixes #2316 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


