### PR TITLE
fix(sample-app): for the loading status which did not return to false when the list of attachments or pinned messages was empty

### DIFF
--- a/examples/SampleApp/src/hooks/usePaginatedAttachments.ts
+++ b/examples/SampleApp/src/hooks/usePaginatedAttachments.ts
@@ -31,6 +31,7 @@ export const usePaginatedAttachments = (
 
       if (!hasMoreResults.current) {
         queryInProgress.current = false;
+        setLoading(false);
         return;
       }
 
@@ -50,6 +51,7 @@ export const usePaginatedAttachments = (
 
       if (!newMessages) {
         queryInProgress.current = false;
+        setLoading(false);
         return;
       }
 

--- a/examples/SampleApp/src/hooks/usePaginatedPinnedMessages.ts
+++ b/examples/SampleApp/src/hooks/usePaginatedPinnedMessages.ts
@@ -30,6 +30,7 @@ export const usePaginatedPinnedMessages = (channel: Channel<StreamChatGenerics>)
 
       if (!hasMoreResults.current) {
         queryInProgress.current = false;
+        setLoading(false);
         return;
       }
 
@@ -48,6 +49,7 @@ export const usePaginatedPinnedMessages = (channel: Channel<StreamChatGenerics>)
 
       if (!newMessages) {
         queryInProgress.current = false;
+        setLoading(false);
         return;
       }
 


### PR DESCRIPTION
## 🎯 Goal

The goal of this change is to fix a bug in the usePaginatedAttachments and usePaginatedPinnedMessages hooks. This bug caused the loading state to not be reset to false for empty lists. As a result, the empty list indicator could not be displayed.

## 🛠 Implementation details

The change consists of adding the following code to both hooks:
`setLoading(false)`

## 🧪 Testing
1. Create a new chat without any messages.
2. Open the screen with attachments or pinned messages.
3. Notice that the empty state is not visible. This is because the loading state is still true even though there are no results and the data has finished loading from the API.