### PR TITLE
feat: add optional logging for sqlite methods

### DIFF
--- a/examples/TypeScriptMessaging/App.tsx
+++ b/examples/TypeScriptMessaging/App.tsx
@@ -13,6 +13,7 @@ import {
   MessageInput,
   MessageList,
   OverlayProvider,
+  QuickSqliteClient,
   Streami18n,
   Thread,
   ThreadContextValue,
@@ -52,6 +53,10 @@ const options = {
 };
 
 I18nManager.forceRTL(false);
+
+QuickSqliteClient.logger = (level, message, extraData) => {
+  console.log(level, `QuickSqliteClient: ${message}`, extraData);
+};
 
 const chatClient = StreamChat.getInstance<StreamChatGenerics>('q95x9hkbyd6p');
 const userToken =

--- a/package/src/store/apis/addPendingTask.ts
+++ b/package/src/store/apis/addPendingTask.ts
@@ -4,14 +4,33 @@ import { createDeleteQuery } from '../sqlite-utils/createDeleteQuery';
 import { createUpsertQuery } from '../sqlite-utils/createUpsertQuery';
 import type { PendingTask } from '../types';
 
+/*
+ * addPendingTask - Adds a pending task to the database
+ *
+ * @param {PendingTask} task - The task to add
+ *
+ * @return {() => void} - A function that can be called to remove the task from the database
+ */
 export const addPendingTask = (task: PendingTask) => {
   const storable = mapTaskToStorable(task);
+  const { channelId, channelType, payload, type } = storable;
   const query = createUpsertQuery('pendingTasks', storable);
+  QuickSqliteClient.logger?.('info', 'addPendingTask', {
+    channelId,
+    channelType,
+    id: task.id,
+    type,
+  });
 
   QuickSqliteClient.executeSql.apply(null, query);
 
   return () => {
-    const { channelId, channelType, payload, type } = storable;
+    QuickSqliteClient.logger?.('info', 'deletePendingTaskAfterAddition', {
+      channelId,
+      channelType,
+      id: task.id,
+      type,
+    });
     const query = createDeleteQuery('pendingTasks', {
       channelId,
       channelType,

--- a/package/src/store/apis/deleteChannel.ts
+++ b/package/src/store/apis/deleteChannel.ts
@@ -6,6 +6,11 @@ export const deleteChannel = ({ cid, flush = true }: { cid: string; flush?: bool
     cid,
   });
 
+  QuickSqliteClient.logger?.('info', 'deleteChannel', {
+    cid,
+    flush,
+  });
+
   if (flush) {
     QuickSqliteClient.executeSql.apply(null, query);
   }

--- a/package/src/store/apis/deleteMember.ts
+++ b/package/src/store/apis/deleteMember.ts
@@ -17,6 +17,12 @@ export const deleteMember = ({
     userId: member.user_id,
   });
 
+  QuickSqliteClient.logger?.('info', 'deleteMember', {
+    cid,
+    flush,
+    userId: member.user_id,
+  });
+
   if (flush) {
     QuickSqliteClient.executeSql.apply(null, query);
   }

--- a/package/src/store/apis/deleteMessage.ts
+++ b/package/src/store/apis/deleteMessage.ts
@@ -5,6 +5,12 @@ export const deleteMessage = ({ flush = true, id }: { id: string; flush?: boolea
   const query = createDeleteQuery('messages', {
     id,
   });
+
+  QuickSqliteClient.logger?.('info', 'deleteMessage', {
+    flush,
+    id,
+  });
+
   if (flush) {
     QuickSqliteClient.executeSql.apply(null, query);
   }

--- a/package/src/store/apis/deleteMessagesForChannel.ts
+++ b/package/src/store/apis/deleteMessagesForChannel.ts
@@ -11,6 +11,12 @@ export const deleteMessagesForChannel = ({
   const query = createDeleteQuery('messages', {
     cid,
   });
+
+  QuickSqliteClient.logger?.('info', 'deleteMessagesForChannel', {
+    cid,
+    flush,
+  });
+
   if (flush) {
     QuickSqliteClient.executeSql.apply(null, query);
   }

--- a/package/src/store/apis/deletePendingTask.ts
+++ b/package/src/store/apis/deletePendingTask.ts
@@ -6,6 +6,10 @@ export const deletePendingTask = ({ id }: { id: number }) => {
     id,
   });
 
+  QuickSqliteClient.logger?.('info', 'deletePendingTask', {
+    id,
+  });
+
   QuickSqliteClient.executeSql.apply(null, query);
 
   return [query];

--- a/package/src/store/apis/deleteReaction.ts
+++ b/package/src/store/apis/deleteReaction.ts
@@ -18,6 +18,12 @@ export const deleteReaction = ({
     userId,
   });
 
+  QuickSqliteClient.logger?.('info', 'deleteReaction', {
+    messageId,
+    type: reactionType,
+    userId,
+  });
+
   if (flush) {
     QuickSqliteClient.executeSql.apply(null, query);
   }

--- a/package/src/store/apis/deleteReactions.ts
+++ b/package/src/store/apis/deleteReactions.ts
@@ -11,13 +11,12 @@ export const deleteReactionsForMessage = ({
   const query = createDeleteQuery('reactions', {
     messageId,
   });
+  console.log('deleteReactionsForMessage', {
+    flush,
+    messageId,
+  });
   if (flush) {
-    QuickSqliteClient.executeSql.apply(
-      null,
-      createDeleteQuery('reactions', {
-        messageId,
-      }),
-    );
+    QuickSqliteClient.executeSql.apply(null, query);
   }
 
   return [query];

--- a/package/src/store/apis/getAllChannelIds.ts
+++ b/package/src/store/apis/getAllChannelIds.ts
@@ -1,7 +1,10 @@
 import { selectChannels } from './queries/selectChannels';
 
+import { QuickSqliteClient } from '../QuickSqliteClient';
+
 export const getAllChannelIds = () => {
   const channels = selectChannels();
 
+  QuickSqliteClient.logger?.('info', 'getAllChannelIds');
   return channels.map((c) => c.cid);
 };

--- a/package/src/store/apis/getAppSettings.ts
+++ b/package/src/store/apis/getAppSettings.ts
@@ -8,6 +8,9 @@ export const getAppSettings = ({
 }: {
   currentUserId: string;
 }): AppSettingsAPIResponse => {
+  QuickSqliteClient.logger?.('info', 'getAppSettings', {
+    currentUserId,
+  });
   const result = QuickSqliteClient.executeSql.apply(
     null,
     createSelectQuery('userSyncStatus', ['*'], {

--- a/package/src/store/apis/getChannelMessages.ts
+++ b/package/src/store/apis/getChannelMessages.ts
@@ -7,6 +7,7 @@ import { selectReactionsForMessages } from './queries/selectReactionsForMessages
 import type { DefaultStreamChatGenerics } from '../../types/types';
 import { isBlockedMessage } from '../../utils/utils';
 import { mapStorableToMessage } from '../mappers/mapStorableToMessage';
+import { QuickSqliteClient } from '../QuickSqliteClient';
 import type { TableRowJoinedUser } from '../types';
 
 export const getChannelMessages = <
@@ -18,6 +19,10 @@ export const getChannelMessages = <
   channelIds: string[];
   currentUserId: string;
 }) => {
+  QuickSqliteClient.logger?.('info', 'getChannelMessages', {
+    channelIds,
+    currentUserId,
+  });
   const messageRows = selectMessagesForChannels(channelIds);
   const messageIds = messageRows.map(({ id }) => id);
 

--- a/package/src/store/apis/getChannels.ts
+++ b/package/src/store/apis/getChannels.ts
@@ -7,6 +7,7 @@ import { selectChannels } from './queries/selectChannels';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
 import { mapStorableToChannel } from '../mappers/mapStorableToChannel';
+import { QuickSqliteClient } from '../QuickSqliteClient';
 
 /**
  * Returns the list of channels with state enriched for given channel ids.
@@ -26,6 +27,7 @@ export const getChannels = <
   channelIds: string[];
   currentUserId: string;
 }): Omit<ChannelAPIResponse<StreamChatGenerics>, 'duration'>[] => {
+  QuickSqliteClient.logger?.('info', 'getChannels', { channelIds, currentUserId });
   const channels = selectChannels({ channelIds });
 
   const cidVsMembers = getMembers<StreamChatGenerics>({ channelIds });

--- a/package/src/store/apis/getChannelsForFilterSort.ts
+++ b/package/src/store/apis/getChannelsForFilterSort.ts
@@ -4,6 +4,8 @@ import type { ChannelAPIResponse, ChannelFilters, ChannelSort } from 'stream-cha
 import { getChannels } from './getChannels';
 import { selectChannelIdsForFilterSort } from './queries/selectChannelIdsForFilterSort';
 
+import { QuickSqliteClient } from '../QuickSqliteClient';
+
 /**
  * Gets the channels from database for given filter and sort query.
  *
@@ -29,6 +31,8 @@ export const getChannelsForFilterSort = <
     console.warn('Please provide the query (filters/sort) to fetch channels from DB');
     return null;
   }
+
+  QuickSqliteClient.logger?.('info', 'getChannelsForFilterSort', { filters, sort });
 
   const channelIds = selectChannelIdsForFilterSort({ filters, sort });
 

--- a/package/src/store/apis/getLastSyncedAt.ts
+++ b/package/src/store/apis/getLastSyncedAt.ts
@@ -6,6 +6,7 @@ export const getLastSyncedAt = ({
 }: {
   currentUserId: string;
 }): number | undefined => {
+  QuickSqliteClient.logger?.('info', 'getLastSyncedAt', { currentUserId });
   const result = QuickSqliteClient.executeSql.apply(
     null,
     createSelectQuery('userSyncStatus', ['*'], {

--- a/package/src/store/apis/getMembers.ts
+++ b/package/src/store/apis/getMembers.ts
@@ -4,6 +4,7 @@ import { selectMembersForChannels } from './queries/selectMembersForChannels';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
 import { mapStorableToMember } from '../mappers/mapStorableToMember';
+import { QuickSqliteClient } from '../QuickSqliteClient';
 
 export const getMembers = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -12,6 +13,7 @@ export const getMembers = <
 }: {
   channelIds: string[];
 }) => {
+  QuickSqliteClient.logger?.('info', 'getMembers', { channelIds });
   const memberRows = selectMembersForChannels(channelIds);
   const cidVsMembers: Record<string, ChannelMemberResponse<StreamChatGenerics>[]> = {};
   memberRows.forEach((member) => {

--- a/package/src/store/apis/getPendingTasks.ts
+++ b/package/src/store/apis/getPendingTasks.ts
@@ -8,6 +8,7 @@ export const getPendingTasks = (conditions: { messageId?: string } = {}) => {
     createdAt: 1,
   });
 
+  QuickSqliteClient.logger?.('info', 'getPendingTasks', { conditions });
   const result = QuickSqliteClient.executeSql.apply(null, query);
 
   return result.map((r: TableRowJoinedUser<'pendingTasks'>) => mapStorableToTask(r));

--- a/package/src/store/apis/getReads.ts
+++ b/package/src/store/apis/getReads.ts
@@ -4,6 +4,7 @@ import { selectReadsForChannels } from './queries/selectReadsForChannels';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
 import { mapStorableToRead } from '../mappers/mapStorableToRead';
+import { QuickSqliteClient } from '../QuickSqliteClient';
 
 export const getReads = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -12,6 +13,7 @@ export const getReads = <
 }: {
   channelIds: string[];
 }) => {
+  QuickSqliteClient.logger?.('info', 'getReads', { channelIds });
   const reads = selectReadsForChannels(channelIds);
   const cidVsReads: Record<string, ReadResponse<StreamChatGenerics>[]> = {};
 

--- a/package/src/store/apis/insertReaction.ts
+++ b/package/src/store/apis/insertReaction.ts
@@ -14,12 +14,19 @@ export const insertReaction = ({
 }) => {
   const queries: PreparedQueries[] = [];
 
-  queries.push(createUpsertQuery('reactions', mapReactionToStorable(reaction)));
+  const storableReaction = mapReactionToStorable(reaction);
+
+  queries.push(createUpsertQuery('reactions', storableReaction));
 
   queries.push([
     'UPDATE messages SET reactionCounts = reactionCounts + 1 WHERE id = ?',
     [reaction.message_id],
   ]);
+
+  QuickSqliteClient.logger?.('info', 'insertReaction', {
+    flush,
+    reaction: storableReaction,
+  });
 
   if (flush) {
     QuickSqliteClient.executeSqlBatch(queries);

--- a/package/src/store/apis/queries/selectChannelIdsForFilterSort.ts
+++ b/package/src/store/apis/queries/selectChannelIdsForFilterSort.ts
@@ -26,6 +26,11 @@ export const selectChannelIdsForFilterSort = <
   sort?: ChannelSort<StreamChatGenerics>;
 }): string[] | null => {
   const query = convertFilterSortToQuery({ filters, sort });
+
+  QuickSqliteClient.logger?.('info', 'selectChannelIdsForFilterSort', {
+    query,
+  });
+
   const results = QuickSqliteClient.executeSql.apply(
     null,
     createSelectQuery('channelQueries', ['*'], {

--- a/package/src/store/apis/queries/selectChannels.ts
+++ b/package/src/store/apis/queries/selectChannels.ts
@@ -15,6 +15,10 @@ export const selectChannels = ({
       : undefined,
   );
 
+  QuickSqliteClient.logger?.('info', 'selectChannels', {
+    channelIds,
+  });
+
   const result = QuickSqliteClient.executeSql.apply(null, query);
 
   if (channelIds) {

--- a/package/src/store/apis/queries/selectMembersForChannels.ts
+++ b/package/src/store/apis/queries/selectMembersForChannels.ts
@@ -12,6 +12,10 @@ export const selectMembersForChannels = (cids: string[]): TableRowJoinedUser<'me
     .map((name) => `'${name}', b.${name}`)
     .join(', ');
 
+  QuickSqliteClient.logger?.('info', 'selectMembersForChannels', {
+    cids,
+  });
+
   const result = QuickSqliteClient.executeSql(
     `SELECT
       json_object(

--- a/package/src/store/apis/queries/selectMessagesForChannels.ts
+++ b/package/src/store/apis/queries/selectMessagesForChannels.ts
@@ -11,6 +11,10 @@ export const selectMessagesForChannels = (cids: string[]): TableRowJoinedUser<'m
     .map((name) => `'${name}', b.${name}`)
     .join(', ');
 
+  QuickSqliteClient.logger?.('info', 'selectMessagesForChannels', {
+    cids,
+  });
+
   const result = QuickSqliteClient.executeSql(
     `SELECT
       json_object(

--- a/package/src/store/apis/queries/selectReactionsForMessages.ts
+++ b/package/src/store/apis/queries/selectReactionsForMessages.ts
@@ -13,6 +13,10 @@ export const selectReactionsForMessages = (
     .map((name) => `'${name}', b.${name}`)
     .join(', ');
 
+  QuickSqliteClient.logger?.('info', 'selectReactionsForMessages', {
+    messageIds,
+  });
+
   const result = QuickSqliteClient.executeSql(
     `SELECT
       json_object(

--- a/package/src/store/apis/queries/selectReadsForChannels.ts
+++ b/package/src/store/apis/queries/selectReadsForChannels.ts
@@ -10,6 +10,11 @@ export const selectReadsForChannels = (cids: string[]): TableRowJoinedUser<'read
   const userColumnNames = Object.keys(tables.users.columns)
     .map((name) => `'${name}', b.${name}`)
     .join(', ');
+
+  QuickSqliteClient.logger?.('info', 'selectReadsForChannels', {
+    cids,
+  });
+
   const result = QuickSqliteClient.executeSql(
     `SELECT
       json_object(

--- a/package/src/store/apis/upsertAppSettings.ts
+++ b/package/src/store/apis/upsertAppSettings.ts
@@ -12,8 +12,15 @@ export const upsertAppSettings = ({
   currentUserId: string;
   flush?: boolean;
 }) => {
+  const storableAppSettings = JSON.stringify(appSettings);
   const query = createUpsertQuery('userSyncStatus', {
-    appSettings: JSON.stringify(appSettings),
+    appSettings: storableAppSettings,
+    userId: currentUserId,
+  });
+
+  QuickSqliteClient.logger?.('info', 'upsertAppSettings', {
+    appSettings: storableAppSettings,
+    flush,
     userId: currentUserId,
   });
 

--- a/package/src/store/apis/upsertChannelData.ts
+++ b/package/src/store/apis/upsertChannelData.ts
@@ -11,7 +11,12 @@ export const upsertChannelData = ({
   channel: ChannelResponse;
   flush?: boolean;
 }) => {
-  const query = createUpsertQuery('channels', mapChannelDataToStorable(channel));
+  const storableChannel = mapChannelDataToStorable(channel);
+  const query = createUpsertQuery('channels', storableChannel);
+  QuickSqliteClient.logger?.('info', 'upsertChannelData', {
+    channel: storableChannel,
+    flush,
+  });
   if (flush) {
     QuickSqliteClient.executeSqlBatch([query]);
   }

--- a/package/src/store/apis/upsertChannels.ts
+++ b/package/src/store/apis/upsertChannels.ts
@@ -27,8 +27,13 @@ export const upsertChannels = ({
   // Update the database only if the query is provided.
   let queries: PreparedQueries[] = [];
 
+  const channelIds = channels.map((channel) => channel.channel.cid);
+
+  QuickSqliteClient.logger?.('info', 'upsertChannels', {
+    channelIds,
+  });
+
   if (filters || sort) {
-    const channelIds = channels.map((channel) => channel.channel.cid);
     queries = queries.concat(
       upsertCidsForQuery({
         cids: channelIds,

--- a/package/src/store/apis/upsertCidsForQuery.ts
+++ b/package/src/store/apis/upsertCidsForQuery.ts
@@ -17,9 +17,17 @@ export const upsertCidsForQuery = ({
   sort?: ChannelSort;
 }) => {
   // Update the database only if the query is provided.
+  const cidsString = JSON.stringify(cids);
+  const id = convertFilterSortToQuery({ filters, sort });
   const query = createUpsertQuery('channelQueries', {
-    cids: JSON.stringify(cids),
-    id: convertFilterSortToQuery({ filters, sort }),
+    cids: cidsString,
+    id,
+  });
+
+  QuickSqliteClient.logger?.('info', 'upsertCidsForQuery', {
+    cids: cidsString,
+    flush,
+    id,
   });
 
   if (flush) {

--- a/package/src/store/apis/upsertMembers.ts
+++ b/package/src/store/apis/upsertMembers.ts
@@ -17,20 +17,26 @@ export const upsertMembers = ({
 }) => {
   const queries: PreparedQueries[] = [];
 
+  const storableUsers: Array<ReturnType<typeof mapUserToStorable>> = [];
+  const storableMembers: Array<ReturnType<typeof mapMemberToStorable>> = [];
+
   members?.forEach((member) => {
     if (member.user) {
-      queries.push(createUpsertQuery('users', mapUserToStorable(member.user)));
+      const storableUser = mapUserToStorable(member.user);
+      storableUsers.push(storableUser);
+      queries.push(createUpsertQuery('users', storableUser));
     }
+    const storableMember = mapMemberToStorable({ cid, member });
+    storableMembers.push(storableMember);
 
-    queries.push(
-      createUpsertQuery(
-        'members',
-        mapMemberToStorable({
-          cid,
-          member,
-        }),
-      ),
-    );
+    queries.push(createUpsertQuery('members', storableMember));
+  });
+
+  QuickSqliteClient.logger?.('info', 'upsertMembers', {
+    cid,
+    flush,
+    storableMembers,
+    storableUsers,
   });
 
   if (flush) {

--- a/package/src/store/apis/upsertUserSyncStatus.ts
+++ b/package/src/store/apis/upsertUserSyncStatus.ts
@@ -13,5 +13,10 @@ export const upsertUserSyncStatus = ({
     userId: currentUserId,
   });
 
+  QuickSqliteClient.logger?.('info', 'upsertUserSyncStatus', {
+    lastSyncedAt,
+    userId: currentUserId,
+  });
+
   QuickSqliteClient.executeSql.apply(null, query);
 };


### PR DESCRIPTION
The goal is to provide a way to enable sqlite logging so that customers can easily report to us sqlite errors with trace of the reproduction steps.

in entry point of the app (index.js or App.tsx), integrators can add a custom logger. 

For example, in TS example app the following logger is added:

```
QuickSqliteClient.logger = (level, message, extraData) => {
  console.log(level, `QuickSqliteClient: ${message}`, extraData);
};
```

Which results in rich logging in the chrome console:

<img width="1411" alt="Screenshot 2024-03-07 at 14 46 33" src="https://github.com/GetStream/stream-chat-react-native/assets/3846977/35433cfe-f6bb-44ce-9361-8bd5c6868107">

Similarly, loggers can be added to crashlytics or bugsnag etc to trace this and report to us.


