### PR TITLE
fix: offline support saving cyclic structure

### DIFF
--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -37,9 +37,6 @@ import { UserSelectorScreen } from './src/screens/UserSelectorScreen';
 
 import type { StreamChat } from 'stream-chat';
 
-LogBox.ignoreLogs(["Seems like you're using an old API"]);
-LogBox.ignoreLogs(['Each child in a list should have a unique']);
-
 if (__DEV__) {
   DevSettings.addMenuItem('Reset local DB (offline storage)', () => {
     QuickSqliteClient.resetDB();
@@ -56,7 +53,6 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { navigateToChannel, RootNavigationRef } from './src/utils/RootNavigation';
 import FastImage from 'react-native-fast-image';
 
-LogBox.ignoreAllLogs(true);
 LogBox.ignoreLogs(['Non-serializable values were found in the navigation state']);
 console.assert = () => null;
 

--- a/package/src/components/MessageInput/SendButton.tsx
+++ b/package/src/components/MessageInput/SendButton.tsx
@@ -35,7 +35,7 @@ const SendButtonWithContext = <
   return (
     <Pressable
       disabled={disabled}
-      onPress={disabled ? () => null : () => sendMessage(undefined)}
+      onPress={disabled ? () => null : () => sendMessage()}
       style={[sendButton]}
       testID='send-button'
     >

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -165,7 +165,9 @@ export type LocalMessageInputContext<
   resetInput: (pendingAttachments?: Attachment<StreamChatGenerics>[]) => void;
   selectedPicker: string | undefined;
   sending: React.MutableRefObject<boolean>;
-  sendMessage: (customMessageData?: Partial<Message<StreamChatGenerics>>) => Promise<void>;
+  sendMessage: (params?: {
+    customMessageData?: Partial<Message<StreamChatGenerics>>;
+  }) => Promise<void>;
   sendMessageAsync: (id: string) => void;
   sendThreadMessageInChannel: boolean;
   setAsyncIds: React.Dispatch<React.SetStateAction<string[]>>;
@@ -706,8 +708,12 @@ export const MessageInputProvider = <
   };
 
   // TODO: Figure out why this is async, as it doesn't await any promise.
-  // eslint-disable-next-line require-await
-  const sendMessage = async (customMessageData?: Partial<Message<StreamChatGenerics>>) => {
+  const sendMessage = async ({
+    customMessageData,
+  }: {
+    customMessageData?: Partial<Message<StreamChatGenerics>>;
+    // eslint-disable-next-line require-await
+  } = {}) => {
     if (sending.current) {
       return;
     }


### PR DESCRIPTION
due to #2422 we supported adding any custom fields to the message

but if an integrator adds `<TouchableOpacity onPress={sendMessage}>` it will unintentionally add any touchable event params to the signature. And this creates a bug with offline support as it has cyclic structure.

This was pointed out [here](https://github.com/GetStream/stream-chat-react-native/pull/2453#issuecomment-2015865576)

In this PR we change the signature of the method so that this cannot happen anymore