### PR TITLE
refactor: add back channel prop to ChannelPreviewTitle and ChannelPreviewUnreadCount

### DIFF
--- a/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
@@ -165,10 +165,10 @@ const ChannelPreviewMessengerWithContext = <
         testID={`channel-preview-content-${channel.id}`}
       >
         <View style={[styles.row, row]}>
-          <PreviewTitle displayName={displayName} />
+          <PreviewTitle channel={channel} displayName={displayName} />
           <View style={[styles.statusContainer, row]}>
             {isChannelMuted && <PreviewMutedStatus />}
-            <PreviewUnreadCount maxUnreadCount={maxUnreadCount} unread={unread} />
+            <PreviewUnreadCount channel={channel} maxUnreadCount={maxUnreadCount} unread={unread} />
           </View>
         </View>
         <View style={[styles.row, row]}>

--- a/package/src/components/ChannelPreview/ChannelPreviewTitle.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewTitle.tsx
@@ -1,20 +1,29 @@
 import React from 'react';
 import { StyleSheet, Text } from 'react-native';
 
+import type { ChannelPreviewProps } from './ChannelPreview';
+
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
+import type { DefaultStreamChatGenerics } from '../../types/types';
 
 const styles = StyleSheet.create({
   title: { fontSize: 14, fontWeight: '700' },
 });
 
-export type ChannelPreviewTitleProps = {
+export type ChannelPreviewTitleProps<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+> = Pick<ChannelPreviewProps<StreamChatGenerics>, 'channel'> & {
   /**
    * Formatted name for the previewed channel.
    */
   displayName: string;
 };
 
-export const ChannelPreviewTitle = (props: ChannelPreviewTitleProps) => {
+export const ChannelPreviewTitle = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+>(
+  props: ChannelPreviewTitleProps<StreamChatGenerics>,
+) => {
   const { displayName } = props;
   const {
     theme: {

--- a/package/src/components/ChannelPreview/ChannelPreviewUnreadCount.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewUnreadCount.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { ChannelPreviewProps } from './ChannelPreview';
+
 import type { ChannelsContextValue } from '../../contexts/channelsContext/ChannelsContext';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 
@@ -8,12 +10,13 @@ import type { DefaultStreamChatGenerics } from '../../types/types';
 
 export type ChannelPreviewUnreadCountProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
-> = Pick<ChannelsContextValue<StreamChatGenerics>, 'maxUnreadCount'> & {
-  /**
-   * Number of unread messages on the channel
-   */
-  unread?: number;
-};
+> = Pick<ChannelsContextValue<StreamChatGenerics>, 'maxUnreadCount'> &
+  Pick<ChannelPreviewProps<StreamChatGenerics>, 'channel'> & {
+    /**
+     * Number of unread messages on the channel
+     */
+    unread?: number;
+  };
 
 export const ChannelPreviewUnreadCount = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,

--- a/package/src/contexts/channelsContext/ChannelsContext.tsx
+++ b/package/src/contexts/channelsContext/ChannelsContext.tsx
@@ -199,7 +199,7 @@ export type ChannelsContextValue<
    *
    * **Default** [ChannelPreviewTitle](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/ChannelPreview/ChannelPreviewTitle.tsx)
    */
-  PreviewTitle?: React.ComponentType<ChannelPreviewTitleProps>;
+  PreviewTitle?: React.ComponentType<ChannelPreviewTitleProps<StreamChatGenerics>>;
   /**
    * Custom UI component to render preview avatar.
    *


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


