### PR TITLE
fix: deprecate global config from usage and add resizableCDNHosts to resizableCDNHosts

### DIFF
--- a/docusaurus/docs/reactnative/contexts/chat-context.mdx
+++ b/docusaurus/docs/reactnative/contexts/chat-context.mdx
@@ -61,5 +61,14 @@ Array of users muted by current user.
 | ----- |
 | array |
 
+
+### `resizableCDNHosts`
+
+This option allows you to specify a list of CDNs that offer image resizing.
+
+| Type       | Default                  |
+| ---------- | ------------------------ |
+| `string[]` | `['.stream-io-cdn.com']` |
+
 <!-- ### setActiveChannel -->
 <!-- ### channel -->

--- a/docusaurus/docs/reactnative/contexts/chat-context.mdx
+++ b/docusaurus/docs/reactnative/contexts/chat-context.mdx
@@ -61,7 +61,6 @@ Array of users muted by current user.
 | ----- |
 | array |
 
-
 ### `resizableCDNHosts`
 
 This option allows you to specify a list of CDNs that offer image resizing.

--- a/docusaurus/docs/reactnative/core-components/chat.mdx
+++ b/docusaurus/docs/reactnative/core-components/chat.mdx
@@ -86,7 +86,6 @@ Themes are not hoisted though, therefore a theme provided to `Chat` will not cha
 | ------ |
 | Object |
 
-
 ### `resizableCDNHosts`
 
 This option allows you to specify a list of CDNs that offer image resizing.

--- a/docusaurus/docs/reactnative/core-components/chat.mdx
+++ b/docusaurus/docs/reactnative/core-components/chat.mdx
@@ -86,6 +86,15 @@ Themes are not hoisted though, therefore a theme provided to `Chat` will not cha
 | ------ |
 | Object |
 
+
+### `resizableCDNHosts`
+
+This option allows you to specify a list of CDNs that offer image resizing.
+
+| Type       | Default                  |
+| ---------- | ------------------------ |
+| `string[]` | `['.stream-io-cdn.com']` |
+
 ## UI Component Props
 
 ### `ImageComponent`

--- a/docusaurus/docs/reactnative/customization/global_config.mdx
+++ b/docusaurus/docs/reactnative/customization/global_config.mdx
@@ -8,7 +8,7 @@ The core of Stream Chat for React Native is it's ability to be customized to you
 The new `Global Config` feature allows you to enable and disable features of the library and alter the default behavior of the SDK.
 
 :::info
-This will be not be the recommneded way of setting the config in the next major version of the SDK i.e. v6 onwards.
+This will be not be the recommended way of setting the config in the next major version of the SDK that is v6.
 
 Use the `resizableCDNHosts` prop in the [`Chat`](../core-components/chat.mdx) component instead.
 :::

--- a/docusaurus/docs/reactnative/customization/global_config.mdx
+++ b/docusaurus/docs/reactnative/customization/global_config.mdx
@@ -7,8 +7,11 @@ title: Global Config
 The core of Stream Chat for React Native is it's ability to be customized to your needs.
 The new `Global Config` feature allows you to enable and disable features of the library and alter the default behavior of the SDK.
 
-We will be gradually adding more features/options to the global config.
-In the future this will be the main way to alter the default behavior of the SDK and it's components.
+:::info
+This will be not be the recommneded way of setting the config in the next major version of the SDK i.e. v6 onwards.
+
+Use the `resizableCDNHosts` prop in the [`Chat`](../core-components/chat.mdx) component instead.
+:::
 
 ## When to use global config
 

--- a/package/src/components/Chat/Chat.tsx
+++ b/package/src/components/Chat/Chat.tsx
@@ -27,6 +27,7 @@ import { SDK } from '../../native';
 import { QuickSqliteClient } from '../../store/QuickSqliteClient';
 import type { DefaultStreamChatGenerics } from '../../types/types';
 import { DBSyncManager } from '../../utils/DBSyncManager';
+import { StreamChatRN } from '../../utils/StreamChatRN';
 import type { Streami18n } from '../../utils/Streami18n';
 import { version } from '../../version.json';
 
@@ -35,7 +36,7 @@ init();
 export type ChatProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 > = Pick<ChatContextValue<StreamChatGenerics>, 'client'> &
-  Partial<Pick<ChatContextValue<StreamChatGenerics>, 'ImageComponent'>> & {
+  Partial<Pick<ChatContextValue<StreamChatGenerics>, 'ImageComponent' | 'resizableCDNHosts'>> & {
     /**
      * When false, ws connection won't be disconnection upon backgrounding the app.
      * To receive push notifications, its necessary that user doesn't have active
@@ -142,6 +143,7 @@ const ChatWithContext = <
     enableOfflineSupport = false,
     i18nInstance,
     ImageComponent = Image,
+    resizableCDNHosts = ['.stream-io-cdn.com'],
     style,
   } = props;
 
@@ -168,6 +170,9 @@ const ChatWithContext = <
 
   const debugRef = useDebugContext();
   const isDebugModeEnabled = __DEV__ && debugRef && debugRef.current;
+
+  // Set the `resizableCDNHosts` as per the prop.
+  StreamChatRN.setConfig({ resizableCDNHosts });
 
   useEffect(() => {
     if (client) {
@@ -209,6 +214,7 @@ const ChatWithContext = <
     ImageComponent,
     isOnline,
     mutedUsers,
+    resizableCDNHosts,
     setActiveChannel,
   });
 

--- a/package/src/components/Chat/hooks/useCreateChatContext.ts
+++ b/package/src/components/Chat/hooks/useCreateChatContext.ts
@@ -24,7 +24,6 @@ export const useCreateChatContext = <
       }${client.mutedChannels.length}`
     : 'Offline';
   const mutedUsersLength = mutedUsers.length;
-  const stringifiedResizableCDNHosts = resizableCDNHosts?.join(',');
 
   const chatContext: ChatContextValue<StreamChatGenerics> = useMemo(
     () => ({
@@ -39,14 +38,7 @@ export const useCreateChatContext = <
       resizableCDNHosts,
       setActiveChannel,
     }),
-    [
-      channelId,
-      clientValues,
-      connectionRecovering,
-      isOnline,
-      mutedUsersLength,
-      stringifiedResizableCDNHosts,
-    ],
+    [channelId, clientValues, connectionRecovering, isOnline, mutedUsersLength],
   );
 
   return chatContext;

--- a/package/src/components/Chat/hooks/useCreateChatContext.ts
+++ b/package/src/components/Chat/hooks/useCreateChatContext.ts
@@ -14,6 +14,7 @@ export const useCreateChatContext = <
   ImageComponent,
   isOnline,
   mutedUsers,
+  resizableCDNHosts,
   setActiveChannel,
 }: ChatContextValue<StreamChatGenerics>) => {
   const channelId = channel?.id;
@@ -23,6 +24,7 @@ export const useCreateChatContext = <
       }${client.mutedChannels.length}`
     : 'Offline';
   const mutedUsersLength = mutedUsers.length;
+  const stringifiedResizableCDNHosts = resizableCDNHosts?.join(',');
 
   const chatContext: ChatContextValue<StreamChatGenerics> = useMemo(
     () => ({
@@ -34,9 +36,17 @@ export const useCreateChatContext = <
       ImageComponent,
       isOnline,
       mutedUsers,
+      resizableCDNHosts,
       setActiveChannel,
     }),
-    [channelId, clientValues, connectionRecovering, isOnline, mutedUsersLength],
+    [
+      channelId,
+      clientValues,
+      connectionRecovering,
+      isOnline,
+      mutedUsersLength,
+      stringifiedResizableCDNHosts,
+    ],
   );
 
   return chatContext;

--- a/package/src/contexts/chatContext/ChatContext.tsx
+++ b/package/src/contexts/chatContext/ChatContext.tsx
@@ -65,6 +65,10 @@ export type ChatContextValue<
    * @overrideType Channel
    */
   channel?: Channel<StreamChatGenerics>;
+  /**
+   * This option allows you to specify a list of CDNs that offer image resizing.
+   */
+  resizableCDNHosts?: string[];
 };
 
 export const ChatContext = React.createContext(DEFAULT_BASE_CONTEXT_VALUE as ChatContextValue);

--- a/package/src/utils/StreamChatRN.ts
+++ b/package/src/utils/StreamChatRN.ts
@@ -8,6 +8,8 @@ const DEFAULT_GLOBAL_STREAM_CONFIG = {
 /**
  * StreamChatRN - Global config for the RN Chat SDK
  * This config is used to enable/disable features and options for the SDK.
+ *
+ * @deprecated Use the `resizableCDNHosts` prop in the `Chat` component, instead. StreamChatRN will not be exposed starting the next major release.
  */
 export class StreamChatRN {
   /**


### PR DESCRIPTION
## 🎯 Goal

The goal of the PR is to deprecate the global config `StreamChatRN` and in turn introduce the prop inside `Chat` component.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


