### PR TITLE
fix: inability to cancel file uploads

### DIFF
--- a/package/src/components/MessageInput/FileUploadPreview.tsx
+++ b/package/src/components/MessageInput/FileUploadPreview.tsx
@@ -285,16 +285,16 @@ const FileUploadPreviewWithContext = <
               </View>
             </View>
           )}
-          <TouchableOpacity
-            onPress={() => {
-              removeFile(item.id);
-            }}
-            style={[styles.dismiss, { backgroundColor: grey_gainsboro }, dismiss]}
-            testID='remove-file-upload-preview'
-          >
-            <Close pathFill={grey_dark} />
-          </TouchableOpacity>
         </UploadProgressIndicator>
+        <TouchableOpacity
+          onPress={() => {
+            removeFile(item.id);
+          }}
+          style={[styles.dismiss, { backgroundColor: grey_gainsboro }, dismiss]}
+          testID='remove-file-upload-preview'
+        >
+          <Close pathFill={grey_dark} />
+        </TouchableOpacity>
       </>
     );
   };


### PR DESCRIPTION
## 🎯 Goal

The PR fixes [this JIRA issue](https://stream-io.atlassian.net/browse/PBE-5600).

## 🛠 Implementation details

The cancel button set as a child of `UploadProgressIndicator`, making it unclickable whenever `enableOfflineSupport` is set to `false`. Moving it out fixes the issue.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


