### PR TITLE
fix: Theme color overrides durationText

### DIFF
--- a/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
@@ -126,7 +126,7 @@ const AttachmentVideo = (props: AttachmentVideoProps) => {
         <View style={styles.videoView}>
           <Recorder height={20} pathFill={white} width={25} />
           {videoDuration ? (
-            <Text style={[styles.durationText, durationText, { color: white }]}>
+            <Text style={[{ color: white }, styles.durationText, durationText]}>
               {durationLabel}
             </Text>
           ) : null}


### PR DESCRIPTION
## 🎯 Goal

The `white` theme color was overriding the attachment picker video item's `durationText` `color` property. The latter should be prioritized because we should be able to set a different color than `white` for the `durationText`.

## 🛠 Implementation details

Fixed the order of styles in the `<Text />` component inside `<AttachmentVideo />`

## 🎨 UI Changes

N/A

## 🧪 Testing

N/A

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


