### PR TITLE
Make `imageGalleryGridHandleHeight` optional in `OverlayContext`

### DIFF
--- a/package/src/contexts/overlayContext/OverlayContext.tsx
+++ b/package/src/contexts/overlayContext/OverlayContext.tsx
@@ -59,7 +59,6 @@ export type OverlayProviderProps<
       | 'OverlayReactionsAvatar'
     >
   > & {
-    imageGalleryGridHandleHeight: number;
     autoPlayVideo?: boolean;
     /**
      * The giphy version to render - check the keys of the [Image Object](https://developers.giphy.com/docs/api/schema#image-object) for possible values. Uses 'fixed_height' by default
@@ -69,6 +68,7 @@ export type OverlayProviderProps<
     giphyVersion?: keyof NonNullable<Attachment['giphy']>;
     /** https://github.com/GetStream/stream-chat-react-native/wiki/Internationalization-(i18n) */
     i18nInstance?: Streami18n;
+    imageGalleryGridHandleHeight?: number;
     imageGalleryGridSnapPoints?: [string | number, string | number];
     isMyMessage?: boolean;
     isThreadMessage?: boolean;


### PR DESCRIPTION
## 🎯 Goal

The [documentation](https://getstream.io/chat/docs/sdk/reactnative/core-components/overlay-provider/#imagegallerygridhandleheight) says that this is an optional field with a default value. I noticed [a recent change](https://github.com/GetStream/stream-chat-react-native/pull/2490) made this a required parameter despite still having a default value. This change makes the field optional in the type again.

## 🛠 Implementation details

Adds `?` to type param to allow undefined again.

## 🎨 UI Changes

None

## 🧪 Testing

This is a type-only change. I tested by making the change to my local node_modules and verified that I no longer get a TypeScript error when not specifying the `imageGalleryGridHandleHeight` parameter in the `OverlayContext` component.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated (docs already state this field as optional with default)
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


