### PR TITLE
fix: undefined thumb_url when image grid opens in image gallery

### DIFF
--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -272,7 +272,7 @@ export const ImageGallery = <
               !attachment.title_link &&
               !attachment.og_scrape_url &&
               getUrlOfImageAttachment(attachment)) ||
-            (isVideoPackageAvailable() && attachment.type === 'video'),
+            ((isVideoPackageAvailable() && attachment.type) === 'video' && attachment.thumb_url),
         )
         .reverse() || [];
 
@@ -292,6 +292,7 @@ export const ImageGallery = <
         original_width: a.original_width,
         paused: isInitiallyPaused,
         progress: 0,
+        thumb_url: a.thumb_url,
         type: a.type,
         uri:
           a.type === 'giphy'
@@ -728,6 +729,7 @@ export type Photo<
   original_width?: number;
   paused?: boolean;
   progress?: number;
+  thumb_url?: string;
   type?: string;
   user?: UserResponse<StreamChatGenerics> | null;
   user_id?: string;

--- a/package/src/components/ImageGallery/components/ImageGrid.tsx
+++ b/package/src/components/ImageGallery/components/ImageGrid.tsx
@@ -74,7 +74,7 @@ const GridImage = <
   const { vw } = useViewport();
   const { imageComponent, ...restItem } = item;
 
-  const { numberOfImageGalleryGridColumns, selectAndClose, type, uri } = restItem;
+  const { numberOfImageGalleryGridColumns, selectAndClose, thumb_url, type, uri } = restItem;
 
   const size = vw(100) / (numberOfImageGalleryGridColumns || 3) - 2;
 
@@ -86,7 +86,7 @@ const GridImage = <
     <TouchableOpacity accessibilityLabel='Grid Image' onPress={selectAndClose}>
       {type === 'video' ? (
         <View style={[styles.image, { height: size, width: size }, gridImage]}>
-          <VideoThumbnail />
+          <VideoThumbnail thumb_url={thumb_url} />
         </View>
       ) : (
         <Image source={{ uri }} style={[styles.image, { height: size, width: size }]} />


### PR DESCRIPTION
## 🎯 Goal

The goal of the PR is to fix the undefined thumb_url when image grid is opened in image gallery.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


