### PR TITLE
fix: theme for MessageList and SendMessageDisallowedIndicator

### DIFF
--- a/examples/ExpoMessaging/useStreamChatTheme.ts
+++ b/examples/ExpoMessaging/useStreamChatTheme.ts
@@ -14,49 +14,51 @@ export const useStreamChatTheme = () => {
     colors:
       colorScheme === 'dark'
         ? {
-          accent_blue: '#005FFF',
-          accent_green: '#20E070',
-          accent_red: '#FF3742',
-          bg_gradient_end: '#101214',
-          bg_gradient_start: '#070A0D',
-          black: '#FFFFFF',
-          blue_alice: '#00193D',
-          border: '#141924',
-          grey: '#7A7A7A',
-          grey_gainsboro: '#2D2F2F',
-          grey_whisper: '#1C1E22',
-          icon_background: '#FFFFFF',
-          modal_shadow: '#000000',
-          overlay: '#FFFFFFCC', // CC = 80% opacity
-          shadow_icon: '#00000080', // 80 = 50% opacity
-          targetedMessageBackground: '#302D22',
-          transparent: 'transparent',
-          white: '#101418',
-          white_smoke: '#13151B',
-          white_snow: '#070A0D',
-        }
+            accent_blue: '#005FFF',
+            accent_green: '#20E070',
+            accent_red: '#FF3742',
+            bg_gradient_end: '#101214',
+            bg_gradient_start: '#070A0D',
+            black: '#FFFFFF',
+            blue_alice: '#00193D',
+            border: '#141924',
+            grey: '#7A7A7A',
+            grey_dark: '#F7F7F8',
+            grey_gainsboro: '#2D2F2F',
+            grey_whisper: '#1C1E22',
+            icon_background: '#FFFFFF',
+            modal_shadow: '#000000',
+            overlay: '#FFFFFFCC', // CC = 80% opacity
+            shadow_icon: '#00000080', // 80 = 50% opacity
+            targetedMessageBackground: '#302D22',
+            transparent: 'transparent',
+            white: '#101418',
+            white_smoke: '#13151B',
+            white_snow: '#070A0D',
+          }
         : {
-          accent_blue: '#005FFF',
-          accent_green: '#20E070',
-          accent_red: '#FF3742',
-          bg_gradient_end: '#F7F7F7',
-          bg_gradient_start: '#FCFCFC',
-          black: '#000000',
-          blue_alice: '#E9F2FF',
-          border: '#00000014', // 14 = 8% opacity; top: x=0, y=-1; bottom: x=0, y=1
-          grey: '#7A7A7A',
-          grey_gainsboro: '#DBDBDB',
-          grey_whisper: '#ECEBEB',
-          icon_background: '#FFFFFF',
-          modal_shadow: '#00000099', // 99 = 60% opacity; x=0, y= 1, radius=4
-          overlay: '#00000099', // 99 = 60% opacity
-          shadow_icon: '#00000040', // 40 = 25% opacity; x=0, y=0, radius=4
-          targetedMessageBackground: '#FBF4DD', // dark mode = #302D22
-          transparent: 'transparent',
-          white: '#FFFFFF',
-          white_smoke: '#F2F2F2',
-          white_snow: '#FCFCFC',
-        },
+            accent_blue: '#005FFF',
+            accent_green: '#20E070',
+            accent_red: '#FF3742',
+            bg_gradient_end: '#F7F7F7',
+            bg_gradient_start: '#FCFCFC',
+            black: '#000000',
+            blue_alice: '#E9F2FF',
+            border: '#00000014', // 14 = 8% opacity; top: x=0, y=-1; bottom: x=0, y=1
+            grey: '#7A7A7A',
+            grey_dark: '#17191C',
+            grey_gainsboro: '#DBDBDB',
+            grey_whisper: '#ECEBEB',
+            icon_background: '#FFFFFF',
+            modal_shadow: '#00000099', // 99 = 60% opacity; x=0, y= 1, radius=4
+            overlay: '#00000099', // 99 = 60% opacity
+            shadow_icon: '#00000040', // 40 = 25% opacity; x=0, y=0, radius=4
+            targetedMessageBackground: '#FBF4DD', // dark mode = #302D22
+            transparent: 'transparent',
+            white: '#FFFFFF',
+            white_smoke: '#F2F2F2',
+            white_snow: '#FCFCFC',
+          },
     spinner: {
       height: 15,
       width: 15,

--- a/examples/TypeScriptMessaging/App.tsx
+++ b/examples/TypeScriptMessaging/App.tsx
@@ -228,7 +228,6 @@ const App = () => {
         theme={{
           colors: {
             ...(colorScheme === 'dark' ? DarkTheme : DefaultTheme).colors,
-            background: theme.colors?.white_snow || '#FCFCFC',
           },
           dark: colorScheme === 'dark',
         }}

--- a/examples/TypeScriptMessaging/useStreamChatTheme.ts
+++ b/examples/TypeScriptMessaging/useStreamChatTheme.ts
@@ -21,6 +21,7 @@ const getChatStyle = (colorScheme: string): DeepPartial<Theme> => ({
           blue_alice: '#00193D',
           border: '#141924',
           grey: '#7A7A7A',
+          grey_dark: '#F7F7F8',
           grey_gainsboro: '#2D2F2F',
           grey_whisper: '#1C1E22',
           icon_background: '#FFFFFF',
@@ -43,6 +44,7 @@ const getChatStyle = (colorScheme: string): DeepPartial<Theme> => ({
           blue_alice: '#E9F2FF',
           border: '#00000014', // 14 = 8% opacity; top: x=0, y=-1; bottom: x=0, y=1
           grey: '#7A7A7A',
+          grey_dark: '#17191C',
           grey_gainsboro: '#DBDBDB',
           grey_whisper: '#ECEBEB',
           icon_background: '#FFFFFF',

--- a/package/src/components/Indicators/LoadingIndicator.tsx
+++ b/package/src/components/Indicators/LoadingIndicator.tsx
@@ -21,14 +21,14 @@ const styles = StyleSheet.create({
 const LoadingIndicatorWrapper: React.FC<{ text: string }> = ({ text }) => {
   const {
     theme: {
-      colors: { black },
+      colors: { black, white_snow },
       loadingIndicator: { container, loadingText },
     },
   } = useTheme();
 
   return (
-    <View style={[styles.container, container]}>
-      <Spinner />
+    <View style={[styles.container, { backgroundColor: white_snow }, container]}>
+      <Spinner height={20} width={20} />
       <Text style={[styles.loadingText, { color: black }, loadingText]} testID='loading'>
         {text}
       </Text>

--- a/package/src/components/MessageInput/SendMessageDisallowedIndicator.tsx
+++ b/package/src/components/MessageInput/SendMessageDisallowedIndicator.tsx
@@ -21,7 +21,7 @@ export const SendMessageDisallowedIndicator = () => {
   const { t } = useTranslationContext();
   const {
     theme: {
-      colors: { border, grey_dark },
+      colors: { border, grey_dark, white },
       messageInput: {
         sendMessageDisallowedIndicator: { container, text },
       },
@@ -33,6 +33,7 @@ export const SendMessageDisallowedIndicator = () => {
       style={[
         styles.container,
         {
+          backgroundColor: white,
           borderTopColor: border,
           height: 50,
         },

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -1072,7 +1072,11 @@ const MessageListWithContext = <
   const renderListEmptyComponent = useCallback(
     () => (
       <View
-        style={[styles.flex, shouldApplyAndroidWorkaround ? styles.invertAndroid : styles.invert]}
+        style={[
+          styles.flex,
+          { backgroundColor: white_snow },
+          shouldApplyAndroidWorkaround ? styles.invertAndroid : styles.invert,
+        ]}
         testID='empty-state'
       >
         <EmptyStateIndicator listType='message' />
@@ -1099,16 +1103,6 @@ const MessageListWithContext = <
     [shouldApplyAndroidWorkaround, HeaderComponent],
   );
 
-  if (!FlatList) return null;
-
-  if (loading) {
-    return (
-      <View style={styles.flex}>
-        <LoadingIndicator listType='message' />
-      </View>
-    );
-  }
-
   const StickyHeaderComponent = () => {
     if (!stickyHeaderDateString) return null;
     if (StickyHeader) return <StickyHeader dateString={stickyHeaderDateString} />;
@@ -1125,6 +1119,16 @@ const MessageListWithContext = <
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { contentContainerStyle, style, ...rest } = additionalFlatListProps;
     additionalFlatListPropsExcludingStyle = rest;
+  }
+
+  if (!FlatList) return null;
+
+  if (loading) {
+    return (
+      <View style={[styles.container, { backgroundColor: white_snow }, container]}>
+        <LoadingIndicator listType='message' />
+      </View>
+    );
   }
 
   return (


### PR DESCRIPTION
## 🎯 Goal

This PR fixes the theme for the `MessageList` and the `SendMessageDisallowedIndicator` components. The background colour is especially fixed, which was white for most cases if no external colour is applied.

The empty state spinner was also not rendering. That is also fixed in the PR.

Before:

https://github.com/GetStream/stream-chat-react-native/assets/39884168/354b86c4-8158-4c01-86b6-74bab4fbe895

After:

https://github.com/GetStream/stream-chat-react-native/assets/39884168/bbbf4011-6d32-42d0-9d4a-28b6893a4084

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


