### PR TITLE
fix: add channel prop to ChannelPreviewStatus and fix docs props information

### DIFF
--- a/docusaurus/docs/reactnative/ui-components/channel-preview-status.mdx
+++ b/docusaurus/docs/reactnative/ui-components/channel-preview-status.mdx
@@ -37,7 +37,7 @@ const App = () => {
 
 ## Props
 
-### <div class="label description required">required</div> `channel`
+### `channel`
 
 <Channel />
 

--- a/docusaurus/docs/reactnative/ui-components/channel-preview-title.mdx
+++ b/docusaurus/docs/reactnative/ui-components/channel-preview-title.mdx
@@ -18,6 +18,6 @@ Formatted name for the previewed channel.
 | ------ |
 | String |
 
-### <div class="label description required">required</div> `channel`
+### `channel`
 
 <Channel />

--- a/docusaurus/docs/reactnative/ui-components/channel-preview-unread-count.mdx
+++ b/docusaurus/docs/reactnative/ui-components/channel-preview-unread-count.mdx
@@ -12,6 +12,10 @@ This is the default component provided to the prop [`PreviewUnreadCount`](../cor
 
 ## Props
 
+### `channel`
+
+<Channel />
+
 ### <div class="label description required">required</div> `maxUnreadCount`
 
 <MaxUnreadCount />
@@ -20,6 +24,3 @@ This is the default component provided to the prop [`PreviewUnreadCount`](../cor
 
 <Unread />
 
-### `channel`
-
-<Channel />

--- a/docusaurus/docs/reactnative/ui-components/channel-preview-unread-count.mdx
+++ b/docusaurus/docs/reactnative/ui-components/channel-preview-unread-count.mdx
@@ -23,4 +23,3 @@ This is the default component provided to the prop [`PreviewUnreadCount`](../cor
 ### <div class="label description required">required</div> `unread`
 
 <Unread />
-

--- a/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
@@ -174,6 +174,7 @@ const ChannelPreviewMessengerWithContext = <
         <View style={[styles.row, row]}>
           <PreviewMessage latestMessagePreview={latestMessagePreview} />
           <PreviewStatus
+            channel={channel}
             formatLatestMessageDate={formatLatestMessageDate}
             latestMessagePreview={latestMessagePreview}
           />

--- a/package/src/components/ChannelPreview/ChannelPreviewStatus.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewStatus.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { ChannelPreviewProps } from './ChannelPreview';
 import type { ChannelPreviewMessengerPropsWithContext } from './ChannelPreviewMessenger';
 import { MessageReadStatus } from './hooks/useLatestMessagePreview';
 
@@ -25,7 +26,8 @@ export type ChannelPreviewStatusProps<
 > = Pick<
   ChannelPreviewMessengerPropsWithContext<StreamChatGenerics>,
   'latestMessagePreview' | 'formatLatestMessageDate'
->;
+> &
+  Pick<ChannelPreviewProps<StreamChatGenerics>, 'channel'>;
 
 export const ChannelPreviewStatus = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,


### PR DESCRIPTION


## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


