### PR TITLE
fix: wrong path in gh workflow for SampleApp

### DIFF
--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - '.github/workflows/sample-distribution.yml'
       - 'package/**'
-      - 'packages/examples/SampleApp/**'
+      - 'examples/SampleApp/**'
 
 jobs:
   build_and_deploy_ios_testflight_qa:


### PR DESCRIPTION
## 🎯 Goal

Pushing directly (and only) to the `SampleApp` path [like so](https://github.com/GetStream/stream-chat-react-native/commit/54fe1b7fb5eb4a8cc5ebddc8fdfa9aa211624050) did not trigger a release, since the path was wrong (likely old structure).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


