### PR TITLE
chore: enable rules of hooks for RN chat SDK

### DIFF
--- a/package/.eslintrc.json
+++ b/package/.eslintrc.json
@@ -148,7 +148,7 @@
         "@typescript-eslint/ban-ts-comment": 0,
         "@typescript-eslint/no-unused-vars": 1,
         "@typescript-eslint/no-var-requires": 0,
-        "react-hooks/exhaustive-deps": 0,
+        "react-hooks/exhaustive-deps": 1,
         "react-native/no-inline-styles": 0,
         "array-callback-return": 2,
         "arrow-body-style": 2,

--- a/package/src/components/Attachment/AudioAttachment.tsx
+++ b/package/src/components/Attachment/AudioAttachment.tsx
@@ -155,6 +155,7 @@ export const AudioAttachment = (props: AudioAttachmentProps) => {
         soundRef.current.unloadAsync();
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // This is needed for expo applications where the rerender doesn't occur on time thefore you need to update the state of the sound.

--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -141,6 +141,7 @@ const GalleryWithContext = <
         images: imagesAndVideos,
         sizeConfig,
       }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [imagesAndVideosValue],
   );
 

--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -137,6 +137,7 @@ export const AttachmentPicker = React.forwardRef(
         }
         setLoadingPhotos(false);
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentIndex, selectedPicker, loadingPhotos]);
 
     // we need to use ref here to avoid running effect when getMorePhotos changes
@@ -172,6 +173,7 @@ export const AttachmentPicker = React.forwardRef(
       const backHandler = BackHandler.addEventListener('hardwareBackPress', backAction);
 
       return () => backHandler.remove();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedPicker, closePicker]);
 
     useEffect(() => {
@@ -196,6 +198,7 @@ export const AttachmentPicker = React.forwardRef(
           Keyboard.removeListener(keyboardShowEvent, onKeyboardOpenHandler);
         }
       };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [closePicker, selectedPicker]);
 
     useEffect(() => {
@@ -208,6 +211,7 @@ export const AttachmentPicker = React.forwardRef(
           setPhotoError(false);
         }
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentIndex, loadingPhotos]);
 
     useEffect(() => {

--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -129,6 +129,7 @@ const AutoCompleteInputWithContext = <
 
   useEffect(() => {
     handleChange(text, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [text]);
 
   const startTracking = (trigger: Trigger) => {

--- a/package/src/components/AutoCompleteInput/AutoCompleteSuggestionList.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteSuggestionList.tsx
@@ -95,6 +95,7 @@ export const AutoCompleteSuggestionListWithContext = <
     return triggerType === 'emoji' || triggerType === 'command'
       ? totalItemHeight + AUTO_COMPLETE_SUGGESTION_LIST_HEADER_HEIGHT
       : totalItemHeight;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [itemHeight, data.length]);
 
   const renderItem = ({ item }: { item: Suggestion<StreamChatGenerics> }) => {

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -677,6 +677,7 @@ const ChannelWithContext = <
       loadMoreFinished.cancel();
       loadMoreThreadFinished.cancel();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelId, messageId]);
 
   const threadPropsExists = !!threadProps;
@@ -690,6 +691,7 @@ const ChannelWithContext = <
     } else {
       setThread(null);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadPropsExists, shouldSyncChannel]);
 
   const handleAppBackground = useCallback(() => {
@@ -702,6 +704,7 @@ const ChannelWithContext = <
         type: 'typing.stop',
       } as StreamEvent<StreamChatGenerics>);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [thread?.id, channelId]);
 
   useAppStateListener(undefined, handleAppBackground);
@@ -806,6 +809,7 @@ const ChannelWithContext = <
     return () => {
       channelSubscriptions.forEach((s) => s.unsubscribe());
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelId, shouldSyncChannel]);
 
   // subscribe to the generic all channel event
@@ -843,6 +847,7 @@ const ChannelWithContext = <
     };
     const { unsubscribe } = channel.on(handleEvent);
     return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelId, thread?.id, shouldSyncChannel]);
 
   // subscribe to channel.deleted event
@@ -854,6 +859,7 @@ const ChannelWithContext = <
     });
 
     return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelId]);
 
   useEffect(() => {
@@ -863,6 +869,7 @@ const ChannelWithContext = <
 
     const { unsubscribe } = client.on('notification.mark_read', handleEvent);
     return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const channelQueryCallRef = useRef(
@@ -1058,6 +1065,7 @@ const ChannelWithContext = <
       // now restart it since its done
       restartSetsMergeFuncRef.current();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [targetedMessage]);
 
   /**
@@ -1361,6 +1369,7 @@ const ChannelWithContext = <
     return () => {
       connectionChangedSubscription.unsubscribe();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enableOfflineSupport, shouldSyncChannel]);
 
   const reloadChannel = () =>
@@ -1825,6 +1834,7 @@ const ChannelWithContext = <
      * Where the deps are [channelId, hasMore, loadingMoreRecent, loadingMore]
      * and only those deps should be used here because of that
      */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [channelId, hasMore, loadingMore],
   );
 
@@ -1896,6 +1906,7 @@ const ChannelWithContext = <
      * Where the deps are [channelId, hasMore, loadingMoreRecent, loadingMore, hasNoMoreRecentMessagesToLoad]
      * and and only those deps should be used here because of that
      */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [channelId, hasNoMoreRecentMessagesToLoad],
   );
 
@@ -2086,6 +2097,7 @@ const ChannelWithContext = <
       setThread(message);
       setThreadMessages(newThreadMessages);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [setThread, setThreadMessages],
   );
 

--- a/package/src/components/Channel/hooks/useCreateChannelContext.ts
+++ b/package/src/components/Channel/hooks/useCreateChannelContext.ts
@@ -84,6 +84,7 @@ export const useCreateChannelContext = <
       watcherCount,
       watchers,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       channelId,
       disabled,

--- a/package/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
+++ b/package/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
@@ -133,6 +133,7 @@ export const useCreateInputMessageInputContext = <
       StartAudioRecordingButton,
       UploadProgressIndicator,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [compressImageQuality, channelId, editingDep, initialValue, maxMessageLength, quotedMessageId],
   );
 

--- a/package/src/components/Channel/hooks/useCreateMessagesContext.ts
+++ b/package/src/components/Channel/hooks/useCreateMessagesContext.ts
@@ -189,6 +189,7 @@ export const useCreateMessagesContext = <
       UrlPreview,
       VideoThumbnail,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       additionalTouchablePropsLength,
       channelId,

--- a/package/src/components/Channel/hooks/useCreateOwnCapabilitiesContext.ts
+++ b/package/src/components/Channel/hooks/useCreateOwnCapabilitiesContext.ts
@@ -41,6 +41,7 @@ export const useCreateOwnCapabilitiesContext = <
     return () => {
       listener.unsubscribe();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const ownCapabilitiesContext: OwnCapabilitiesContextValue = useMemo(() => {
@@ -56,6 +57,7 @@ export const useCreateOwnCapabilitiesContext = <
     );
 
     return ownCapabilitiesContext;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channel.id, overrideCapabilitiesStr, own_capabilities]);
 
   return ownCapabilitiesContext;

--- a/package/src/components/Channel/hooks/useCreatePaginatedMessageListContext.ts
+++ b/package/src/components/Channel/hooks/useCreatePaginatedMessageListContext.ts
@@ -34,6 +34,7 @@ export const useCreatePaginatedMessageListContext = <
       setLoadingMore,
       setLoadingMoreRecent,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       channelId,
       hasMore,

--- a/package/src/components/Channel/hooks/useCreateThreadContext.ts
+++ b/package/src/components/Channel/hooks/useCreateThreadContext.ts
@@ -36,6 +36,7 @@ export const useCreateThreadContext = <
       threadLoadingMore,
       threadMessages,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       allowThreadMessagesInChannel,
       threadHasMore,

--- a/package/src/components/Channel/hooks/useCreateTypingContext.ts
+++ b/package/src/components/Channel/hooks/useCreateTypingContext.ts
@@ -14,6 +14,7 @@ export const useCreateTypingContext = <
     () => ({
       typing,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [typingValue],
   );
 

--- a/package/src/components/ChannelList/ChannelList.tsx
+++ b/package/src/components/ChannelList/ChannelList.tsx
@@ -368,6 +368,7 @@ export const ChannelList = <
       filters,
       sort,
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelIdsStr, staticChannelsActive]);
 
   const channelsContext = useCreateChannelsContext({

--- a/package/src/components/ChannelList/Skeleton.tsx
+++ b/package/src/components/ChannelList/Skeleton.tsx
@@ -55,6 +55,7 @@ export const Skeleton = () => {
       }),
       -1,
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const animatedStyle = useAnimatedStyle(

--- a/package/src/components/ChannelList/hooks/listeners/useAddedToChannelNotification.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useAddedToChannelNotification.ts
@@ -44,5 +44,6 @@ export const useAddedToChannelNotification = <
 
     const listener = client?.on('notification.added_to_channel', handleEvent);
     return () => listener?.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/package/src/components/ChannelList/hooks/listeners/useChannelDeleted.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useChannelDeleted.ts
@@ -43,5 +43,6 @@ export const useChannelDeleted = <
 
     const listener = client?.on('channel.deleted', handleEvent);
     return () => listener?.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/package/src/components/ChannelList/hooks/listeners/useChannelHidden.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useChannelHidden.ts
@@ -44,5 +44,6 @@ export const useChannelHidden = <
 
     const listener = client?.on('channel.hidden', handleEvent);
     return () => listener?.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/package/src/components/ChannelList/hooks/listeners/useChannelTruncated.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useChannelTruncated.ts
@@ -38,5 +38,6 @@ export const useChannelTruncated = <
 
     const listener = client?.on('channel.truncated', handleEvent);
     return () => listener?.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/package/src/components/ChannelList/hooks/listeners/useChannelUpdated.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useChannelUpdated.ts
@@ -50,5 +50,6 @@ export const useChannelUpdated = <
 
     const listener = client?.on('channel.updated', handleEvent);
     return () => listener?.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/package/src/components/ChannelList/hooks/listeners/useChannelVisible.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useChannelVisible.ts
@@ -44,5 +44,6 @@ export const useChannelVisible = <
 
     const listener = client?.on('channel.visible', handleEvent);
     return () => listener?.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/package/src/components/ChannelList/hooks/listeners/useNewMessage.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useNewMessage.ts
@@ -57,5 +57,6 @@ export const useNewMessage = <
 
     const listener = client?.on('message.new', handleEvent);
     return () => listener?.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/package/src/components/ChannelList/hooks/listeners/useNewMessageNotification.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useNewMessageNotification.ts
@@ -54,5 +54,6 @@ export const useNewMessageNotification = <
 
     const listener = client?.on('notification.message_new', handleEvent);
     return () => listener?.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/package/src/components/ChannelList/hooks/listeners/useRemovedFromChannelNotification.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useRemovedFromChannelNotification.ts
@@ -39,5 +39,6 @@ export const useRemovedFromChannelNotification = <
 
     const listener = client?.on('notification.removed_from_channel', handleEvent);
     return () => listener?.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/package/src/components/ChannelList/hooks/listeners/useUserPresence.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useUserPresence.ts
@@ -43,5 +43,6 @@ export const useUserPresence = <
     return () => {
       listeners?.forEach((l) => l?.unsubscribe());
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/package/src/components/ChannelList/hooks/useCreateChannelsContext.ts
+++ b/package/src/components/ChannelList/hooks/useCreateChannelsContext.ts
@@ -80,6 +80,7 @@ export const useCreateChannelsContext = <
       setFlatListRef,
       Skeleton,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       channelValueString,
       error,

--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -249,6 +249,7 @@ export const usePaginatedChannels = <
     }
 
     return () => listener?.unsubscribe?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filterStr, sortStr]);
 
   return {

--- a/package/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreview.tsx
@@ -52,6 +52,7 @@ const ChannelPreviewWithContext = <
       setUnread(channel.countUnread());
     });
     return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -65,6 +66,7 @@ const ChannelPreviewWithContext = <
 
     const newUnreadCount = channel.countUnread();
     setUnread(newUnreadCount);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelLastMessageString, channelListForceUpdate]);
 
   useEffect(() => {
@@ -92,6 +94,7 @@ const ChannelPreviewWithContext = <
     ];
 
     return () => listeners.forEach((l) => l.unsubscribe());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -105,6 +108,7 @@ const ChannelPreviewWithContext = <
 
     const listener = channel.on('message.read', handleReadEvent);
     return () => listener.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return <Preview channel={channel} latestMessagePreview={latestMessagePreview} unread={unread} />;

--- a/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
@@ -143,6 +143,7 @@ const ChannelPreviewMessengerWithContext = <
 
     client.on('notification.channel_mutes_updated', handleEvent);
     return () => client.off('notification.channel_mutes_updated', handleEvent);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client]);
 
   return (

--- a/package/src/components/ChannelPreview/hooks/useChannelPreviewDisplayAvatar.ts
+++ b/package/src/components/ChannelPreview/hooks/useChannelPreviewDisplayAvatar.ts
@@ -72,6 +72,7 @@ export const useChannelPreviewDisplayAvatar = <
 
   useEffect(() => {
     setDisplayAvatar(getChannelPreviewDisplayAvatar(channel, client));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, image, name]);
 
   return displayAvatar;

--- a/package/src/components/ChannelPreview/hooks/useChannelPreviewDisplayName.ts
+++ b/package/src/components/ChannelPreview/hooks/useChannelPreviewDisplayName.ts
@@ -106,6 +106,7 @@ export const useChannelPreviewDisplayName = <
         members,
       }),
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelName, currentUserId, characterLimit, numOfMembers]);
 
   return displayName;

--- a/package/src/components/ChannelPreview/hooks/useChannelPreviewDisplayPresence.ts
+++ b/package/src/components/ChannelPreview/hooks/useChannelPreviewDisplayPresence.ts
@@ -48,6 +48,7 @@ export const useChannelPreviewDisplayPresence = <
 
   useEffect(() => {
     setDisplayPresence(getChannelPreviewDisplayPresence(channel, client));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelMemberOnline]);
 
   return displayPresence;

--- a/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
+++ b/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
@@ -258,6 +258,7 @@ export const useLatestMessagePreview = <
         setReadEvents(read_events);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelConfigExists]);
 
   useEffect(
@@ -271,6 +272,7 @@ export const useLatestMessagePreview = <
           t,
         }),
       ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [channelLastMessageString, forceUpdate, readEvents, readStatus],
   );
 

--- a/package/src/components/Chat/Chat.tsx
+++ b/package/src/components/Chat/Chat.tsx
@@ -197,6 +197,7 @@ const ChatWithContext = <
           data: client.user,
         });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, enableOfflineSupport]);
 
   const setActiveChannel = (newChannel?: Channel<StreamChatGenerics>) => setChannel(newChannel);
@@ -208,6 +209,7 @@ const ChatWithContext = <
       DBSyncManager.init(client as unknown as StreamChat);
       setInitialisedDatabaseConfig({ initialised: true, userID });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userID, enableOfflineSupport]);
 
   const initialisedDatabase =

--- a/package/src/components/Chat/hooks/useAppSettings.ts
+++ b/package/src/components/Chat/hooks/useAppSettings.ts
@@ -47,6 +47,7 @@ export const useAppSettings = <
     }
 
     enforeAppSettings();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, isOnline, initialisedDatabase]);
 
   return appSettings;

--- a/package/src/components/Chat/hooks/useCreateChatContext.ts
+++ b/package/src/components/Chat/hooks/useCreateChatContext.ts
@@ -38,6 +38,7 @@ export const useCreateChatContext = <
       resizableCDNHosts,
       setActiveChannel,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [appSettings, channelId, clientValues, connectionRecovering, isOnline, mutedUsersLength],
   );
 

--- a/package/src/components/Chat/hooks/useIsOnline.ts
+++ b/package/src/components/Chat/hooks/useIsOnline.ts
@@ -102,6 +102,7 @@ export const useIsOnline = <
       chatListeners.forEach((listener) => listener.unsubscribe?.());
       unsubscribeNetInfo?.();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clientExists]);
 
   return { connectionRecovering, isOnline };

--- a/package/src/components/Chat/hooks/useMutedUsers.ts
+++ b/package/src/components/Chat/hooks/useMutedUsers.ts
@@ -20,6 +20,7 @@ export const useMutedUsers = <
 
     const listener = client?.on('notification.mutes_updated', handleEvent);
     return () => listener?.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setMutedUsers]);
 
   return mutedUsers;

--- a/package/src/components/Chat/hooks/useSyncDatabase.ts
+++ b/package/src/components/Chat/hooks/useSyncDatabase.ts
@@ -28,5 +28,6 @@ export const useSyncDatabase = <
     return () => {
       listener?.unsubscribe();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, initialisedDatabase]);
 };

--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -160,6 +160,7 @@ export const ImageGallery = <
   const quarterScreenHeight = fullWindowHeight / 4;
   const snapPoints = React.useMemo(
     () => [(fullWindowHeight * 3) / 4, fullWindowHeight - imageGalleryGridHandleHeight],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 
@@ -193,6 +194,7 @@ export const ImageGallery = <
   useEffect(() => {
     Keyboard.dismiss();
     showScreen();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   /**
@@ -295,6 +297,7 @@ export const ImageGallery = <
 
   useEffect(() => {
     setImageGalleryAttachments(photos);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   /**
@@ -324,6 +327,7 @@ export const ImageGallery = <
     );
 
     runOnUI(updatePosition)(newIndex);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedMessage, photoLength]);
 
   /**
@@ -351,6 +355,7 @@ export const ImageGallery = <
         });
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uriForCurrentImage]);
 
   const { onDoubleTap, onPan, onPinch, onSingleTap } = useImageGalleryGestures({

--- a/package/src/components/ImageGallery/components/ImageGalleryOverlay.tsx
+++ b/package/src/components/ImageGallery/components/ImageGalleryOverlay.tsx
@@ -54,6 +54,7 @@ export const ImageGalleryOverlay = (props: Props) => {
       opacity.value = 0;
       setFadedIn(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentBottomSheetIndex]);
 
   const showOverlayStyle = useAnimatedStyle<ViewStyle>(

--- a/package/src/components/Indicators/LoadingDot.tsx
+++ b/package/src/components/Indicators/LoadingDot.tsx
@@ -42,6 +42,7 @@ export const LoadingDot = (props: Props) => {
         -1,
       ),
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const dotStyle = useAnimatedStyle<ViewStyle>(

--- a/package/src/components/KeyboardCompatibleView/KeyboardCompatibleViewFC.tsx
+++ b/package/src/components/KeyboardCompatibleView/KeyboardCompatibleViewFC.tsx
@@ -108,10 +108,12 @@ export const KeyboardCompatibleView = ({
 
       unsetKeyboardListeners();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     updateBottomIfNecessary();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [keyboardEvent.current]);
 
   const dismissKeyboard: () => Promise<void> | undefined = () => {

--- a/package/src/components/Message/hooks/useCreateMessageContext.ts
+++ b/package/src/components/Message/hooks/useCreateMessageContext.ts
@@ -100,6 +100,7 @@ export const useCreateMessageContext = <
       threadList,
       videos,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       actionsEnabled,
       quotedMessageDeletedValue,

--- a/package/src/components/Message/hooks/useProcessReactions.ts
+++ b/package/src/components/Message/hooks/useProcessReactions.ts
@@ -112,5 +112,6 @@ export const useProcessReactions = <
       hasReactions: unsortedReactions.length > 0,
       totalReactionCount: unsortedReactions.reduce((total, { count }) => total + count, 0),
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reaction_groups, own_reactions?.length, latest_reactions?.length, sortReactions]);
 };

--- a/package/src/components/MessageInput/FileUploadPreview.tsx
+++ b/package/src/components/MessageInput/FileUploadPreview.tsx
@@ -158,6 +158,7 @@ const FileUploadPreviewWithContext = <
         progress: 0,
       })),
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fileUploads.length]);
 
   // Handler triggered when an audio is loaded in the message input. The initial state is defined for the audio here and the duration is set.

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -268,6 +268,7 @@ const MessageInputWithContext = <
     setMaxNumberOfFiles(maxNumberOfFiles ?? 10);
 
     return closeAttachmentPicker;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const [hasResetImages, setHasResetImages] = useState(false);
@@ -288,6 +289,7 @@ const MessageInputWithContext = <
       imageUploads.forEach((image) => removeImage(image.id));
     }
     return () => setSelectedImages([]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   /**
@@ -300,24 +302,28 @@ const MessageInputWithContext = <
     }
 
     return () => setSelectedFiles([]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     if (hasResetImages === false && imageUploadsLength === 0 && selectedImagesLength === 0) {
       setHasResetImages(true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [imageUploadsLength, selectedImagesLength]);
 
   useEffect(() => {
     if (hasResetFiles === false && fileUploadsLength === 0 && selectedFilesLength === 0) {
       setHasResetFiles(true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fileUploadsLength, selectedFilesLength]);
 
   useEffect(() => {
     if (imagesForInput === false && imageUploadsLength) {
       imageUploads.forEach((image) => removeImage(image.id));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [imagesForInput, imageUploadsLength]);
 
   const uploadImagesHandler = () => {
@@ -353,6 +359,7 @@ const MessageInputWithContext = <
         removeImagesHandler();
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedImagesLength]);
 
   useEffect(() => {
@@ -377,6 +384,7 @@ const MessageInputWithContext = <
       );
       filesToRemove.forEach((file) => removeFile(file.id));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFilesLength]);
 
   useEffect(() => {
@@ -409,6 +417,7 @@ const MessageInputWithContext = <
         );
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [imageUploadsLength, hasImagePicker]);
 
   useEffect(() => {
@@ -440,6 +449,7 @@ const MessageInputWithContext = <
         );
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fileUploadsLength, hasImagePicker]);
 
   const editingExists = !!editing;
@@ -468,6 +478,7 @@ const MessageInputWithContext = <
     ) {
       resetInput();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editingExists]);
 
   const asyncIdsString = asyncIds.join();
@@ -484,6 +495,7 @@ const MessageInputWithContext = <
       asyncIds.forEach((id) => sendMessageAsync(id));
       sending.current = false;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [asyncIdsString, asyncUploadsString, sendMessageAsync]);
 
   const getMembers = () => {
@@ -544,6 +556,7 @@ const MessageInputWithContext = <
         if (setFocused) setFocused(true);
       },
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [additionalTextInputProps],
   );
 

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -290,6 +290,7 @@ const MessageListWithContext = <
 
   const modifiedTheme = useMemo(
     () => mergeThemes({ style: myMessageTheme, theme }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [myMessageThemeString, theme],
   );
 
@@ -469,6 +470,7 @@ const MessageListWithContext = <
     if (getShouldMarkReadAutomatically()) {
       markRead();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, scrollToBottomButtonVisible, isInitialScrollDone]);
 
   useEffect(() => {
@@ -535,6 +537,7 @@ const MessageListWithContext = <
 
     messageListLengthBeforeUpdate.current = messageListLengthAfterUpdate;
     topMessageBeforeUpdate.current = topMessageAfterUpdate;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     threadList,
     hasNoMoreRecentMessagesToLoad,
@@ -582,6 +585,7 @@ const MessageListWithContext = <
         }, 150); // flatlist might take a bit to update, so a small delay is needed
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rawMessageList, threadList]);
 
   // TODO: do not apply on RN 0.73 and above
@@ -964,6 +968,7 @@ const MessageListWithContext = <
         });
       }
     }, 50);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [targetedMessage, initialScrollToFirstUnreadMessage]);
 
   const messagesWithImages =
@@ -1009,6 +1014,7 @@ const MessageListWithContext = <
     ) {
       setMessages(messagesWithImages as MessageType<StreamChatGenerics>[]);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     imageString,
     isListActive,

--- a/package/src/components/MessageList/StickyHeader.tsx
+++ b/package/src/components/MessageList/StickyHeader.tsx
@@ -34,6 +34,7 @@ export const StickyHeader = ({ date, DateHeader, dateString }: StickyHeaderProps
       tDateTimeParser,
       timestampTranslationKey: 'timestamp/StickyHeader',
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [date]);
 
   if (!date) return null;

--- a/package/src/components/MessageList/hooks/useShouldScrollToRecentOnNewOwnMessage.ts
+++ b/package/src/components/MessageList/hooks/useShouldScrollToRecentOnNewOwnMessage.ts
@@ -38,6 +38,7 @@ export function useShouldScrollToRecentOnNewOwnMessage<
         }
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rawMessageList]);
 
   return isMyOwnNewMessageRef;

--- a/package/src/components/MessageOverlay/MessageOverlay.tsx
+++ b/package/src/components/MessageOverlay/MessageOverlay.tsx
@@ -163,6 +163,7 @@ const MessageOverlayWithContext = <
 
   const modifiedTheme = useMemo(
     () => mergeThemes({ style: myMessageTheme, theme }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [myMessageThemeString, theme],
   );
 
@@ -206,6 +207,7 @@ const MessageOverlayWithContext = <
   useEffect(() => {
     Keyboard.dismiss();
     fadeScreen();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onPan = useAnimatedGestureHandler<PanGestureHandlerGestureEvent>({

--- a/package/src/components/MessageOverlay/hooks/useFetchReactions.ts
+++ b/package/src/components/MessageOverlay/hooks/useFetchReactions.ts
@@ -69,16 +69,19 @@ export const useFetchReactions = <
     } catch (error) {
       console.log('Error fetching reactions: ', error);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, messageId, reactionType, sortString, next, enableOfflineSupport]);
 
   const loadNextPage = useCallback(async () => {
     if (next) {
       await fetchReactions();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchReactions]);
 
   useEffect(() => {
     fetchReactions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messageId, reactionType, sortString]);
 
   return { loading, loadNextPage, reactions };

--- a/package/src/components/ProgressControl/ProgressControl.tsx
+++ b/package/src/components/ProgressControl/ProgressControl.tsx
@@ -72,6 +72,7 @@ export const ProgressControl = React.memo(
         state.value = progress * widthInNumbers;
         translateX.value = progress * widthInNumbers;
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [progress, widthInNumbers]);
 
     const animatedStyles = useAnimatedStyle(() => ({

--- a/package/src/components/ProgressControl/WaveProgressBar.tsx
+++ b/package/src/components/ProgressControl/WaveProgressBar.tsx
@@ -75,12 +75,14 @@ export const WaveProgressBar = React.memo(
       state.value = stageProgress * (WAVEFORM_WIDTH * 2);
       setEndPosition(state.value);
       setCurrentWaveformProgress(stageProgress);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [progress]);
 
     const stringifiedWaveformData = waveformData.toString();
 
     const resampledWaveformData = useMemo(
       () => resampleWaveformData(waveformData, amplitudesCount),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [amplitudesCount, stringifiedWaveformData],
     );
 

--- a/package/src/components/Spinner/Spinner.tsx
+++ b/package/src/components/Spinner/Spinner.tsx
@@ -53,6 +53,7 @@ export const Spinner = (props: SpinnerProps) => {
       }),
       -1,
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/package/src/components/Thread/Thread.tsx
+++ b/package/src/components/Thread/Thread.tsx
@@ -80,6 +80,7 @@ const ThreadWithContext = <
     if (thread?.id && thread.reply_count) {
       loadMoreThreadAsync();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(
@@ -91,6 +92,7 @@ const ThreadWithContext = <
         onThreadDismount();
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 

--- a/package/src/contexts/channelsStateContext/ChannelsStateContext.tsx
+++ b/package/src/contexts/channelsStateContext/ChannelsStateContext.tsx
@@ -166,6 +166,7 @@ export const ChannelsStateProvider = <
       setState,
       state,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [state],
   );
 

--- a/package/src/contexts/channelsStateContext/useChannelState.ts
+++ b/package/src/contexts/channelsStateContext/useChannelState.ts
@@ -39,12 +39,14 @@ function useStateManager<
   >,
   initialValue?: ChannelState<StreamChatGenerics>[Key],
 ) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const memoizedInitialValue = useMemo(() => initialValue, []);
   const value =
     state[cid]?.[key] || (memoizedInitialValue as ChannelState<StreamChatGenerics>[Key]);
 
   const setValue = useCallback(
     (value: ChannelState<StreamChatGenerics>[Key]) => setState({ cid, key, value }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [cid, key],
   );
 
@@ -86,6 +88,7 @@ export function useChannelState<
     return () => {
       decreaseSubscriberCount({ cid });
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const [members, setMembers] = useStateManager(

--- a/package/src/contexts/messageInputContext/hooks/useCreateMessageInputContext.ts
+++ b/package/src/contexts/messageInputContext/hooks/useCreateMessageInputContext.ts
@@ -232,6 +232,7 @@ export const useCreateMessageInputContext = <
       uploadNewImage,
       UploadProgressIndicator,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       asyncIdsLength,
       asyncUploadsValue,

--- a/package/src/contexts/messageInputContext/hooks/useMessageDetailsForState.ts
+++ b/package/src/contexts/messageInputContext/hooks/useMessageDetailsForState.ts
@@ -34,6 +34,7 @@ export const useMessageDetailsForState = <
     if (fileUploads.length || imageUploads.length) {
       setShowMoreOptions(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [text, imageUploads.length, fileUploads.length]);
 
   const messageValue =
@@ -44,6 +45,7 @@ export const useMessageDetailsForState = <
       const mentionedUsers = message.mentioned_users.map((user) => user.id);
       setMentionedUsers(mentionedUsers);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messageValue]);
 
   const mapAttachmentToFileUpload = (attachment: Attachment<StreamChatGenerics>): FileUpload => {
@@ -148,6 +150,7 @@ export const useMessageDetailsForState = <
         setImageUploads(newImageUploads);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messageValue]);
 
   return {

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -189,6 +189,7 @@ export const OverlayProvider = <
     } else {
       overlayOpacity.value = withTiming(0);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [overlay]);
 
   const attachmentPickerContext = {

--- a/package/src/hooks/useScreenDimensions.ts
+++ b/package/src/hooks/useScreenDimensions.ts
@@ -25,11 +25,13 @@ export const useScreenDimensions = (rounded?: boolean) => {
     return () => subscriptions?.remove();
   }, []);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const vw = (percentageWidth: number) => {
     const value = screenDimensions.width * (percentageWidth / 100);
     return rounded ? Math.round(value) : value;
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const vh = (percentageHeight: number) => {
     const value = screenDimensions.height * (percentageHeight / 100);
     return rounded ? Math.round(value) : value;

--- a/package/src/hooks/useStreami18n.ts
+++ b/package/src/hooks/useStreami18n.ts
@@ -45,6 +45,7 @@ export const useStreami18n = (i18nInstance?: Streami18n) => {
       unsubscribeOnTFuncOverrideListener();
       unsubscribeOnLanguageChangeListener();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [i18nInstance]);
 
   return translators;

--- a/package/src/hooks/useViewport.ts
+++ b/package/src/hooks/useViewport.ts
@@ -25,11 +25,13 @@ export const useViewport = (rounded?: boolean) => {
     return () => subscriptions?.remove();
   }, []);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const vw = (percentageWidth: number) => {
     const value = viewportDimensions.width * (percentageWidth / 100);
     return rounded ? Math.round(value) : value;
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const vh = (percentageHeight: number) => {
     const value = viewportDimensions.height * (percentageHeight / 100);
     return rounded ? Math.round(value) : value;


### PR DESCRIPTION
## 🎯 Goal

As @santhoshvai pointed out in [this Slack thread](https://getstream.slack.com/archives/C02EK5GMU8Z/p1724068320926449?thread_ts=1724067980.230399&cid=C02EK5GMU8Z), the [Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks) `eslint` plugin has been disabled for the Chat SDK. We want to re-enable it so that future development follows these rules intrinsically. 

## 🛠 Implementation details

This is mostly a port of https://github.com/GetStream/stream-chat-react/pull/2244 (thanks @myandrienko !) to our SDK. 

Brief rundown of the steps:

- Enable the `react-hooks/exhaustive-deps` plugin
- Run `yarn eslint 'src/**/*.{js,ts,tsx,md}' -f json -o lint.json` in all directories for which the plugin was enabled
- Execute the script mentioned in the PR above (be mindful to change `const json = require('./lint.json');` to whichever path your `lint.json` files got generated at)
- Run `yarn prettier --write` to fix all of the formatting issues
- Finally, run `yarn eslint` again to make sure that no warnings pop up after the script had been run

Care that `prettier` might also do some other changes in additional files - everything was checked by hand as well after the script was run and odd edge cases were handled adhoc (in my case they were only `prettier` ones).

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


