### PR TITLE
fix: store message_text_updated_at field in the offline DB

### DIFF
--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -58,6 +58,7 @@ exports[`Thread should match thread snapshot 1`] = `
               ],
               "html": "<p>regular</p>",
               "id": "38ef6f7c-3090-5759-a37f-ab0053aadb96",
+              "message_text_updated_at": "2020-05-05T14:50:00.000Z",
               "parent_id": "b4612a73-fa2b-5787-bf71-1adc8f291a04",
               "pinned_at": null,
               "readBy": false,
@@ -86,6 +87,7 @@ exports[`Thread should match thread snapshot 1`] = `
               ],
               "html": "<p>regular</p>",
               "id": "516efa25-5d29-5c9a-ad2d-4cc183e785bd",
+              "message_text_updated_at": "2020-05-05T14:50:00.000Z",
               "parent_id": "b4612a73-fa2b-5787-bf71-1adc8f291a04",
               "pinned_at": null,
               "readBy": false,
@@ -114,6 +116,7 @@ exports[`Thread should match thread snapshot 1`] = `
               ],
               "html": "<p>regular</p>",
               "id": "82a83b16-b611-527c-b3ac-765ef6220490",
+              "message_text_updated_at": "2020-05-05T14:50:00.000Z",
               "parent_id": "b4612a73-fa2b-5787-bf71-1adc8f291a04",
               "pinned_at": null,
               "readBy": false,
@@ -490,6 +493,40 @@ exports[`Thread should match thread snapshot 1`] = `
                           >
                             2:50 PM
                           </Text>
+                          <Text
+                            style={
+                              [
+                                {
+                                  "paddingHorizontal": 4,
+                                },
+                                {
+                                  "color": "#7A7A7A",
+                                  "textAlign": "left",
+                                },
+                                {
+                                  "fontSize": 12,
+                                },
+                              ]
+                            }
+                          >
+                            ⦁
+                          </Text>
+                          <Text
+                            style={
+                              [
+                                {
+                                  "fontSize": 12,
+                                },
+                                {
+                                  "color": "#7A7A7A",
+                                  "textAlign": "left",
+                                },
+                                {},
+                              ]
+                            }
+                          >
+                            Edited
+                          </Text>
                         </View>
                       </View>
                     </View>
@@ -770,6 +807,40 @@ exports[`Thread should match thread snapshot 1`] = `
                           >
                             2:50 PM
                           </Text>
+                          <Text
+                            style={
+                              [
+                                {
+                                  "paddingHorizontal": 4,
+                                },
+                                {
+                                  "color": "#7A7A7A",
+                                  "textAlign": "left",
+                                },
+                                {
+                                  "fontSize": 12,
+                                },
+                              ]
+                            }
+                          >
+                            ⦁
+                          </Text>
+                          <Text
+                            style={
+                              [
+                                {
+                                  "fontSize": 12,
+                                },
+                                {
+                                  "color": "#7A7A7A",
+                                  "textAlign": "left",
+                                },
+                                {},
+                              ]
+                            }
+                          >
+                            Edited
+                          </Text>
                         </View>
                       </View>
                     </View>
@@ -1049,6 +1120,40 @@ exports[`Thread should match thread snapshot 1`] = `
                             }
                           >
                             2:50 PM
+                          </Text>
+                          <Text
+                            style={
+                              [
+                                {
+                                  "paddingHorizontal": 4,
+                                },
+                                {
+                                  "color": "#7A7A7A",
+                                  "textAlign": "left",
+                                },
+                                {
+                                  "fontSize": 12,
+                                },
+                              ]
+                            }
+                          >
+                            ⦁
+                          </Text>
+                          <Text
+                            style={
+                              [
+                                {
+                                  "fontSize": 12,
+                                },
+                                {
+                                  "color": "#7A7A7A",
+                                  "textAlign": "left",
+                                },
+                                {},
+                              ]
+                            }
+                          >
+                            Edited
                           </Text>
                         </View>
                       </View>
@@ -1369,6 +1474,40 @@ exports[`Thread should match thread snapshot 1`] = `
                                 }
                               >
                                 2:50 PM
+                              </Text>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "paddingHorizontal": 4,
+                                    },
+                                    {
+                                      "color": "#7A7A7A",
+                                      "textAlign": "left",
+                                    },
+                                    {
+                                      "fontSize": 12,
+                                    },
+                                  ]
+                                }
+                              >
+                                ⦁
+                              </Text>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "fontSize": 12,
+                                    },
+                                    {
+                                      "color": "#7A7A7A",
+                                      "textAlign": "left",
+                                    },
+                                    {},
+                                  ]
+                                }
+                              >
+                                Edited
                               </Text>
                             </View>
                           </View>

--- a/package/src/mock-builders/generator/message.js
+++ b/package/src/mock-builders/generator/message.js
@@ -11,6 +11,7 @@ export const generateMessage = (options = {}) => {
     created_at: timestamp,
     html: '<p>regular</p>',
     id: uuidv4(),
+    message_text_updated_at: timestamp,
     text: uuidv4(),
     type: 'regular',
     updated_at: timestamp.toString(),
@@ -24,6 +25,7 @@ export const generateStaticMessage = (seed, options, date) =>
   generateMessage({
     created_at: date || '2020-04-27T13:39:49.331742Z',
     id: uuidv5(seed, StreamReactNativeNamespace),
+    message_text_updated_at: date || '2020-04-27T13:39:49.331742Z',
     text: seed,
     updated_at: date || '2020-04-27T13:39:49.331742Z',
     ...options,

--- a/package/src/store/QuickSqliteClient.ts
+++ b/package/src/store/QuickSqliteClient.ts
@@ -30,7 +30,7 @@ import type { PreparedQueries, Table } from './types';
  *
  */
 export class QuickSqliteClient {
-  static dbVersion = 4;
+  static dbVersion = 5;
 
   static dbName = DB_NAME;
   static dbLocation = DB_LOCATION;

--- a/package/src/store/mappers/mapMessageToStorable.ts
+++ b/package/src/store/mappers/mapMessageToStorable.ts
@@ -15,6 +15,7 @@ export const mapMessageToStorable = (
     id,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     latest_reactions,
+    message_text_updated_at,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     own_reactions,
     reaction_groups,
@@ -32,6 +33,7 @@ export const mapMessageToStorable = (
     deletedAt: mapDateTimeToStorable(deleted_at),
     extraData: JSON.stringify(extraData),
     id,
+    messageTextUpdatedAt: mapDateTimeToStorable(message_text_updated_at),
     reactionGroups: JSON.stringify(reaction_groups),
     text,
     type,

--- a/package/src/store/mappers/mapStorableToMessage.ts
+++ b/package/src/store/mappers/mapStorableToMessage.ts
@@ -19,7 +19,16 @@ export const mapStorableToMessage = <
   messageRow: TableRowJoinedUser<'messages'>;
   reactionRows: TableRowJoinedUser<'reactions'>[];
 }): MessageResponse<StreamChatGenerics> => {
-  const { createdAt, deletedAt, extraData, reactionGroups, updatedAt, user, ...rest } = messageRow;
+  const {
+    createdAt,
+    deletedAt,
+    extraData,
+    messageTextUpdatedAt,
+    reactionGroups,
+    updatedAt,
+    user,
+    ...rest
+  } = messageRow;
   const latestReactions =
     reactionRows?.map((reaction) => mapStorableToReaction<StreamChatGenerics>(reaction)) || [];
 
@@ -31,6 +40,7 @@ export const mapStorableToMessage = <
     created_at: createdAt,
     deleted_at: deletedAt,
     latest_reactions: latestReactions,
+    message_text_updated_at: messageTextUpdatedAt,
     own_reactions: ownReactions,
     reaction_groups: reactionGroups ? JSON.parse(reactionGroups) : {},
     updated_at: updatedAt,

--- a/package/src/store/schema.ts
+++ b/package/src/store/schema.ts
@@ -102,6 +102,7 @@ export const tables: Tables = {
       deletedAt: 'TEXT',
       extraData: 'TEXT',
       id: 'TEXT',
+      messageTextUpdatedAt: 'TEXT',
       reactionGroups: 'TEXT',
       text: "TEXT DEFAULT ''",
       type: 'TEXT',
@@ -262,6 +263,7 @@ export type Schema = {
     deletedAt: string;
     extraData: string;
     id: string;
+    messageTextUpdatedAt: string;
     reactionGroups: string;
     type: MessageLabel;
     updatedAt: string;

--- a/package/src/utils/removeReservedFields.ts
+++ b/package/src/utils/removeReservedFields.ts
@@ -22,6 +22,7 @@ export const removeReservedFields = <
     'reaction_groups',
     'last_message_at',
     'member_count',
+    'message_text_updated_at',
     'type',
     'updated_at',
     'reply_count',


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


