### PR TITLE
fix: add borderRadius theme property for Gallery image

### DIFF
--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -289,7 +289,7 @@ const GalleryThumbnail = <
     theme: {
       colors: { overlay },
       messageSimple: {
-        gallery: { image, imageContainer, moreImagesContainer, moreImagesText },
+        gallery: { image, imageBorderRadius, imageContainer, moreImagesContainer, moreImagesText },
       },
     },
   } = useTheme();
@@ -366,7 +366,7 @@ const GalleryThumbnail = <
       {thumbnail.type === 'video' ? (
         <VideoThumbnail
           style={[
-            borderRadius,
+            imageBorderRadius ?? borderRadius,
             {
               height: thumbnail.height - 1,
               width: thumbnail.width - 1,
@@ -378,7 +378,7 @@ const GalleryThumbnail = <
       ) : (
         <View style={styles.imageContainerStyle}>
           <GalleryImageThumbnail
-            borderRadius={borderRadius}
+            borderRadius={imageBorderRadius ?? borderRadius}
             ImageLoadingFailedIndicator={ImageLoadingFailedIndicator}
             ImageLoadingIndicator={ImageLoadingIndicator}
             thumbnail={thumbnail}

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -499,6 +499,12 @@ export type Theme = {
       moreImagesContainer: ViewStyle;
       moreImagesText: TextStyle;
       thumbnail: ViewStyle;
+      imageBorderRadius?: {
+        borderBottomLeftRadius: number;
+        borderBottomRightRadius: number;
+        borderTopLeftRadius: number;
+        borderTopRightRadius: number;
+      };
     };
     giphy: {
       buttonContainer: ViewStyle;
@@ -1079,6 +1085,7 @@ export const defaultTheme: Theme = {
       gridHeight: 195,
       gridWidth: 256,
       image: {},
+      imageBorderRadius: undefined,
       imageContainer: {},
       maxHeight: 300,
       maxWidth: 256,


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


