### PR TITLE
fix: add back formattedDate prop to MessageFooter

### DIFF
--- a/package/src/components/Message/MessageSimple/MessageFooter.tsx
+++ b/package/src/components/Message/MessageSimple/MessageFooter.tsx
@@ -28,6 +28,7 @@ import type { MessageType } from '../../MessageList/hooks/useMessageList';
 
 type MessageFooterComponentProps = {
   date?: string | Date;
+  formattedDate?: string | Date;
   isDeleted?: boolean;
 };
 
@@ -89,6 +90,7 @@ const MessageFooterWithContext = <
     alignment,
     date,
     deletedMessagesVisibilityType,
+    formattedDate,
     isDeleted,
     isEditedMessageOpen,
     lastGroupMessage,
@@ -116,7 +118,7 @@ const MessageFooterWithContext = <
         {deletedMessagesVisibilityType === 'sender' && (
           <OnlyVisibleToYouComponent alignment={alignment} />
         )}
-        <MessageTimestamp format='LT' timestamp={date} />
+        <MessageTimestamp format='LT' formattedDate={formattedDate} timestamp={date} />
       </View>
     );
   }
@@ -135,7 +137,7 @@ const MessageFooterWithContext = <
           <Text style={[styles.text, { color: grey }, messageUser]}>{message.user.name}</Text>
         ) : null}
         {showMessageStatus && <MessageStatus />}
-        <MessageTimestamp format='LT' timestamp={date} />
+        <MessageTimestamp format='LT' formattedDate={formattedDate} timestamp={date} />
 
         {isEditedMessage(message) && !isEditedMessageOpen && (
           <>
@@ -157,7 +159,9 @@ const MessageFooterWithContext = <
           </>
         )}
       </View>
-      {isEditedMessageOpen && <MessageEditedTimestamp format='LT' timestamp={date} />}
+      {isEditedMessageOpen && (
+        <MessageEditedTimestamp format='LT' formattedDate={formattedDate} timestamp={date} />
+      )}
     </>
   );
 };
@@ -169,6 +173,7 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
   const {
     alignment: prevAlignment,
     date: prevDate,
+    formattedDate: prevFormattedDate,
     isEditedMessageOpen: prevIsEditedMessageOpen,
     lastGroupMessage: prevLastGroupMessage,
     members: prevMembers,
@@ -179,6 +184,7 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
   const {
     alignment: nextAlignment,
     date: nextDate,
+    formattedDate: nextFormattedDate,
     isEditedMessageOpen: nextIsEditedMessageOpen,
     lastGroupMessage: nextLastGroupMessage,
     members: nextMembers,
@@ -225,6 +231,9 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
 
   const dateEqual = prevDate === nextDate;
   if (!dateEqual) return false;
+
+  const formattedDateEqual = prevFormattedDate === nextFormattedDate;
+  if (!formattedDateEqual) return false;
 
   return true;
 };

--- a/package/src/components/Message/MessageSimple/MessageTimestamp.tsx
+++ b/package/src/components/Message/MessageSimple/MessageTimestamp.tsx
@@ -23,13 +23,25 @@ export type MessageTimestampProps = Partial<Pick<TranslationContextValue, 'tDate
    */
   formatDate?: (date: TDateTimeParserInput) => string;
   /**
+   * Already Formatted date
+   */
+  formattedDate?: string | Date;
+  /**
    * The timestamp of the message.
    */
   timestamp?: string | Date;
 };
 
 export const MessageTimestamp = (props: MessageTimestampProps) => {
-  const { calendar, format, formatDate, tDateTimeParser: propsTDateTimeParser, timestamp } = props;
+  const {
+    calendar,
+    format,
+    formatDate,
+    formattedDate,
+    tDateTimeParser: propsTDateTimeParser,
+    timestamp,
+  } = props;
+
   const {
     theme: {
       colors: { grey },
@@ -40,9 +52,15 @@ export const MessageTimestamp = (props: MessageTimestampProps) => {
   } = useTheme();
   const { tDateTimeParser: contextTDateTimeParser } = useTranslationContext();
 
+  if (formattedDate) {
+    return (
+      <Text style={[styles.text, { color: grey }, timestampText]}>{formattedDate.toString()}</Text>
+    );
+  }
+
   if (!timestamp) return null;
 
-  const formattedDate = getDateString({
+  const dateString = getDateString({
     calendar,
     date: timestamp,
     format,
@@ -50,11 +68,9 @@ export const MessageTimestamp = (props: MessageTimestampProps) => {
     tDateTimeParser: propsTDateTimeParser || contextTDateTimeParser,
   });
 
-  if (!formattedDate) return null;
+  if (!dateString) return null;
 
-  return (
-    <Text style={[styles.text, { color: grey }, timestampText]}>{formattedDate.toString()}</Text>
-  );
+  return <Text style={[styles.text, { color: grey }, timestampText]}>{dateString.toString()}</Text>;
 };
 
 const styles = StyleSheet.create({

--- a/package/src/utils/getDateString.ts
+++ b/package/src/utils/getDateString.ts
@@ -39,7 +39,7 @@ export function getDateString({
   format,
   formatDate,
   tDateTimeParser,
-}: DateFormatterOptions): string | Date | undefined {
+}: DateFormatterOptions): string | number | undefined {
   if (!date || (typeof date === 'string' && !Date.parse(date))) {
     return;
   }

--- a/package/src/utils/getDateString.ts
+++ b/package/src/utils/getDateString.ts
@@ -39,9 +39,9 @@ export function getDateString({
   format,
   formatDate,
   tDateTimeParser,
-}: DateFormatterOptions): string | number | null {
+}: DateFormatterOptions): string | Date | undefined {
   if (!date || (typeof date === 'string' && !Date.parse(date))) {
-    return null;
+    return;
   }
 
   if (typeof formatDate === 'function') {
@@ -50,7 +50,7 @@ export function getDateString({
 
   if (!tDateTimeParser) {
     console.log(noParsingFunctionWarning);
-    return null;
+    return;
   }
 
   const parsedTime = tDateTimeParser(date);


### PR DESCRIPTION
## 🎯 Goal

We mistakenly removed the `formattedDate` prop from the `MessageFooter` component and introduced a `date` prop in #2514. In this PR, we add back the prop and allow both modes of data passing in the component.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


