### PR TITLE
fix: multiple image upload issue using native image picker and generic improvements for upload

### DIFF
--- a/package/expo-package/src/optionalDependencies/takePhoto.ts
+++ b/package/expo-package/src/optionalDependencies/takePhoto.ts
@@ -43,8 +43,6 @@ export const takePhoto = ImagePicker
           // since we only support single photo upload for now we will only be focusing on 0'th element.
           const photo = assets && assets[0];
 
-          console.log(photo);
-
           if (canceled === false && photo && photo.height && photo.width && photo.uri) {
             let size: Size = {};
             if (Platform.OS === 'android') {

--- a/package/expo-package/src/optionalDependencies/takePhoto.ts
+++ b/package/expo-package/src/optionalDependencies/takePhoto.ts
@@ -43,6 +43,8 @@ export const takePhoto = ImagePicker
           // since we only support single photo upload for now we will only be focusing on 0'th element.
           const photo = assets && assets[0];
 
+          console.log(photo);
+
           if (canceled === false && photo && photo.height && photo.width && photo.uri) {
             let size: Size = {};
             if (Platform.OS === 'android') {
@@ -74,6 +76,7 @@ export const takePhoto = ImagePicker
 
             return {
               cancelled: false,
+              size: photo.fileSize,
               source: 'camera',
               uri: photo.uri,
               ...size,

--- a/package/native-package/src/optionalDependencies/pickImage.ts
+++ b/package/native-package/src/optionalDependencies/pickImage.ts
@@ -10,7 +10,9 @@ try {
 export const pickImage = ImagePicker
   ? async () => {
       try {
-        const result = await ImagePicker.launchImageLibrary({ mediaType: 'mixed' });
+        const result = await ImagePicker.launchImageLibrary({
+          mediaType: 'mixed',
+        });
         const canceled = result.didCancel;
         const errorCode = result.errorCode;
 
@@ -20,7 +22,7 @@ export const pickImage = ImagePicker
         if (!canceled) {
           const assets = result.assets.map((asset) => ({
             ...asset,
-            duration: asset.duration * 1000, // in milliseconds
+            duration: asset.duration ? asset.duration * 1000 : undefined, // in milliseconds
             name: asset.fileName,
             size: asset.fileSize,
             source: 'picker',

--- a/package/native-package/src/optionalDependencies/takePhoto.ts
+++ b/package/native-package/src/optionalDependencies/takePhoto.ts
@@ -60,6 +60,7 @@ export const takePhoto = ImagePicker
           }
           return {
             cancelled: false,
+            size: photo.size,
             source: 'camera',
             uri: photo.path,
             ...size,

--- a/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
@@ -5,7 +5,7 @@ import { Alert, ImageBackground, Platform, StyleSheet, Text, View } from 'react-
 import { TouchableOpacity } from '@gorhom/bottom-sheet';
 import { lookup } from 'mime-types';
 
-import type { AttachmentPickerContextValue } from '../../../contexts/attachmentPickerContext/AttachmentPickerContext';
+import { AttachmentPickerContextValue } from '../../../contexts/attachmentPickerContext/AttachmentPickerContext';
 import { useTheme } from '../../../contexts/themeContext/ThemeContext';
 import { useViewport } from '../../../hooks/useViewport';
 import { Recorder } from '../../../icons';
@@ -23,7 +23,6 @@ type AttachmentPickerItemType = Pick<
   selected: boolean;
   numberOfAttachmentPickerImageColumns?: number;
 };
-
 type AttachmentImageProps = Omit<AttachmentPickerItemType, 'setSelectedFiles' | 'selectedFiles'>;
 
 type AttachmentVideoProps = Omit<AttachmentPickerItemType, 'setSelectedImages' | 'selectedImages'>;

--- a/package/src/components/MessageInput/FileUploadPreview.tsx
+++ b/package/src/components/MessageInput/FileUploadPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, I18nManager, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { UploadProgressIndicator } from './UploadProgressIndicator';
@@ -34,6 +34,7 @@ const styles = StyleSheet.create({
   dismiss: {
     borderRadius: 24,
     height: 24,
+    marginRight: 4,
     position: 'absolute',
     right: 8,
     top: 8,
@@ -299,7 +300,7 @@ const FileUploadPreviewWithContext = <
     );
   };
 
-  const fileUploadsLength = fileUploads.length;
+  const fileUploadsLength = useMemo(() => fileUploads.length, [fileUploads.length]);
 
   useEffect(() => {
     if (fileUploadsLength && flatListRef.current) {

--- a/package/src/components/MessageInput/FileUploadPreview.tsx
+++ b/package/src/components/MessageInput/FileUploadPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { FlatList, I18nManager, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { UploadProgressIndicator } from './UploadProgressIndicator';
@@ -300,7 +300,7 @@ const FileUploadPreviewWithContext = <
     );
   };
 
-  const fileUploadsLength = useMemo(() => fileUploads.length, [fileUploads.length]);
+  const fileUploadsLength = fileUploads.length;
 
   useEffect(() => {
     if (fileUploadsLength && flatListRef.current) {

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -1,5 +1,12 @@
-import type { LegacyRef } from 'react';
-import React, { PropsWithChildren, useContext, useEffect, useRef, useState } from 'react';
+import React, {
+  LegacyRef,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { Alert, Keyboard, Linking, TextInput, TextInputProps } from 'react-native';
 
 import uniq from 'lodash/uniq';
@@ -46,7 +53,7 @@ import type { SendButtonProps } from '../../components/MessageInput/SendButton';
 import type { UploadProgressIndicatorProps } from '../../components/MessageInput/UploadProgressIndicator';
 import type { MessageType } from '../../components/MessageList/hooks/useMessageList';
 import type { Emoji } from '../../emoji-data';
-import { pickDocument, pickImage, takePhoto } from '../../native';
+import { isImageMediaLibraryAvailable, pickDocument, pickImage, takePhoto } from '../../native';
 import {
   Asset,
   DefaultStreamChatGenerics,
@@ -690,30 +697,30 @@ export const MessageInputProvider = <
   /**
    * Function to open the attachment picker if the MediaLibary is installed.
    */
-  const openAttachmentPicker = () => {
+  const openAttachmentPicker = useCallback(() => {
     Keyboard.dismiss();
     setSelectedPicker('images');
     openPicker();
-  };
+  }, [openPicker, setSelectedPicker]);
 
   /**
    * Function to close the attachment picker if the MediaLibrary is installed.
    */
-  const closeAttachmentPicker = () => {
+  const closeAttachmentPicker = useCallback(() => {
     setSelectedPicker(undefined);
     closePicker();
-  };
+  }, [closePicker, setSelectedPicker]);
 
   /**
    * Function to toggle the attachment picker if the MediaLibrary is installed.
    */
-  const toggleAttachmentPicker = () => {
+  const toggleAttachmentPicker = useCallback(() => {
     if (selectedPicker) {
       closeAttachmentPicker();
     } else {
       openAttachmentPicker();
     }
-  };
+  }, [closeAttachmentPicker, openAttachmentPicker, selectedPicker]);
 
   const onSelectItem = (item: UserResponse<StreamChatGenerics>) => {
     setMentionedUsers((prevMentionedUsers) => [...prevMentionedUsers, item.id]);
@@ -750,21 +757,35 @@ export const MessageInputProvider = <
     }
   };
 
-  const removeFile = (id: string) => {
-    if (fileUploads.some((file) => file.id === id)) {
-      setFileUploads((prevFileUploads) => prevFileUploads.filter((file) => file.id !== id));
-      setNumberOfUploads((prevNumberOfUploads) => prevNumberOfUploads - 1);
-    }
-  };
+  const removeFile = useCallback(
+    (id: string) => {
+      if (fileUploads.some((file) => file.id === id)) {
+        setFileUploads((prevFileUploads) => prevFileUploads.filter((file) => file.id !== id));
+        setNumberOfUploads((prevNumberOfUploads) => prevNumberOfUploads - 1);
+      }
+    },
+    [fileUploads, setFileUploads, setNumberOfUploads],
+  );
 
-  const removeImage = (id: string) => {
-    if (imageUploads.some((image) => image.id === id)) {
-      setImageUploads((prevImageUploads) => prevImageUploads.filter((image) => image.id !== id));
-      setNumberOfUploads((prevNumberOfUploads) => prevNumberOfUploads - 1);
-    }
-  };
+  const removeImage = useCallback(
+    (id: string) => {
+      if (imageUploads.some((image) => image.id === id)) {
+        setImageUploads((prevImageUploads) => prevImageUploads.filter((image) => image.id !== id));
+        setNumberOfUploads((prevNumberOfUploads) => prevNumberOfUploads - 1);
+      }
+    },
+    [imageUploads, setImageUploads, setNumberOfUploads],
+  );
 
   const resetInput = (pendingAttachments: Attachment<StreamChatGenerics>[] = []) => {
+    /**
+     * If the MediaLibrary is available, reset the selected files and images
+     */
+    if (isImageMediaLibraryAvailable()) {
+      setSelectedFiles([]);
+      setSelectedImages([]);
+    }
+
     setFileUploads([]);
     setGiphyActive(false);
     setShowMoreOptions(true);
@@ -1250,87 +1271,98 @@ export const MessageInputProvider = <
   };
 
   const uploadNewFile = async (file: File) => {
-    const id: string = generateRandomId();
-    const fileConfig = getFileUploadConfig();
-    const { size_limit } = fileConfig;
+    try {
+      const id: string = generateRandomId();
+      const fileConfig = getFileUploadConfig();
+      const { size_limit } = fileConfig;
 
-    const isAllowed = isUploadAllowed({ config: fileConfig, file });
+      const isAllowed = isUploadAllowed({ config: fileConfig, file });
 
-    const sizeLimit = size_limit || MAX_FILE_SIZE_TO_UPLOAD;
+      const sizeLimit = size_limit || MAX_FILE_SIZE_TO_UPLOAD;
 
-    if (file.size && file.size > sizeLimit) {
-      Alert.alert(
-        t('File is too large: {{ size }}, maximum upload size is {{ limit }}', {
-          limit: prettifyFileSize(sizeLimit),
-          size: prettifyFileSize(file.size),
-        }),
-      );
-      setSelectedFiles(selectedFiles.filter((selectedFile) => selectedFile.uri !== file.uri));
-      return;
-    }
+      if (file.size && file.size > sizeLimit) {
+        Alert.alert(
+          t('File is too large: {{ size }}, maximum upload size is {{ limit }}', {
+            limit: prettifyFileSize(sizeLimit),
+            size: prettifyFileSize(file.size),
+          }),
+        );
+        setSelectedFiles(selectedFiles.filter((selectedFile) => selectedFile.uri !== file.uri));
+        return;
+      }
 
-    const fileState = isAllowed ? FileState.UPLOADING : FileState.NOT_SUPPORTED;
+      const fileState = isAllowed ? FileState.UPLOADING : FileState.NOT_SUPPORTED;
 
-    // If file type is explicitly provided while upload we use it, else we derive the file type.
-    const fileType = file.type || file.mimeType?.split('/')[0];
+      // If file type is explicitly provided while upload we use it, else we derive the file type.
+      const fileType = file.type || file.mimeType?.split('/')[0];
 
-    const newFile: FileUpload = {
-      duration: file.duration || 0,
-      file,
-      id: file.id || id,
-      state: fileState,
-      type: fileType,
-    };
+      const newFile: FileUpload = {
+        duration: file.duration || 0,
+        file,
+        id: file.id || id,
+        state: fileState,
+        type: fileType,
+        url: file.uri,
+      };
 
-    await Promise.all([
-      setFileUploads((prevFileUploads) => prevFileUploads.concat([newFile])),
-      setNumberOfUploads((prevNumberOfUploads) => prevNumberOfUploads + 1),
-    ]);
+      await Promise.all([
+        setFileUploads((prevFileUploads) => prevFileUploads.concat([newFile])),
+        setNumberOfUploads((prevNumberOfUploads) => prevNumberOfUploads + 1),
+      ]);
 
-    if (isAllowed) {
-      await uploadFile({ newFile });
+      if (isAllowed) {
+        await uploadFile({ newFile });
+      }
+    } catch (error) {
+      console.log('Error uploading file', error);
     }
   };
 
   const uploadNewImage = async (image: Partial<Asset>) => {
-    const id = generateRandomId();
-    const imageUploadConfig = getImageUploadConfig();
+    try {
+      const id = generateRandomId();
+      const imageUploadConfig = getImageUploadConfig();
 
-    const { size_limit } = imageUploadConfig;
+      const { size_limit } = imageUploadConfig;
 
-    const isAllowed = isUploadAllowed({ config: imageUploadConfig, file: image });
+      const isAllowed = isUploadAllowed({ config: imageUploadConfig, file: image });
 
-    const sizeLimit = size_limit || MAX_FILE_SIZE_TO_UPLOAD;
+      const sizeLimit = size_limit || MAX_FILE_SIZE_TO_UPLOAD;
 
-    if (image.size && image?.size > sizeLimit) {
-      Alert.alert(
-        t('File is too large: {{ size }}, maximum upload size is {{ limit }}', {
-          limit: prettifyFileSize(sizeLimit),
-          size: prettifyFileSize(image.size),
-        }),
-      );
-      setSelectedImages(selectedImages.filter((selectedImage) => selectedImage.uri !== image.uri));
-      return;
-    }
+      if (image.size && image?.size > sizeLimit) {
+        Alert.alert(
+          t('File is too large: {{ size }}, maximum upload size is {{ limit }}', {
+            limit: prettifyFileSize(sizeLimit),
+            size: prettifyFileSize(image.size),
+          }),
+        );
+        setSelectedImages(
+          selectedImages.filter((selectedImage) => selectedImage.uri !== image.uri),
+        );
+        return;
+      }
 
-    const imageState = isAllowed ? FileState.UPLOADING : FileState.NOT_SUPPORTED;
+      const imageState = isAllowed ? FileState.UPLOADING : FileState.NOT_SUPPORTED;
 
-    const newImage: ImageUpload = {
-      file: image,
-      height: image.height,
-      id,
-      state: imageState,
-      url: image.uri,
-      width: image.width,
-    };
+      const newImage: ImageUpload = {
+        file: image,
+        height: image.height,
+        id,
+        state: imageState,
+        url: image.uri,
+        width: image.width,
+      };
 
-    await Promise.all([
-      setImageUploads((prevImageUploads) => prevImageUploads.concat([newImage])),
-      setNumberOfUploads((prevNumberOfUploads) => prevNumberOfUploads + 1),
-    ]);
+      await Promise.all([
+        setImageUploads((prevImageUploads) => prevImageUploads.concat([newImage])),
+        setNumberOfUploads((prevNumberOfUploads) => prevNumberOfUploads + 1),
+      ]);
 
-    if (isAllowed) {
-      await uploadImage({ newImage });
+      if (isAllowed) {
+        await uploadImage({ newImage });
+      }
+    } catch (error) {
+      console.log('Error uploading image', error);
     }
   };
 

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -657,7 +657,7 @@ export const MessageInputProvider = <
       );
     }
     if (!photo.cancelled) {
-      setSelectedImages((images) => [...images, photo]);
+      await uploadNewImage(photo);
     }
   };
 
@@ -677,14 +677,11 @@ export const MessageInputProvider = <
       );
     }
     if (result.assets && result.assets.length > 0) {
-      result.assets.forEach((asset) => {
+      result.assets.forEach(async (asset) => {
         if (asset.type.includes('image')) {
-          setSelectedImages((prevImages) => [...prevImages, asset]);
+          await uploadNewImage(asset);
         } else {
-          setSelectedFiles((prevFiles) => [
-            ...prevFiles,
-            { ...asset, mimeType: asset.type, type: FileTypes.Video },
-          ]);
+          await uploadNewFile({ ...asset, mimeType: asset.type, type: FileTypes.Video });
         }
       });
     }
@@ -740,7 +737,7 @@ export const MessageInputProvider = <
     });
 
     if (!result.cancelled && result.assets) {
-      result.assets.forEach((asset) => {
+      result.assets.forEach(async (asset) => {
         /**
          * TODO: The current tight coupling of images to the image
          * picker does not allow images picked from the file picker
@@ -748,7 +745,7 @@ export const MessageInputProvider = <
          * This should be updated alongside allowing image a file
          * uploads together.
          */
-        uploadNewFile(asset);
+        await uploadNewFile(asset);
       });
     }
   };
@@ -1291,7 +1288,7 @@ export const MessageInputProvider = <
     ]);
 
     if (isAllowed) {
-      uploadFile({ newFile });
+      await uploadFile({ newFile });
     }
   };
 
@@ -1333,7 +1330,7 @@ export const MessageInputProvider = <
     ]);
 
     if (isAllowed) {
-      uploadImage({ newImage });
+      await uploadImage({ newImage });
     }
   };
 

--- a/package/src/contexts/messageInputContext/__tests__/sendMessage.test.tsx
+++ b/package/src/contexts/messageInputContext/__tests__/sendMessage.test.tsx
@@ -12,6 +12,7 @@ import { generateMessage } from '../../../mock-builders/generator/message';
 import { generateUser } from '../../../mock-builders/generator/user';
 import type { DefaultStreamChatGenerics } from '../../../types/types';
 import { FileState } from '../../../utils/utils';
+import * as AttachmentPickerContext from '../../attachmentPickerContext/AttachmentPickerContext';
 import {
   InputMessageInputContextValue,
   MessageInputContextValue,
@@ -39,6 +40,10 @@ const Wrapper = <StreamChatGenerics extends DefaultStreamChatGenerics = DefaultS
 
 const newMessage = generateMessage({ id: 'new-id' });
 describe("MessageInputContext's sendMessage", () => {
+  jest.spyOn(AttachmentPickerContext, 'useAttachmentPickerContext').mockImplementation(() => ({
+    setSelectedFiles: jest.fn(),
+    setSelectedImages: jest.fn(),
+  }));
   const message: boolean | MessageType<DefaultStreamChatGenerics> = generateMessage({
     created_at: 'Sat Jul 02 2022 23:55:13 GMT+0530 (India Standard Time)',
     id: '7a85f744-cc89-4f82-a1d4-5456432cc8bf',

--- a/package/src/contexts/messageInputContext/__tests__/updateMessage.test.tsx
+++ b/package/src/contexts/messageInputContext/__tests__/updateMessage.test.tsx
@@ -11,6 +11,7 @@ import { ChatContextValue, ChatProvider } from '../../../contexts/chatContext/Ch
 import { generateMessage } from '../../../mock-builders/generator/message';
 import { generateUser } from '../../../mock-builders/generator/user';
 import type { DefaultStreamChatGenerics } from '../../../types/types';
+import * as AttachmentPickerContext from '../../attachmentPickerContext/AttachmentPickerContext';
 import {
   InputMessageInputContextValue,
   MessageInputContextValue,
@@ -49,6 +50,10 @@ const Wrapper = <StreamChatGenerics extends DefaultStreamChatGenerics = DefaultS
 );
 
 describe("MessageInputContext's updateMessage", () => {
+  jest.spyOn(AttachmentPickerContext, 'useAttachmentPickerContext').mockImplementation(() => ({
+    setSelectedFiles: jest.fn(),
+    setSelectedImages: jest.fn(),
+  }));
   const clearEditingStateMock = jest.fn();
   const generatedMessage: boolean | MessageType<DefaultStreamChatGenerics> = generateMessage({
     created_at: 'Sat Jul 02 2022 23:55:13 GMT+0530 (India Standard Time)',

--- a/package/src/contexts/messageInputContext/hooks/useMessageDetailsForState.ts
+++ b/package/src/contexts/messageInputContext/hooks/useMessageDetailsForState.ts
@@ -8,7 +8,7 @@ import {
   FileUpload,
   ImageUpload,
 } from '../../../types/types';
-import { generateRandomId } from '../../../utils/utils';
+import { generateRandomId, stringifyMessage } from '../../../utils/utils';
 
 import type { MessageInputContextValue } from '../MessageInputContext';
 
@@ -37,8 +37,7 @@ export const useMessageDetailsForState = <
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [text, imageUploads.length, fileUploads.length]);
 
-  const messageValue =
-    message === undefined ? '' : `${message.id}${message.text}${message.updated_at}`;
+  const messageValue = message ? stringifyMessage(message) : '';
 
   useEffect(() => {
     if (message && Array.isArray(message?.mentioned_users)) {
@@ -67,9 +66,11 @@ export const useMessageDetailsForState = <
     } else if (attachment.type === FileTypes.Video) {
       return {
         file: {
+          duration: attachment.duration,
           mimeType: attachment.mime_type,
           name: attachment.title || '',
           size: attachment.file_size,
+          uri: attachment.asset_url,
         },
         id,
         state: 'finished',
@@ -96,6 +97,7 @@ export const useMessageDetailsForState = <
           mimeType: attachment.mime_type,
           name: attachment.title || '',
           size: attachment.file_size,
+          uri: attachment.asset_url,
         },
         id,
         state: 'finished',
@@ -107,6 +109,7 @@ export const useMessageDetailsForState = <
           mimeType: attachment.mime_type,
           name: attachment.title || '',
           size: attachment.file_size,
+          uri: attachment.asset_url,
         },
         id,
         state: 'finished',
@@ -128,9 +131,11 @@ export const useMessageDetailsForState = <
           const id = generateRandomId();
           newImageUploads.push({
             file: {
+              height: attachment.original_height,
               name: attachment.fallback,
               size: attachment.file_size,
               type: attachment.type,
+              width: attachment.original_width,
             },
             id,
             state: 'finished',


### PR DESCRIPTION
## 🎯 Goal

The goal of the PR is to primarily solve the multiple image upload issue on the new architecture but this also applies to the current v5 branch as the improvements here make sense and are not architectural dependant.

There are a few improvements in the `useEffect` of the `MessageInput` as well that is supposed to target only the media library(attachment picker) but don't make sense for the native image pickers, so proper checks are added around the same and improves the upload process for normal use-cases.

The PR also solves the issue of clicked images not respecting the file size config check.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


