### PR TITLE
fix: change quotedMessage type to MessageType or undefined

### DIFF
--- a/docusaurus/docs/reactnative/common-content/contexts/message-input-context/editing.mdx
+++ b/docusaurus/docs/reactnative/common-content/contexts/message-input-context/editing.mdx
@@ -2,4 +2,4 @@ Defined with message type if the user is editing some message within `MessageInp
 
 | Type    |
 | ------- |
-| Boolean |
+| `Message`\| `undefined` |

--- a/docusaurus/docs/reactnative/common-content/contexts/message-input-context/editing.mdx
+++ b/docusaurus/docs/reactnative/common-content/contexts/message-input-context/editing.mdx
@@ -1,5 +1,5 @@
 Defined with message type if the user is editing some message within `MessageInput` component else its undefined.
 
-| Type    |
-| ------- |
+| Type                    |
+| ----------------------- |
 | `Message`\| `undefined` |

--- a/docusaurus/docs/reactnative/common-content/contexts/message-input-context/quoted_message.mdx
+++ b/docusaurus/docs/reactnative/common-content/contexts/message-input-context/quoted_message.mdx
@@ -2,4 +2,4 @@ Message that is quoted to the original message
 
 | Type                        |
 | --------------------------- |
-| `Boolean` \| `Message` type |
+| `Message`\| `undefined` |

--- a/docusaurus/docs/reactnative/common-content/contexts/message-input-context/quoted_message.mdx
+++ b/docusaurus/docs/reactnative/common-content/contexts/message-input-context/quoted_message.mdx
@@ -1,5 +1,5 @@
 Message that is quoted to the original message
 
-| Type                        |
-| --------------------------- |
+| Type                    |
+| ----------------------- |
 | `Message`\| `undefined` |

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -603,8 +603,8 @@ const ChannelWithContext = <
   const [loadingMore, setLoadingMore] = useState(false);
 
   const [loadingMoreRecent, setLoadingMoreRecent] = useState(false);
-  const [quotedMessage, setQuotedMessage] = useState<boolean | MessageType<StreamChatGenerics>>(
-    false,
+  const [quotedMessage, setQuotedMessage] = useState<MessageType<StreamChatGenerics> | undefined>(
+    undefined,
   );
   const [thread, setThread] = useState<ThreadContextValue<StreamChatGenerics>['thread']>(
     threadProps || null,
@@ -1940,7 +1940,7 @@ const ChannelWithContext = <
     () => setEditing(undefined);
 
   const clearQuotedMessageState: InputMessageInputContextValue<StreamChatGenerics>['clearQuotedMessageState'] =
-    () => setQuotedMessage(false);
+    () => setQuotedMessage(undefined);
 
   /**
    * Removes the message from local state

--- a/package/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
+++ b/package/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
@@ -67,12 +67,8 @@ export const useCreateInputMessageInputContext = <
    */
   channelId?: string;
 }) => {
-  const editingDep = typeof editing === 'boolean' ? editing : editing?.id;
-  const quotedMessageId = quotedMessage
-    ? typeof quotedMessage === 'boolean'
-      ? ''
-      : quotedMessage.id
-    : '';
+  const editingDep = editing ? editing.id : '';
+  const quotedMessageId = quotedMessage ? quotedMessage.id : '';
 
   const inputMessageInputContext: InputMessageInputContextValue<StreamChatGenerics> = useMemo(
     () => ({

--- a/package/src/components/Message/MessageSimple/MessageAvatar.tsx
+++ b/package/src/components/Message/MessageSimple/MessageAvatar.tsx
@@ -92,6 +92,7 @@ export const MessageAvatar = <
   const { alignment, lastGroupMessage, message, showAvatar } =
     useMessageContext<StreamChatGenerics>();
   const { ImageComponent } = useChatContext<StreamChatGenerics>();
+
   return (
     <MemoizedMessageAvatar
       {...{

--- a/package/src/components/Reply/Reply.tsx
+++ b/package/src/components/Reply/Reply.tsx
@@ -167,14 +167,14 @@ const ReplyWithContext = <
     },
   } = useTheme();
 
-  const messageText = typeof quotedMessage === 'boolean' ? '' : quotedMessage.text || '';
+  const messageText = quotedMessage ? quotedMessage.text : '';
 
   const emojiOnlyText = useMemo(() => {
     if (!messageText) return false;
     return hasOnlyEmojis(messageText);
   }, [messageText]);
 
-  if (typeof quotedMessage === 'boolean') return null;
+  if (!quotedMessage) return null;
 
   const lastAttachment = quotedMessage.attachments?.slice(-1)[0] as Attachment<StreamChatGenerics>;
   const messageType = lastAttachment && getMessageType(lastAttachment);

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -329,7 +329,6 @@ export type InputMessageInputContextValue<
   MoreOptionsButton: React.ComponentType<MoreOptionsButtonProps<StreamChatGenerics>>;
   /** Limit on the number of lines in the text input before scrolling */
   numberOfLines: number;
-  quotedMessage: boolean | MessageType<StreamChatGenerics>;
   /**
    * Custom UI component for send button.
    *
@@ -455,6 +454,7 @@ export type InputMessageInputContextValue<
    * Callback that is called when the text input's text changes. Changed text is passed as a single string argument to the callback handler.
    */
   onChangeText?: (newText: string) => void;
+  quotedMessage?: MessageType<StreamChatGenerics>;
   SendMessageDisallowedIndicator?: React.ComponentType;
   /**
    * ref for input setter function
@@ -915,8 +915,7 @@ export const MessageInputProvider = <
           mentioned_users: uniq(mentionedUsers),
           /** Parent message id - in case of thread */
           parent_id: thread?.id,
-          quoted_message_id:
-            typeof value.quotedMessage === 'boolean' ? undefined : value.quotedMessage.id,
+          quoted_message_id: value.quotedMessage ? value.quotedMessage.id : undefined,
           show_in_channel: sendThreadMessageInChannel || undefined,
           text: prevText,
           ...customMessageData,
@@ -956,8 +955,7 @@ export const MessageInputProvider = <
           attachments,
           mentioned_users: [],
           parent_id: thread?.id,
-          quoted_message_id:
-            typeof value.quotedMessage === 'boolean' ? undefined : value.quotedMessage.id,
+          quoted_message_id: value.quotedMessage ? value.quotedMessage.id : undefined,
           show_in_channel: sendThreadMessageInChannel || undefined,
           text: '',
         } as unknown as Partial<StreamMessage<StreamChatGenerics>>);

--- a/package/src/contexts/messageInputContext/hooks/useCreateMessageInputContext.ts
+++ b/package/src/contexts/messageInputContext/hooks/useCreateMessageInputContext.ts
@@ -117,11 +117,7 @@ export const useCreateMessageInputContext = <
   const imageUploadsValue = imageUploads.map(({ state }) => state).join();
   const asyncUploadsValue = Object.keys(asyncUploads).join();
   const mentionedUsersLength = mentionedUsers.length;
-  const quotedMessageId = quotedMessage
-    ? typeof quotedMessage === 'boolean'
-      ? ''
-      : quotedMessage.id
-    : '';
+  const quotedMessageId = quotedMessage ? quotedMessage.id : '';
   const threadId = thread?.id;
   const asyncIdsLength = asyncIds.length;
 

--- a/package/src/contexts/messagesContext/MessagesContext.tsx
+++ b/package/src/contexts/messagesContext/MessagesContext.tsx
@@ -243,7 +243,7 @@ export type MessagesContextValue<
   ScrollToBottomButton: React.ComponentType<ScrollToBottomButtonProps>;
   sendReaction: (type: string, messageId: string) => Promise<void>;
   setEditingState: (message?: MessageType<StreamChatGenerics>) => void;
-  setQuotedMessageState: (message: MessageType<StreamChatGenerics> | boolean) => void;
+  setQuotedMessageState: (message?: MessageType<StreamChatGenerics>) => void;
   supportedReactions: ReactionData[];
   /**
    * UI component for TypingIndicator


### PR DESCRIPTION
## 🎯 Goal

Change quoted message state from `boolean | message type` to `message type | undefined` to improve code.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


