### PR TITLE
Fix: channel.lastRead() returns null after posting a message

### DIFF
--- a/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
+++ b/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
@@ -165,7 +165,7 @@ const getLatestMessageReadStatus = <
     return MessageReadStatus.NOT_SENT_BY_CURRENT_USER;
   }
 
-  const readList = channel.state.read;
+  const readList = {...channel.state.read};
   if (currentUserId) {
     delete readList[currentUserId];
   }

--- a/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
+++ b/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
@@ -165,7 +165,7 @@ const getLatestMessageReadStatus = <
     return MessageReadStatus.NOT_SENT_BY_CURRENT_USER;
   }
 
-  const readList = {...channel.state.read};
+  const readList = { ...channel.state.read };
   if (currentUserId) {
     delete readList[currentUserId];
   }


### PR DESCRIPTION
## 🎯 Goal

Preventing deleting last_read of current user.

## 🛠 Implementation details

In current implementation, `getLatestMessageReadStatus` function manipulates `channel.state.read` directly and deletes read state of current user.

```
  const readList = channel.state.read;
  if (currentUserId) {
    delete readList[currentUserId];
  }
```

This causes problems in case of using `channel.lastRead()` function after posting new message. Because `this.state.read[userID]` is set undefined after calling `getLatestMessageReadStatus`.

https://github.com/GetStream/stream-chat-js/blob/master/src/channel.ts#L901

To prevent this, how about copying object to avoid manipulating state directly?

## 🎨 UI Changes

Nothing changed.

## 🧪 Testing

- `channel.lastRead()` does not return null after posting new message.

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


