### PR TITLE
fix: scroll to bottom issue when the message list is empty

### DIFF
--- a/examples/SampleApp/src/hooks/usePaginatedSearchedMessages.ts
+++ b/examples/SampleApp/src/hooks/usePaginatedSearchedMessages.ts
@@ -64,7 +64,7 @@ export const usePaginatedSearchedMessages = (
         {
           limit: DEFAULT_PAGINATION_LIMIT,
           offset: offset.current,
-          sort: { created_at: -1 },
+          sort: { updated_at: -1 },
         },
       );
 

--- a/examples/SampleApp/src/hooks/usePaginatedSearchedMessages.ts
+++ b/examples/SampleApp/src/hooks/usePaginatedSearchedMessages.ts
@@ -64,6 +64,7 @@ export const usePaginatedSearchedMessages = (
         {
           limit: DEFAULT_PAGINATION_LIMIT,
           offset: offset.current,
+          sort: { created_at: -1 },
         },
       );
 

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -805,7 +805,7 @@ const MessageListWithContext = <
 
   const handleScroll: ScrollViewProps['onScroll'] = (event) => {
     const offset = event.nativeEvent.contentOffset.y;
-    const messageListHasMessages = channel.state.messages.length > 0;
+    const messageListHasMessages = processedMessageList.length > 0;
     // Show scrollToBottom button once scroll position goes beyond 150.
     const isScrollAtBottom = offset <= 150;
 

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -525,7 +525,7 @@ const MessageListWithContext = <
     if (threadList || hasNoMoreRecentMessagesToLoad) {
       scrollToBottomIfNeeded();
     } else {
-      setScrollToBottomButtonVisible(true);
+      setScrollToBottomButtonVisible(false);
     }
 
     if (
@@ -805,13 +805,15 @@ const MessageListWithContext = <
 
   const handleScroll: ScrollViewProps['onScroll'] = (event) => {
     const offset = event.nativeEvent.contentOffset.y;
+    const messageListHasMessages = channel.state.messages.length > 0;
     // Show scrollToBottom button once scroll position goes beyond 150.
     const isScrollAtBottom = offset <= 150;
 
     const notLatestSet = channel.state.messages !== channel.state.latestMessages;
 
     const showScrollToBottomButton =
-      (!threadList && notLatestSet) || !isScrollAtBottom || !hasNoMoreRecentMessagesToLoad;
+      messageListHasMessages &&
+      ((!threadList && notLatestSet) || !isScrollAtBottom || !hasNoMoreRecentMessagesToLoad);
 
     /**
      * 1. If I scroll up -> show scrollToBottom button.


### PR DESCRIPTION
## 🎯 Goal

The goal of the PR is to solve the scroll-to-bottom visible issue when the message list is empty and also not to show the scroll-to-bottom button after the offset is reached.

PFA the video attached that shows the previous and new behaviour(as per the PR):

Previous:

https://github.com/GetStream/stream-chat-react-native/assets/39884168/69e5c23c-0aab-4dc5-bb3f-0b0e820d3b66

New:

https://github.com/GetStream/stream-chat-react-native/assets/39884168/b062ebce-5533-45ee-bb3c-f816da5b86c7

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


