### PR TITLE
fix: targeting message outside bounds

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -964,7 +964,7 @@ const MessageListWithContext = <
         });
       }
       // the message we want to scroll to has not been loaded in the state yet
-      loadChannelAroundMessage({ messageId: messageIdToScroll })
+      loadChannelAroundMessage({ messageId: messageIdToScroll });
     }, 50);
   }, [targetedMessage, initialScrollToFirstUnreadMessage]);
 

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -963,6 +963,8 @@ const MessageListWithContext = <
           viewPosition: 0.5, // try to place message in the center of the screen
         });
       }
+      // the message we want to scroll to has not been loaded in the state yet
+      loadChannelAroundMessage({ messageId: messageIdToScroll })
     }, 50);
   }, [targetedMessage, initialScrollToFirstUnreadMessage]);
 

--- a/package/src/components/MessageList/__tests__/MessageList.test.js
+++ b/package/src/components/MessageList/__tests__/MessageList.test.js
@@ -371,7 +371,7 @@ describe('MessageList', () => {
     for (let i = 0; i <= 150; i += 1) {
       mockedLongMessagesList.push(generateMessage({ timestamp: new Date(), user: user1 }));
     }
-    // could be any message that are not the initially processed ones
+    // could be any message that is not within the initially processed ones
     const { id: targetedMessageId, text: targetedMessageText } = mockedLongMessagesList[3];
     const latestMessageText = mockedLongMessagesList[mockedLongMessagesList.length - 1].text;
 

--- a/package/src/components/MessageList/__tests__/MessageList.test.js
+++ b/package/src/components/MessageList/__tests__/MessageList.test.js
@@ -367,12 +367,14 @@ describe('MessageList', () => {
     const user1 = generateUser();
 
     const mockedLongMessagesList = [];
+    // we need a long enough list to make sure elements aren't preloaded by the underlying FlatList
     for (let i = 0; i <= 150; i += 1) {
       mockedLongMessagesList.push(generateMessage({ timestamp: new Date(), user: user1 }));
     }
     // could be any message that are not the initially processed ones
     const { id: targetedMessageId, text: targetedMessageText } = mockedLongMessagesList[3];
-    const { text: latestMessageText } = mockedLongMessagesList[mockedLongMessagesList.length - 1];
+    const latestMessageText = mockedLongMessagesList[mockedLongMessagesList.length - 1].text;
+
     const mockedChannel = generateChannelResponse({
       members: [generateMember({ user: user1 })],
       messages: mockedLongMessagesList,


### PR DESCRIPTION
## 🎯 Goal

This PR fixes [this Github issue opened towards our SDK](https://github.com/GetStream/stream-chat-react-native/issues/2629).

## 🛠 Implementation details

The issue happened whenever one tried to target a message in a larger channel, that would be outside of the processing window of our underlying `FlatList` in `MessageList`. Whenever this is the case and we cannot find the message, we should try to load it in order to load to the correct message set as well as everything around the message.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


