### PR TITLE
fix: messages not received when connection recovered and do not reload channel when sending message

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -656,6 +656,7 @@ const ChannelWithContext = <
   }, [channelId, messageId]);
 
   const threadPropsExists = !!threadProps;
+
   useEffect(() => {
     if (threadProps && shouldSyncChannel) {
       setThread(threadProps);
@@ -1192,7 +1193,6 @@ const ChannelWithContext = <
 
   const resyncChannel = async () => {
     if (!channel || syncingChannelRef.current) return;
-    if (!channel.initialized) return;
     hasOverlappingRecentMessagesRef.current = false;
     clearInterval(mergeSetsIntervalRef.current);
     syncingChannelRef.current = true;
@@ -1703,10 +1703,6 @@ const ChannelWithContext = <
     });
 
     mergeOverlappingMessageSetsRef.current();
-
-    if (!channel?.state.isUpToDate) {
-      await reloadChannel();
-    }
 
     updateMessage(messagePreview, {
       commands: [],

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -1045,6 +1045,7 @@ const MessageListWithContext = <
     !hasMoved && selectedPicker && setHasMoved(true);
     onUserScrollEvent(event);
   };
+
   const onScrollEndDrag: ScrollViewProps['onScrollEndDrag'] = (event) => {
     hasMoved && selectedPicker && setHasMoved(false);
     onUserScrollEvent(event);


### PR DESCRIPTION
## 🎯 Goal

This PR fixes the bug where we did not watch on connection recovery. Since we directly call the `resyncChannel` function on `connection.changed` event that has this early exit(`if (!channel.initialized) return;`), which will never allow the channel to be watched.

https://github.com/GetStream/stream-chat-react-native/blob/develop/package/src/components/Channel/Channel.tsx#L1206 

Moreover, there is no real need to reload the entire channel when sending a message. When the connection is recovered, the messages sent by other users are already fetched without any issues.

1. Calling the reload channel for offline case is vague, and the messages, even if sent, will fail, and you cannot really fetch new messages while offline thereby reloadChannel will obviously fail. This is also fixed in the PR.
2. Now, when the connection is online, the `channel.state.isUptoDate` is almost true most of the time. But when the messages were to be received when I was offline and came online, the above fix for `resyncChannel` would already handle it. Therefore, it is not needed.

I checked the code on React SDK, they also don't do reloadChannel on sendMessage.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


