### PR TITLE
fix: incorrect mentioned users regex users with same prefix

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -61,12 +61,9 @@ const defaultMarkdownStyles: MarkdownStyle = {
   },
 };
 
-const mentionsParseFunction: ParseFunction = (capture, parse, state) => {
-  console.log(capture, parse, state);
-  return {
-    content: parseInline(parse, capture[0], state),
-  };
-};
+const mentionsParseFunction: ParseFunction = (capture, parse, state) => ({
+  content: parseInline(parse, capture[0], state),
+});
 
 export type MarkdownRules = Partial<DefaultRules>;
 


### PR DESCRIPTION
## 🎯 Goal

Fixes #2505

![simulator_screenshot_13228E9F-C0C3-4606-9870-76D307CA5967](https://github.com/GetStream/stream-chat-react-native/assets/39884168/74684fb5-decf-4cbd-9d66-3793e4548902)

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


