### PR TITLE
fix: channel preview update on new message when coming from BG to FG

### DIFF
--- a/package/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreview.tsx
@@ -42,7 +42,7 @@ const ChannelPreviewWithContext = <
   const [forceUpdate, setForceUpdate] = useState(0);
   const [unread, setUnread] = useState(channel.countUnread());
 
-  const latestMessagePreview = useLatestMessagePreview(channel, forceUpdate);
+  const latestMessagePreview = useLatestMessagePreview(channel, forceUpdate, lastMessage);
 
   const channelLastMessage = channel.lastMessage();
   const channelLastMessageString = `${channelLastMessage?.id}${channelLastMessage?.updated_at}`;

--- a/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
+++ b/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
@@ -8,6 +8,7 @@ import { useTranslationContext } from '../../../contexts/translationContext/Tran
 
 import { useTranslatedMessage } from '../../../hooks/useTranslatedMessage';
 import type { DefaultStreamChatGenerics } from '../../../types/types';
+import { stringifyMessage } from '../../../utils/utils';
 
 type LatestMessage<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -218,18 +219,22 @@ export const useLatestMessagePreview = <
 >(
   channel: Channel<StreamChatGenerics>,
   forceUpdate: number,
+  lastMessage?:
+    | ReturnType<ChannelState<StreamChatGenerics>['formatMessage']>
+    | MessageResponse<StreamChatGenerics>,
 ) => {
   const { client } = useChatContext<StreamChatGenerics>();
   const { t } = useTranslationContext();
 
   const channelConfigExists = typeof channel?.getConfig === 'function';
 
-  const messages = channel.state.messages;
-  const message = messages.length ? messages[messages.length - 1] : undefined;
+  const translatedLastMessage = useTranslatedMessage<StreamChatGenerics>(
+    lastMessage || ({} as MessageResponse<StreamChatGenerics>),
+  );
 
-  const translatedLastMessage = useTranslatedMessage<StreamChatGenerics>(message);
-
-  const channelLastMessageString = `${message?.id}${message?.updated_at}`;
+  const channelLastMessageString = translatedLastMessage
+    ? stringifyMessage(translatedLastMessage)
+    : '';
 
   const [readEvents, setReadEvents] = useState(true);
   const [latestMessagePreview, setLatestMessagePreview] = useState<

--- a/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
+++ b/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
@@ -228,9 +228,7 @@ export const useLatestMessagePreview = <
 
   const channelConfigExists = typeof channel?.getConfig === 'function';
 
-  const translatedLastMessage = useTranslatedMessage<StreamChatGenerics>(
-    lastMessage || ({} as MessageResponse<StreamChatGenerics>),
-  );
+  const translatedLastMessage = useTranslatedMessage<StreamChatGenerics>(lastMessage);
 
   const channelLastMessageString = translatedLastMessage
     ? stringifyMessage(translatedLastMessage)

--- a/package/src/utils/utils.ts
+++ b/package/src/utils/utils.ts
@@ -9,6 +9,7 @@ import type {
   ChannelMemberResponse,
   CommandResponse,
   FormatMessageResponse,
+  MessageResponse,
   StreamChat,
   UserResponse,
 } from 'stream-chat';
@@ -614,7 +615,10 @@ export const stringifyMessage = <
   text,
   type,
   updated_at,
-}: FormatMessageResponse<StreamChatGenerics> | MessageType<StreamChatGenerics>): string =>
+}:
+  | MessageResponse<StreamChatGenerics>
+  | FormatMessageResponse<StreamChatGenerics>
+  | MessageType<StreamChatGenerics>): string =>
   `${
     latest_reactions ? latest_reactions.map(({ type, user }) => `${type}${user?.id}`).join() : ''
   }${


### PR DESCRIPTION
## 🎯 Goal

Fixes #2583 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


