### PR TITLE
fix: prettier doesn't work on docusaurus directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,8 +3,5 @@
 **/dist/
 **/.expo/
 **/vendor/
-*.md
-*.mdx
 package/src/components/docs/
 package/lib/
-docusaurus/


### PR DESCRIPTION
## 🎯 Goal

Prettier or, for, say, code is not formatted on save for the md and mdx files and for the docs files in the `docusaurus` directory. This PR tends to fix the problem since it seems to be related to the fact that they are ignored on the `.prettierignore` file.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


