### PR TITLE
fix: memory leak during remount or user change

### DIFF
--- a/package/src/components/Chat/Chat.tsx
+++ b/package/src/components/Chat/Chat.tsx
@@ -217,7 +217,7 @@ const ChatWithContext = <
 
   // In case something went wrong, make sure to also unsubscribe the listener
   // on unmount if it exists to prevent a memory leak.
-  useEffect(() => () => DBSyncManager.connectionChangedListener?.unsubscribe());
+  useEffect(() => () => DBSyncManager.connectionChangedListener?.unsubscribe(), []);
 
   const initialisedDatabase =
     initialisedDatabaseConfig.initialised && userID === initialisedDatabaseConfig.userID;

--- a/package/src/components/Chat/Chat.tsx
+++ b/package/src/components/Chat/Chat.tsx
@@ -204,13 +204,20 @@ const ChatWithContext = <
 
   useEffect(() => {
     if (userID && enableOfflineSupport) {
+      // This acts as a lock for some very rare occurrences of concurrency
+      // issues we've encountered before with the QuickSqliteClient being
+      // uninitialized before it's being invoked.
       setInitialisedDatabaseConfig({ initialised: false, userID });
       QuickSqliteClient.initializeDatabase();
-      DBSyncManager.init(client as unknown as StreamChat);
       setInitialisedDatabaseConfig({ initialised: true, userID });
+      DBSyncManager.init(client as unknown as StreamChat);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userID, enableOfflineSupport]);
+
+  // In case something went wrong, make sure to also unsubscribe the listener
+  // on unmount if it exists to prevent a memory leak.
+  useEffect(() => () => DBSyncManager.connectionChangedListener?.unsubscribe());
 
   const initialisedDatabase =
     initialisedDatabaseConfig.initialised && userID === initialisedDatabaseConfig.userID;

--- a/package/src/components/Chat/__tests__/Chat.test.js
+++ b/package/src/components/Chat/__tests__/Chat.test.js
@@ -9,7 +9,8 @@ import { useChatContext } from '../../../contexts/chatContext/ChatContext';
 import { useTranslationContext } from '../../../contexts/translationContext/TranslationContext';
 import dispatchConnectionChangedEvent from '../../../mock-builders/event/connectionChanged';
 import dispatchConnectionRecoveredEvent from '../../../mock-builders/event/connectionRecovered';
-import { getTestClient } from '../../../mock-builders/mock';
+import { getTestClient, getTestClientWithUser, setUser } from '../../../mock-builders/mock';
+import { DBSyncManager } from '../../../utils/DBSyncManager';
 import { Streami18n } from '../../../utils/i18n/Streami18n';
 import { Chat } from '../Chat';
 
@@ -24,7 +25,10 @@ const TranslationContextConsumer = ({ fn }) => {
 };
 
 describe('Chat', () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
   const chatClient = getTestClient();
 
   it('renders children without crashing', async () => {
@@ -213,6 +217,52 @@ describe('Chat', () => {
         expect(context.t).toBe(newI18nInstance.t);
         expect(context.tDateTimeParser).not.toBe(i18nInstance.tDateTimeParser);
         expect(context.tDateTimeParser).toBe(newI18nInstance.tDateTimeParser);
+      });
+    });
+
+    it('makes sure DBSyncManager listeners are cleaned up after Chat remount', async () => {
+      const chatClientWithUser = await getTestClientWithUser({ id: 'testID' });
+      jest.spyOn(DBSyncManager, 'init');
+
+      // initial mount and render
+      const { rerender } = render(
+        <Chat client={chatClientWithUser} enableOfflineSupport key={1} />
+      );
+
+      jest.spyOn(DBSyncManager.connectionChangedListener, 'unsubscribe');
+
+      // remount
+      rerender(
+        <Chat client={chatClientWithUser} enableOfflineSupport key={2} />
+      );
+
+      await waitFor(() => {
+        expect(DBSyncManager.init).toHaveBeenCalledTimes(2);
+        expect(DBSyncManager.connectionChangedListener.unsubscribe).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('makes sure DBSyncManager listeners are cleaned up if the user changes', async () => {
+      const chatClientWithUser = await getTestClientWithUser({ id: 'testID1' });
+      jest.spyOn(DBSyncManager, 'init');
+
+      // initial render
+      const { rerender } = render(
+        <Chat client={chatClientWithUser} enableOfflineSupport />
+      );
+
+      // the unsubscribe fn changes during init(), so we keep a reference to the spy
+      const unsubscribeSpy = jest.spyOn(DBSyncManager.connectionChangedListener, 'unsubscribe');
+      await act( async () => { await setUser(chatClientWithUser, { id: 'testID2' });});
+
+      // rerender with different user ID
+      rerender(
+        <Chat client={chatClientWithUser} enableOfflineSupport/>
+      );
+
+      await waitFor(() => {
+        expect(DBSyncManager.init).toHaveBeenCalledTimes(2);
+        expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/package/src/components/Chat/__tests__/Chat.test.js
+++ b/package/src/components/Chat/__tests__/Chat.test.js
@@ -226,7 +226,7 @@ describe('Chat', () => {
 
       // initial mount and render
       const { rerender } = render(
-        <Chat client={chatClientWithUser} enableOfflineSupport key={1} />
+        <Chat client={chatClientWithUser} enableOfflineSupport key={1} />,
       );
 
       // the unsubscribe fn changes during init(), so we keep a reference to the spy
@@ -234,14 +234,14 @@ describe('Chat', () => {
       const listenersAfterInitialMount = chatClientWithUser.listeners['connection.changed'];
 
       // remount
-      rerender(
-        <Chat client={chatClientWithUser} enableOfflineSupport key={2} />
-      );
+      rerender(<Chat client={chatClientWithUser} enableOfflineSupport key={2} />);
 
       await waitFor(() => {
         expect(DBSyncManager.init).toHaveBeenCalledTimes(2);
         expect(unsubscribeSpy).toHaveBeenCalledTimes(2);
-        expect(chatClientWithUser.listeners['connection.changed'].length).toBe(listenersAfterInitialMount.length);
+        expect(chatClientWithUser.listeners['connection.changed'].length).toBe(
+          listenersAfterInitialMount.length,
+        );
       });
     });
 
@@ -250,24 +250,24 @@ describe('Chat', () => {
       jest.spyOn(DBSyncManager, 'init');
 
       // initial render
-      const { rerender } = render(
-        <Chat client={chatClientWithUser} enableOfflineSupport />
-      );
+      const { rerender } = render(<Chat client={chatClientWithUser} enableOfflineSupport />);
 
       // the unsubscribe fn changes during init(), so we keep a reference to the spy
       const unsubscribeSpy = jest.spyOn(DBSyncManager.connectionChangedListener, 'unsubscribe');
-      await act( async () => { await setUser(chatClientWithUser, { id: 'testID2' });});
+      await act(async () => {
+        await setUser(chatClientWithUser, { id: 'testID2' });
+      });
       const listenersAfterInitialMount = chatClientWithUser.listeners['connection.changed'];
 
       // rerender with different user ID
-      rerender(
-        <Chat client={chatClientWithUser} enableOfflineSupport/>
-      );
+      rerender(<Chat client={chatClientWithUser} enableOfflineSupport />);
 
       await waitFor(() => {
         expect(DBSyncManager.init).toHaveBeenCalledTimes(2);
         expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
-        expect(chatClientWithUser.listeners['connection.changed'].length).toBe(listenersAfterInitialMount.length);
+        expect(chatClientWithUser.listeners['connection.changed'].length).toBe(
+          listenersAfterInitialMount.length,
+        );
       });
     });
 
@@ -276,23 +276,21 @@ describe('Chat', () => {
       jest.spyOn(DBSyncManager, 'init');
 
       // initial render
-      const { rerender } = render(
-        <Chat client={chatClientWithUser} enableOfflineSupport />
-      );
+      const { rerender } = render(<Chat client={chatClientWithUser} enableOfflineSupport />);
 
       // the unsubscribe fn changes during init(), so we keep a reference to the spy
       const unsubscribeSpy = jest.spyOn(DBSyncManager.connectionChangedListener, 'unsubscribe');
       const listenersAfterInitialMount = chatClientWithUser.listeners['connection.changed'];
 
       // rerender
-      rerender(
-        <Chat client={chatClientWithUser} enableOfflineSupport/>
-      );
+      rerender(<Chat client={chatClientWithUser} enableOfflineSupport />);
 
       await waitFor(() => {
         expect(DBSyncManager.init).toHaveBeenCalledTimes(1);
         expect(unsubscribeSpy).toHaveBeenCalledTimes(0);
-        expect(chatClientWithUser.listeners['connection.changed'].length).toBe(listenersAfterInitialMount.length);
+        expect(chatClientWithUser.listeners['connection.changed'].length).toBe(
+          listenersAfterInitialMount.length,
+        );
       });
     });
   });

--- a/package/src/mock-builders/mock.js
+++ b/package/src/mock-builders/mock.js
@@ -6,7 +6,7 @@ import { StreamChat } from 'stream-chat';
 const apiKey = 'API_KEY';
 const token = 'dummy_token';
 
-const setUser = (client, user) =>
+export const setUser = (client, user) =>
   new Promise((resolve) => {
     client.connectionId = 'dumm_connection_id';
     client.user = user;

--- a/package/src/utils/DBSyncManager.ts
+++ b/package/src/utils/DBSyncManager.ts
@@ -64,7 +64,6 @@ export class DBSyncManager {
       // within the lifecycle of the app.
       return;
     }
-    console.log('ISE: INIT CALLED', this.connectionChangedListener);
     this.client = client;
     // If the websocket connection is already active, then straightaway
     // call the sync api and also execute pending api calls.

--- a/package/src/utils/DBSyncManager.ts
+++ b/package/src/utils/DBSyncManager.ts
@@ -39,9 +39,6 @@ export class DBSyncManager {
   static listeners: Array<(status: boolean) => void> = [];
   static client: StreamChat | null = null;
   static connectionChangedListener: { unsubscribe: () => void } | null = null;
-  static initializationConfig: { initialized: boolean; userID?: string | undefined } = {
-    initialized: false,
-  };
 
   /**
    * Returns weather channel states in local DB are synced with backend or not.


### PR DESCRIPTION
## 🎯 Goal

This PR fixes a niche' usecase in our SDK as explained in [this Slack thread](https://getstream.slack.com/archives/C04GGF7CD9P/p1724688121503949). The tl;dr version of the issue is the following:

- If the `Chat` component gets unmounted and then remounted (i.e if the chat is perhaps used in a modal, overlay or anything of the sort that would destroy the entire context tree from the virtual DOM whenever closed), we will initialize the `DBSyncManager` multiple times
- This causes the listener towards the `connection.changed` event to be subscribed more than once (since the `DBSyncManager` lives within the JS runtime, rather than the components' lifecycle) amongst other things
- We can also never have the reference towards the old listener back so it's impossible to clean it up, and if done enough times the listeners would snowball into a memory leak until we close the app (thus killing the JS runtime altogether)

## 🛠 Implementation details

To solve this, we do 2 things:

- We make sure that even if `DBSyncManager.init()` is invoked more than once (i.e remounting), we only go through with it if it either has not yet been internally initialized or if the `userID` changes (for example, having a chat app that allows you to log in with different users within the same scope)
- We keep a reference towards the old listener and make sure that if initialization does happen (for any of the above reasons), if there's an already active listener we get rid of it (we anyway do not need it anymore considering it's stale despite having the same logic)

I would like to write some tests for this if we agree with the approach.

Notes: 

- My initial idea was to do the cleanup on component unmount directly in `Chat` and that worked just fine, however I have the impression that this should be handled and prevented within the `DBSyncManager` itself as sort of a validation and breaking off early if some conditions aren't satisfied
- Having it on unmount also means that if in the future we decide to move this logic elsewhere we also need to "remember" to move the cleanup with it too, which did not sit right with me

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


