### PR TITLE
fix: loading skeleton in the Channel List unnecessary display

### DIFF
--- a/package/src/components/ChannelList/ChannelListMessenger.tsx
+++ b/package/src/components/ChannelList/ChannelListMessenger.tsx
@@ -158,10 +158,6 @@ const ChannelListMessengerWithContext = <
     }
   };
 
-  if (loadingChannels) {
-    return <LoadingIndicator listType='channel' />;
-  }
-
   return (
     <>
       <FlatList


### PR DESCRIPTION
## 🎯 Goal

The goal of the PR is to fix the unnecessary render of the skeleton in the Channel List messenger component, especially when it is already handled within the `ListEmptyComponent` of `FlatList`. 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

Remove the extra condition for the same.

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

Before:
![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-08-30 at 11 31 40](https://github.com/user-attachments/assets/9eb17031-826a-4790-b3d6-310be87ee02f)
After:
![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-08-30 at 11 32 17](https://github.com/user-attachments/assets/91a65cf0-43fe-473e-b4fb-01f5023410f0)

<!-- Add relevant screenshots -->

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


