### PR TITLE
feat: add customizability for attachment picker ios select more photos component

### DIFF
--- a/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_bottom_sheet_handle.mdx
+++ b/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_bottom_sheet_handle.mdx
@@ -1,5 +1,0 @@
-Bottom sheet handle component for image picker.
-
-| Type          | Default                                                                                                                                                                                       |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ComponentType | [AttachmentPickerBottomSheetHandle](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/AttachmentPicker/components/AttachmentPickerBottomSheetHandle.tsx) |

--- a/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_bottom_sheet_handle_height.mdx
+++ b/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_bottom_sheet_handle_height.mdx
@@ -1,5 +1,0 @@
-Height of the image picker bottom sheet handle.
-
-| Type   | Default |
-| ------ | ------- |
-| number | 20      |

--- a/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_error.mdx
+++ b/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_error.mdx
@@ -1,5 +1,0 @@
-Error component displayed when the app doesn't have permissions to access photos on the device.
-
-| Type          | Default                                                                                                                                                               |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ComponentType | [AttachmentPickerError](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/AttachmentPicker/components/AttachmentPickerError.tsx) |

--- a/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_error_button_text.mdx
+++ b/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_error_button_text.mdx
@@ -1,5 +1,0 @@
-Text for the button within [`AttachmentPickerError`](../../../../core-components/overlay-provider.mdx#attachmentpickererror) that opens the apps OS level settings.
-
-| Type   | Default                        |
-| ------ | ------------------------------ |
-| string | "Allow access to your Gallery" |

--- a/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_error_image.mdx
+++ b/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_error_image.mdx
@@ -1,5 +1,0 @@
-Image component within [`AttachmentPickerError`](../../../../core-components/overlay-provider.mdx#attachmentpickererror).
-
-| Type          | Default                                                                                                                                                                         |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ComponentType | [AttachmentPickerErrorImage](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/AttachmentPicker/components/AttachmentPickerErrorImage.tsx) |

--- a/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_error_text.mdx
+++ b/docusaurus/docs/reactnative/common-content/ui-components/overlay-provider/props/attachment_picker_error_text.mdx
@@ -1,5 +1,0 @@
-Error text for [`AttachmentPickerError`](../../../../core-components/overlay-provider.mdx#attachmentpickererror).
-
-| Type   | Default                                                                 |
-| ------ | ----------------------------------------------------------------------- |
-| string | "Please enable access to your photos and videos so you can share them." |

--- a/docusaurus/docs/reactnative/core-components/overlay-provider.mdx
+++ b/docusaurus/docs/reactnative/core-components/overlay-provider.mdx
@@ -242,6 +242,14 @@ Image component within [`AttachmentPickerError`](https://github.com/GetStream/s
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | ComponentType | `undefined` \| [`AttachmentPickerErrorImage`](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/AttachmentPicker/components/AttachmentPickerErrorImage.tsx) |
 
+### `AttachmentPickerIOSSelectMorePhotos`
+
+Component to render select more photos option for selected gallery access in iOS.
+
+| Type          | Default                                                                                                                                                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ComponentType | `undefined` \| [`AttachmentPickerIOSSelectMorePhotos`](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/AttachmentPicker/components/AttachmentPickerIOSSelectMorePhotos.tsx) |
+
 ### `CameraSelectorIcon`
 
 Camera selector component displayed in the attachment selector bar.

--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -1,13 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  BackHandler,
-  Button,
-  Dimensions,
-  Keyboard,
-  Platform,
-  StatusBar,
-  StyleSheet,
-} from 'react-native';
+import { BackHandler, Dimensions, Keyboard, Platform, StatusBar, StyleSheet } from 'react-native';
 
 import BottomSheet, { BottomSheetFlatList, BottomSheetHandleProps } from '@gorhom/bottom-sheet';
 import dayjs from 'dayjs';
@@ -19,13 +11,8 @@ import { renderAttachmentPickerItem } from './components/AttachmentPickerItem';
 
 import { useAttachmentPickerContext } from '../../contexts/attachmentPickerContext/AttachmentPickerContext';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
-import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
 import { useViewport } from '../../hooks/useViewport';
-import {
-  getPhotos,
-  iOS14RefreshGallerySelection,
-  oniOS14GalleryLibrarySelectionChange,
-} from '../../native';
+import { getPhotos, oniOS14GalleryLibrarySelectionChange } from '../../native';
 import type { Asset } from '../../types/types';
 
 dayjs.extend(duration);
@@ -58,6 +45,10 @@ export type AttachmentPickerProps = {
    */
   AttachmentPickerErrorImage: React.ComponentType;
   /**
+   * Custom UI Component to render select more photos for selected gallery access in iOS.
+   */
+  AttachmentPickerIOSSelectMorePhotos: React.ComponentType;
+  /**
    * Custom UI component to render overlay component, that shows up on top of [selected image](https://github.com/GetStream/stream-chat-react-native/blob/main/screenshots/docs/1.png) (with tick mark)
    *
    * **Default** [ImageOverlaySelectedComponent](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/AttachmentPicker/components/ImageOverlaySelectedComponent.tsx)
@@ -82,6 +73,7 @@ export const AttachmentPicker = React.forwardRef(
       attachmentPickerErrorButtonText,
       AttachmentPickerErrorImage,
       attachmentPickerErrorText,
+      AttachmentPickerIOSSelectMorePhotos,
       ImageOverlaySelectedComponent,
       numberOfAttachmentImagesToLoadPerCall,
       numberOfAttachmentPickerImageColumns,
@@ -117,7 +109,6 @@ export const AttachmentPicker = React.forwardRef(
     const [loadingPhotos, setLoadingPhotos] = useState(false);
     const [photos, setPhotos] = useState<Asset[]>([]);
     const attemptedToLoadPhotosOnOpenRef = useRef(false);
-    const { t } = useTranslationContext();
 
     const getMorePhotos = useCallback(async () => {
       if (
@@ -323,9 +314,7 @@ export const AttachmentPicker = React.forwardRef(
           ref={ref}
           snapPoints={snapPoints}
         >
-          {iOSLimited && (
-            <Button onPress={iOS14RefreshGallerySelection} title={t('Select More Photos')} />
-          )}
+          {iOSLimited && <AttachmentPickerIOSSelectMorePhotos />}
           <BottomSheetFlatList
             contentContainerStyle={[
               styles.container,

--- a/package/src/components/AttachmentPicker/components/AttachmentPickerIOSSelectMorePhotos.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentPickerIOSSelectMorePhotos.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Button } from 'react-native';
+
+import { useTranslationContext } from '../../../contexts/translationContext/TranslationContext';
+import { iOS14RefreshGallerySelection } from '../../../native';
+
+export const AttachmentPickerIOSSelectMorePhotos = () => {
+  const { t } = useTranslationContext();
+  return <Button onPress={iOS14RefreshGallerySelection} title={t('Select More Photos')} />;
+};

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -18,6 +18,7 @@ import { AttachmentPicker } from '../../components/AttachmentPicker/AttachmentPi
 import { AttachmentPickerBottomSheetHandle as DefaultAttachmentPickerBottomSheetHandle } from '../../components/AttachmentPicker/components/AttachmentPickerBottomSheetHandle';
 import { AttachmentPickerError as DefaultAttachmentPickerError } from '../../components/AttachmentPicker/components/AttachmentPickerError';
 import { AttachmentPickerErrorImage as DefaultAttachmentPickerErrorImage } from '../../components/AttachmentPicker/components/AttachmentPickerErrorImage';
+import { AttachmentPickerIOSSelectMorePhotos as DefaultAttachmentPickerIOSSelectMorePhotos } from '../../components/AttachmentPicker/components/AttachmentPickerIOSSelectMorePhotos';
 import { CameraSelectorIcon as DefaultCameraSelectorIcon } from '../../components/AttachmentPicker/components/CameraSelectorIcon';
 import { FileSelectorIcon as DefaultFileSelectorIcon } from '../../components/AttachmentPicker/components/FileSelectorIcon';
 import { ImageOverlaySelectedComponent as DefaultImageOverlaySelectedComponent } from '../../components/AttachmentPicker/components/ImageOverlaySelectedComponent';
@@ -73,6 +74,7 @@ export const OverlayProvider = <
     AttachmentPickerErrorImage = DefaultAttachmentPickerErrorImage,
     attachmentPickerErrorText,
     attachmentSelectionBarHeight,
+    AttachmentPickerIOSSelectMorePhotos = DefaultAttachmentPickerIOSSelectMorePhotos,
     bottomInset,
     CameraSelectorIcon = DefaultCameraSelectorIcon,
     children,
@@ -132,6 +134,7 @@ export const OverlayProvider = <
     attachmentPickerErrorButtonText,
     AttachmentPickerErrorImage,
     attachmentPickerErrorText,
+    AttachmentPickerIOSSelectMorePhotos,
     attachmentSelectionBarHeight,
     ImageOverlaySelectedComponent,
     numberOfAttachmentImagesToLoadPerCall,

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,6 +1,6 @@
 export * from './components';
 export * from './hooks';
-export { registerNativeHandlers, NetInfo } from './native';
+export { registerNativeHandlers, NetInfo, iOS14RefreshGallerySelection } from './native';
 export * from './contexts';
 export * from './emoji-data';
 


### PR DESCRIPTION
## 🎯 Goal

The goal of the PR is to add the ability to customize the attachment picker to select more photo components for iOS.

Note: This PR also removed unused docs files around the attachment picker.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

The component can be customized using the `AttachmentPickerIOSSelectMorePhotos` prop in the `OverlayProvider` component:

Eg:

```
AttachmentPickerIOSSelectMorePhotos={() => {
                return (
                  <>
                    <Text>You are given selected access to the image gallery.</Text>
                    <Button onPress={iOS14RefreshGallerySelection} title='Manage' />
                  </>
                );
              }}
```

![simulator_screenshot_8A178E3C-A2A3-4587-8510-D65A90EBF142](https://github.com/GetStream/stream-chat-react-native/assets/39884168/c9fa66cc-a931-4df6-9aa1-516dbbce006c)


<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


