### PR TITLE
fix: Stream chat fix http no such file

### DIFF
--- a/package/src/components/MessageInput/hooks/useAudioController.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioController.tsx
@@ -245,7 +245,7 @@ export const useAudioController = () => {
 
     const resampledWaveformData = resampleWaveformData(waveformData, 100);
 
-    const clearFilter = new RegExp("[.:]", 'g')
+    const clearFilter = new RegExp('[.:]', 'g');
     const date = new Date().toISOString().replace(clearFilter, '_');
 
     const file: File = {

--- a/package/src/components/MessageInput/hooks/useAudioController.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioController.tsx
@@ -245,7 +245,7 @@ export const useAudioController = () => {
 
     const resampledWaveformData = resampleWaveformData(waveformData, 100);
 
-    const date = new new Date().toISOString().replace(/[\.\:]/g, '_');
+    const date = new Date().toISOString().replace(/[\.\:]/g, '_');
 
     const file: File = {
       duration: durationInSeconds,

--- a/package/src/components/MessageInput/hooks/useAudioController.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioController.tsx
@@ -245,7 +245,8 @@ export const useAudioController = () => {
 
     const resampledWaveformData = resampleWaveformData(waveformData, 100);
 
-    const date = new Date().toISOString().replace(/[\.\:]/g, '_');
+    const clearFilter = new RegExp("[.:]", 'g')
+    const date = new Date().toISOString().replace(clearFilter, '_');
 
     const file: File = {
       duration: durationInSeconds,

--- a/package/src/components/MessageInput/hooks/useAudioController.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioController.tsx
@@ -245,10 +245,12 @@ export const useAudioController = () => {
 
     const resampledWaveformData = resampleWaveformData(waveformData, 100);
 
+    const date = new new Date().toISOString().replace(/[\.\:]/g, '_');
+
     const file: File = {
       duration: durationInSeconds,
       mimeType: 'audio/aac',
-      name: `audio_recording_${new Date().toISOString()}.aac`,
+      name: `audio_recording_${date}.aac`,
       type: 'voiceRecording',
       uri: typeof recording !== 'string' ? (recording?.getURI() as string) : (recording as string),
       waveform_data: resampledWaveformData,


### PR DESCRIPTION
## 🎯 Goal

Fix issue when upload audio in android.
IOS ??

## 🛠 Implementation details

Replace : and . in sample name audio record

## 🧪 Testing

### Replicate error
Create a new React Native project
Follow steps in getStream page for RN
Add .aac and mime audio/aac en Overview Panel
Enable audioRecording in the chat
Try to send audio
Audio upload file
See logs in GetStream Board: http: no such file. status 400



