### PR TITLE
fix: audio recording variety bugs

### DIFF
--- a/package/expo-package/src/handlers/Audio.ts
+++ b/package/expo-package/src/handlers/Audio.ts
@@ -1,4 +1,4 @@
-import { AudioComponent } from '../optionalDependencies/Video';
+import { AudioComponent, RecordingObject } from '../optionalDependencies/Video';
 
 export enum AndroidOutputFormat {
   DEFAULT = 0,
@@ -220,8 +220,13 @@ const sleep = (ms: number) =>
   });
 
 export const Audio = AudioComponent
-  ? {
-      startRecording: async (recordingOptions: RecordingOptions, onRecordingStatusUpdate) => {
+  ? class {
+      recording: typeof RecordingObject | null;
+
+      constructor() {
+        this.recording = null;
+      }
+      async startRecording(recordingOptions: RecordingOptions, onRecordingStatusUpdate) {
         try {
           const permissions = await AudioComponent.getPermissionsAsync();
           const permissionsStatus = permissions.status;
@@ -280,20 +285,23 @@ export const Audio = AudioComponent
             options,
             onRecordingStatusUpdate,
           );
+          this.recording = recording;
           return { accessGranted: true, recording };
         } catch (error) {
           console.error('Failed to start recording', error);
           return { accessGranted: false, recording: null };
         }
-      },
-      stopRecording: async () => {
+      }
+      async stopRecording() {
         try {
+          await this.recording.stopAndUnloadAsync();
           await AudioComponent.setAudioModeAsync({
             allowsRecordingIOS: false,
           });
+          this.recording = null;
         } catch (error) {
           console.log('Error stopping recoding', error);
         }
-      },
+      }
     }
   : null;

--- a/package/expo-package/src/handlers/Audio.ts
+++ b/package/expo-package/src/handlers/Audio.ts
@@ -219,86 +219,86 @@ const sleep = (ms: number) =>
     }, ms);
   });
 
-export const Audio = AudioComponent
-  ? class {
-      recording: typeof RecordingObject | null = null;
+class _Audio {
+  recording: typeof RecordingObject | null = null;
 
-      startRecording = async (recordingOptions: RecordingOptions, onRecordingStatusUpdate) => {
-        try {
-          const permissions = await AudioComponent.getPermissionsAsync();
-          const permissionsStatus = permissions.status;
-          let permissionsGranted = permissions.granted;
+  startRecording = async (recordingOptions: RecordingOptions, onRecordingStatusUpdate) => {
+    try {
+      const permissions = await AudioComponent.getPermissionsAsync();
+      const permissionsStatus = permissions.status;
+      let permissionsGranted = permissions.granted;
 
-          // If permissions have not been determined yet, ask the user for permissions.
-          if (permissionsStatus === 'undetermined') {
-            const newPermissions = await AudioComponent.requestPermissionsAsync();
-            permissionsGranted = newPermissions.granted;
-          }
+      // If permissions have not been determined yet, ask the user for permissions.
+      if (permissionsStatus === 'undetermined') {
+        const newPermissions = await AudioComponent.requestPermissionsAsync();
+        permissionsGranted = newPermissions.granted;
+      }
 
-          // If they are explicitly denied after this, exit early by throwing an error
-          // that will be caught in the catch block below (as a single source of not
-          // starting the player). The player would error itself anyway if we did not do
-          // this, but there's no reason to run the asynchronous calls when we know
-          // immediately that the player will not be run.
-          if (!permissionsGranted) {
-            throw new Error('Missing audio recording permission.');
-          }
-          await AudioComponent.setAudioModeAsync({
-            allowsRecordingIOS: true,
-            playsInSilentModeIOS: true,
-          });
-          const androidOptions = {
-            audioEncoder: AndroidAudioEncoder.AAC,
-            extension: '.aac',
-            outputFormat: AndroidOutputFormat.AAC_ADTS,
-          };
-          const iosOptions = {
-            audioQuality: IOSAudioQuality.HIGH,
-            bitRate: 128000,
-            extension: '.aac',
-            numberOfChannels: 2,
-            outputFormat: IOSOutputFormat.MPEG4AAC,
-            sampleRate: 44100,
-          };
-          const options = {
-            ...recordingOptions,
-            android: androidOptions,
-            ios: iosOptions,
-            web: {},
-          };
-
-          // This is a band-aid fix for this (still unresolved) issue on Expo's side:
-          // https://github.com/expo/expo/issues/21782. It only occurs whenever we get
-          // the permissions dialog and actually select "Allow", causing the player to
-          // throw an error and send the wrong data downstream. So, if the original
-          // permissions.status is 'undetermined', meaning we got to here by allowing
-          // permissions - we sleep for 500ms before proceeding. Any subsequent calls
-          // to startRecording() will not invoke the sleep.
-          if (permissionsStatus === 'undetermined') {
-            await sleep(500);
-          }
-
-          const { recording } = await AudioComponent.Recording.createAsync(
-            options,
-            onRecordingStatusUpdate,
-          );
-          this.recording = recording;
-          return { accessGranted: true, recording };
-        } catch (error) {
-          console.error('Failed to start recording', error);
-          return { accessGranted: false, recording: null };
-        }
+      // If they are explicitly denied after this, exit early by throwing an error
+      // that will be caught in the catch block below (as a single source of not
+      // starting the player). The player would error itself anyway if we did not do
+      // this, but there's no reason to run the asynchronous calls when we know
+      // immediately that the player will not be run.
+      if (!permissionsGranted) {
+        throw new Error('Missing audio recording permission.');
+      }
+      await AudioComponent.setAudioModeAsync({
+        allowsRecordingIOS: true,
+        playsInSilentModeIOS: true,
+      });
+      const androidOptions = {
+        audioEncoder: AndroidAudioEncoder.AAC,
+        extension: '.aac',
+        outputFormat: AndroidOutputFormat.AAC_ADTS,
       };
-      stopRecording = async () => {
-        try {
-          await this.recording.stopAndUnloadAsync();
-          await AudioComponent.setAudioModeAsync({
-            allowsRecordingIOS: false,
-          });
-          this.recording = null;
-        } catch (error) {
-          console.log('Error stopping recoding', error);
-        }
+      const iosOptions = {
+        audioQuality: IOSAudioQuality.HIGH,
+        bitRate: 128000,
+        extension: '.aac',
+        numberOfChannels: 2,
+        outputFormat: IOSOutputFormat.MPEG4AAC,
+        sampleRate: 44100,
       };
+      const options = {
+        ...recordingOptions,
+        android: androidOptions,
+        ios: iosOptions,
+        web: {},
+      };
+
+      // This is a band-aid fix for this (still unresolved) issue on Expo's side:
+      // https://github.com/expo/expo/issues/21782. It only occurs whenever we get
+      // the permissions dialog and actually select "Allow", causing the player to
+      // throw an error and send the wrong data downstream. So, if the original
+      // permissions.status is 'undetermined', meaning we got to here by allowing
+      // permissions - we sleep for 500ms before proceeding. Any subsequent calls
+      // to startRecording() will not invoke the sleep.
+      if (permissionsStatus === 'undetermined') {
+        await sleep(500);
+      }
+
+      const { recording } = await AudioComponent.Recording.createAsync(
+        options,
+        onRecordingStatusUpdate,
+      );
+      this.recording = recording;
+      return { accessGranted: true, recording };
+    } catch (error) {
+      console.error('Failed to start recording', error);
+      return { accessGranted: false, recording: null };
     }
-  : null;
+  };
+  stopRecording = async () => {
+    try {
+      await this.recording.stopAndUnloadAsync();
+      await AudioComponent.setAudioModeAsync({
+        allowsRecordingIOS: false,
+      });
+      this.recording = null;
+    } catch (error) {
+      console.log('Error stopping recoding', error);
+    }
+  };
+}
+
+export const Audio = AudioComponent ? new _Audio() : null;

--- a/package/expo-package/src/handlers/Audio.ts
+++ b/package/expo-package/src/handlers/Audio.ts
@@ -221,11 +221,8 @@ const sleep = (ms: number) =>
 
 export const Audio = AudioComponent
   ? class {
-      recording: typeof RecordingObject | null;
+      recording: typeof RecordingObject | null = null;
 
-      constructor() {
-        this.recording = null;
-      }
       async startRecording(recordingOptions: RecordingOptions, onRecordingStatusUpdate) {
         try {
           const permissions = await AudioComponent.getPermissionsAsync();

--- a/package/expo-package/src/handlers/Audio.ts
+++ b/package/expo-package/src/handlers/Audio.ts
@@ -223,7 +223,7 @@ export const Audio = AudioComponent
   ? class {
       recording: typeof RecordingObject | null = null;
 
-      async startRecording(recordingOptions: RecordingOptions, onRecordingStatusUpdate) {
+      startRecording = async (recordingOptions: RecordingOptions, onRecordingStatusUpdate) => {
         try {
           const permissions = await AudioComponent.getPermissionsAsync();
           const permissionsStatus = permissions.status;
@@ -288,8 +288,8 @@ export const Audio = AudioComponent
           console.error('Failed to start recording', error);
           return { accessGranted: false, recording: null };
         }
-      }
-      async stopRecording() {
+      };
+      stopRecording = async () => {
         try {
           await this.recording.stopAndUnloadAsync();
           await AudioComponent.setAudioModeAsync({
@@ -299,6 +299,6 @@ export const Audio = AudioComponent
         } catch (error) {
           console.log('Error stopping recoding', error);
         }
-      }
+      };
     }
   : null;

--- a/package/expo-package/src/handlers/Audio.ts
+++ b/package/expo-package/src/handlers/Audio.ts
@@ -212,13 +212,34 @@ export type RecordingOptions = {
   keepAudioActiveHint?: boolean;
 };
 
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+
 export const Audio = AudioComponent
   ? {
       startRecording: async (recordingOptions: RecordingOptions, onRecordingStatusUpdate) => {
         try {
-          const permissionsGranted = await AudioComponent.getPermissionsAsync().granted;
+          const permissions = await AudioComponent.getPermissionsAsync();
+          const permissionsStatus = permissions.status;
+          let permissionsGranted = permissions.granted;
+
+          // If permissions have not been determined yet, ask the user for permissions.
+          if (permissionsStatus === 'undetermined') {
+            const newPermissions = await AudioComponent.requestPermissionsAsync();
+            permissionsGranted = newPermissions.granted;
+          }
+
+          // If they are explicitly denied after this, exit early by throwing an error
+          // that will be caught in the catch block below (as a single source of not
+          // starting the player). The player would error itself anyway if we did not do
+          // this, but there's no reason to run the asynchronous calls when we know
+          // immediately that the player will not be run.
           if (!permissionsGranted) {
-            await AudioComponent.requestPermissionsAsync();
+            throw new Error('Missing audio recording permission.');
           }
           await AudioComponent.setAudioModeAsync({
             allowsRecordingIOS: true,
@@ -243,6 +264,17 @@ export const Audio = AudioComponent
             ios: iosOptions,
             web: {},
           };
+
+          // This is a band-aid fix for this (still unresolved) issue on Expo's side:
+          // https://github.com/expo/expo/issues/21782. It only occurs whenever we get
+          // the permissions dialog and actually select "Allow", causing the player to
+          // throw an error and send the wrong data downstream. So, if the original
+          // permissions.status is 'undetermined', meaning we got to here by allowing
+          // permissions - we sleep for 500ms before proceeding. Any subsequent calls
+          // to startRecording() will not invoke the sleep.
+          if (permissionsStatus === 'undetermined') {
+            await sleep(500);
+          }
 
           const { recording } = await AudioComponent.Recording.createAsync(
             options,

--- a/package/expo-package/src/optionalDependencies/Video.ts
+++ b/package/expo-package/src/optionalDependencies/Video.ts
@@ -1,9 +1,11 @@
 let VideoComponent;
 let AudioComponent;
+let RecordingObject;
 try {
   const audioVideoPackage = require('expo-av');
   VideoComponent = audioVideoPackage.Video;
   AudioComponent = audioVideoPackage.Audio;
+  RecordingObject = audioVideoPackage.RecordingObject;
 } catch (e) {
   // do nothing
 }
@@ -14,4 +16,4 @@ if (!VideoComponent || !AudioComponent) {
   );
 }
 
-export { AudioComponent, VideoComponent };
+export { AudioComponent, VideoComponent, RecordingObject };

--- a/package/jest-setup.js
+++ b/package/jest-setup.js
@@ -19,6 +19,7 @@ registerNativeHandlers({
     startPlayer = jest.fn()
     stopPlayer = jest.fn()
     stopRecording = jest.fn()
+    startRecording = jest.fn(() => ({ accessGranted: true, recording: 'some-recording-path' }))
   },
   compressImage: () => null,
   deleteFile: () => null,

--- a/package/jest-setup.js
+++ b/package/jest-setup.js
@@ -15,9 +15,10 @@ export const setNetInfoFetchMock = (fn) => {
   netInfoFetch = fn;
 };
 registerNativeHandlers({
-  Audio: {
-    startPlayer: jest.fn(),
-    stopPlayer: jest.fn(),
+  Audio: class {
+    startPlayer = jest.fn()
+    stopPlayer = jest.fn()
+    stopRecording = jest.fn()
   },
   compressImage: () => null,
   deleteFile: () => null,

--- a/package/jest-setup.js
+++ b/package/jest-setup.js
@@ -15,11 +15,11 @@ export const setNetInfoFetchMock = (fn) => {
   netInfoFetch = fn;
 };
 registerNativeHandlers({
-  Audio: class {
-    startPlayer = jest.fn()
-    stopPlayer = jest.fn()
-    stopRecording = jest.fn()
-    startRecording = jest.fn(() => ({ accessGranted: true, recording: 'some-recording-path' }))
+  Audio: {
+    startPlayer: jest.fn(),
+    startRecording: jest.fn(() => ({ accessGranted: true, recording: 'some-recording-path' })),
+    stopPlayer: jest.fn(),
+    stopRecording: jest.fn(),
   },
   compressImage: () => null,
   deleteFile: () => null,

--- a/package/native-package/src/optionalDependencies/Audio.ts
+++ b/package/native-package/src/optionalDependencies/Audio.ts
@@ -170,13 +170,13 @@ const verifyAndroidPermissions = async () => {
 
 export const Audio = AudioRecorderPackage
   ? class {
-      async pausePlayer() {
+      pausePlayer = async () => {
         await audioRecorderPlayer.pausePlayer();
-      }
-      async resumePlayer() {
+      };
+      resumePlayer = async () => {
         await audioRecorderPlayer.resumePlayer();
-      }
-      async startPlayer(uri, _, onPlaybackStatusUpdate) {
+      };
+      startPlayer = async (uri, _, onPlaybackStatusUpdate) => {
         try {
           const playback = await audioRecorderPlayer.startPlayer(uri);
           console.log({ playback });
@@ -186,8 +186,8 @@ export const Audio = AudioRecorderPackage
         } catch (error) {
           console.log('Error starting player', error);
         }
-      }
-      async startRecording(options: RecordingOptions, onRecordingStatusUpdate) {
+      };
+      startRecording = async (options: RecordingOptions, onRecordingStatusUpdate) => {
         if (Platform.OS === 'android') {
           try {
             await verifyAndroidPermissions();
@@ -231,22 +231,22 @@ export const Audio = AudioRecorderPackage
           audioRecorderPlayer._hasPausedRecord = false;
           return { accessGranted: false, recording: null };
         }
-      }
-      async stopPlayer() {
+      };
+      stopPlayer = async () => {
         try {
           await audioRecorderPlayer.stopPlayer();
           audioRecorderPlayer.removePlayBackListener();
         } catch (error) {
           console.log(error);
         }
-      }
-      async stopRecording() {
+      };
+      stopRecording = async () => {
         try {
           await audioRecorderPlayer.stopRecorder();
           audioRecorderPlayer.removeRecordBackListener();
         } catch (error) {
           console.log(error);
         }
-      }
+      };
     }
   : null;

--- a/package/native-package/src/optionalDependencies/Audio.ts
+++ b/package/native-package/src/optionalDependencies/Audio.ts
@@ -219,7 +219,6 @@ export const Audio = AudioRecorderPackage
           audioRecorderPlayer.addRecordBackListener((status) => {
             onRecordingStatusUpdate(status);
           });
-          console.log('ISE: PERMISSIONS: ', recording);
           return { accessGranted: true, recording };
         } catch (error) {
           console.error('Failed to start recording', error);

--- a/package/native-package/src/optionalDependencies/Audio.ts
+++ b/package/native-package/src/optionalDependencies/Audio.ts
@@ -168,85 +168,85 @@ const verifyAndroidPermissions = async () => {
   return true;
 };
 
-export const Audio = AudioRecorderPackage
-  ? class {
-      pausePlayer = async () => {
-        await audioRecorderPlayer.pausePlayer();
-      };
-      resumePlayer = async () => {
-        await audioRecorderPlayer.resumePlayer();
-      };
-      startPlayer = async (uri, _, onPlaybackStatusUpdate) => {
-        try {
-          const playback = await audioRecorderPlayer.startPlayer(uri);
-          console.log({ playback });
-          audioRecorderPlayer.addPlayBackListener((status) => {
-            onPlaybackStatusUpdate(status);
-          });
-        } catch (error) {
-          console.log('Error starting player', error);
-        }
-      };
-      startRecording = async (options: RecordingOptions, onRecordingStatusUpdate) => {
-        if (Platform.OS === 'android') {
-          try {
-            await verifyAndroidPermissions();
-          } catch (err) {
-            console.warn('Audio Recording Permissions error', err);
-            return;
-          }
-        }
-        try {
-          const path = Platform.select({
-            android: `${RNFS.CachesDirectoryPath}/sound.aac`,
-            ios: 'sound.aac',
-          });
-          const audioSet = {
-            AudioEncoderAndroid: AudioEncoderAndroidType.AAC,
-            AudioSourceAndroid: AudioSourceAndroidType.MIC,
-            AVEncoderAudioQualityKeyIOS: AVEncoderAudioQualityIOSType.high,
-            AVFormatIDKeyIOS: AVEncodingOption.aac,
-            AVModeIOS: AVModeIOSOption.measurement,
-            AVNumberOfChannelsKeyIOS: 2,
-            OutputFormatAndroid: OutputFormatAndroidType.AAC_ADTS,
-          };
-          const recording = await audioRecorderPlayer.startRecorder(
-            path,
-            audioSet,
-            options?.isMeteringEnabled,
-          );
-
-          audioRecorderPlayer.addRecordBackListener((status) => {
-            onRecordingStatusUpdate(status);
-          });
-          return { accessGranted: true, recording };
-        } catch (error) {
-          console.error('Failed to start recording', error);
-          // There is currently a bug in react-native-audio-recorder-player and we
-          // need to do this until it gets fixed. More information can be found here:
-          // https://github.com/hyochan/react-native-audio-recorder-player/pull/625
-          // eslint-disable-next-line no-underscore-dangle
-          audioRecorderPlayer._isRecording = false;
-          // eslint-disable-next-line no-underscore-dangle
-          audioRecorderPlayer._hasPausedRecord = false;
-          return { accessGranted: false, recording: null };
-        }
-      };
-      stopPlayer = async () => {
-        try {
-          await audioRecorderPlayer.stopPlayer();
-          audioRecorderPlayer.removePlayBackListener();
-        } catch (error) {
-          console.log(error);
-        }
-      };
-      stopRecording = async () => {
-        try {
-          await audioRecorderPlayer.stopRecorder();
-          audioRecorderPlayer.removeRecordBackListener();
-        } catch (error) {
-          console.log(error);
-        }
-      };
+class _Audio {
+  pausePlayer = async () => {
+    await audioRecorderPlayer.pausePlayer();
+  };
+  resumePlayer = async () => {
+    await audioRecorderPlayer.resumePlayer();
+  };
+  startPlayer = async (uri, _, onPlaybackStatusUpdate) => {
+    try {
+      const playback = await audioRecorderPlayer.startPlayer(uri);
+      console.log({ playback });
+      audioRecorderPlayer.addPlayBackListener((status) => {
+        onPlaybackStatusUpdate(status);
+      });
+    } catch (error) {
+      console.log('Error starting player', error);
     }
-  : null;
+  };
+  startRecording = async (options: RecordingOptions, onRecordingStatusUpdate) => {
+    if (Platform.OS === 'android') {
+      try {
+        await verifyAndroidPermissions();
+      } catch (err) {
+        console.warn('Audio Recording Permissions error', err);
+        return;
+      }
+    }
+    try {
+      const path = Platform.select({
+        android: `${RNFS.CachesDirectoryPath}/sound.aac`,
+        ios: 'sound.aac',
+      });
+      const audioSet = {
+        AudioEncoderAndroid: AudioEncoderAndroidType.AAC,
+        AudioSourceAndroid: AudioSourceAndroidType.MIC,
+        AVEncoderAudioQualityKeyIOS: AVEncoderAudioQualityIOSType.high,
+        AVFormatIDKeyIOS: AVEncodingOption.aac,
+        AVModeIOS: AVModeIOSOption.measurement,
+        AVNumberOfChannelsKeyIOS: 2,
+        OutputFormatAndroid: OutputFormatAndroidType.AAC_ADTS,
+      };
+      const recording = await audioRecorderPlayer.startRecorder(
+        path,
+        audioSet,
+        options?.isMeteringEnabled,
+      );
+
+      audioRecorderPlayer.addRecordBackListener((status) => {
+        onRecordingStatusUpdate(status);
+      });
+      return { accessGranted: true, recording };
+    } catch (error) {
+      console.error('Failed to start recording', error);
+      // There is currently a bug in react-native-audio-recorder-player and we
+      // need to do this until it gets fixed. More information can be found here:
+      // https://github.com/hyochan/react-native-audio-recorder-player/pull/625
+      // eslint-disable-next-line no-underscore-dangle
+      audioRecorderPlayer._isRecording = false;
+      // eslint-disable-next-line no-underscore-dangle
+      audioRecorderPlayer._hasPausedRecord = false;
+      return { accessGranted: false, recording: null };
+    }
+  };
+  stopPlayer = async () => {
+    try {
+      await audioRecorderPlayer.stopPlayer();
+      audioRecorderPlayer.removePlayBackListener();
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  stopRecording = async () => {
+    try {
+      await audioRecorderPlayer.stopRecorder();
+      audioRecorderPlayer.removeRecordBackListener();
+    } catch (error) {
+      console.log(error);
+    }
+  };
+}
+
+export const Audio = AudioRecorderPackage ? new _Audio() : null;

--- a/package/native-package/src/optionalDependencies/Audio.ts
+++ b/package/native-package/src/optionalDependencies/Audio.ts
@@ -219,9 +219,17 @@ export const Audio = AudioRecorderPackage
           audioRecorderPlayer.addRecordBackListener((status) => {
             onRecordingStatusUpdate(status);
           });
+          console.log('ISE: PERMISSIONS: ', recording);
           return { accessGranted: true, recording };
         } catch (error) {
           console.error('Failed to start recording', error);
+          // There is currently a bug in react-native-audio-recorder-player and we
+          // need to do this until it gets fixed. More information can be found here:
+          // https://github.com/hyochan/react-native-audio-recorder-player/pull/625
+          // eslint-disable-next-line no-underscore-dangle
+          audioRecorderPlayer._isRecording = false;
+          // eslint-disable-next-line no-underscore-dangle
+          audioRecorderPlayer._hasPausedRecord = false;
           return { accessGranted: false, recording: null };
         }
       },
@@ -234,8 +242,12 @@ export const Audio = AudioRecorderPackage
         }
       },
       stopRecording: async () => {
-        await audioRecorderPlayer.stopRecorder();
-        audioRecorderPlayer.removeRecordBackListener();
+        try {
+          await audioRecorderPlayer.stopRecorder();
+          audioRecorderPlayer.removeRecordBackListener();
+        } catch (error) {
+          console.log(error);
+        }
       },
     }
   : null;

--- a/package/native-package/src/optionalDependencies/Audio.ts
+++ b/package/native-package/src/optionalDependencies/Audio.ts
@@ -169,14 +169,15 @@ const verifyAndroidPermissions = async () => {
 };
 
 export const Audio = AudioRecorderPackage
-  ? {
-      pausePlayer: async () => {
+  ? class {
+      constructor() {}
+      async pausePlayer() {
         await audioRecorderPlayer.pausePlayer();
-      },
-      resumePlayer: async () => {
+      }
+      async resumePlayer() {
         await audioRecorderPlayer.resumePlayer();
-      },
-      startPlayer: async (uri, _, onPlaybackStatusUpdate) => {
+      }
+      async startPlayer(uri, _, onPlaybackStatusUpdate) {
         try {
           const playback = await audioRecorderPlayer.startPlayer(uri);
           console.log({ playback });
@@ -186,8 +187,8 @@ export const Audio = AudioRecorderPackage
         } catch (error) {
           console.log('Error starting player', error);
         }
-      },
-      startRecording: async (options: RecordingOptions, onRecordingStatusUpdate) => {
+      }
+      async startRecording(options: RecordingOptions, onRecordingStatusUpdate) {
         if (Platform.OS === 'android') {
           try {
             await verifyAndroidPermissions();
@@ -231,22 +232,22 @@ export const Audio = AudioRecorderPackage
           audioRecorderPlayer._hasPausedRecord = false;
           return { accessGranted: false, recording: null };
         }
-      },
-      stopPlayer: async () => {
+      }
+      async stopPlayer() {
         try {
           await audioRecorderPlayer.stopPlayer();
           audioRecorderPlayer.removePlayBackListener();
         } catch (error) {
           console.log(error);
         }
-      },
-      stopRecording: async () => {
+      }
+      async stopRecording() {
         try {
           await audioRecorderPlayer.stopRecorder();
           audioRecorderPlayer.removeRecordBackListener();
         } catch (error) {
           console.log(error);
         }
-      },
+      }
     }
   : null;

--- a/package/native-package/src/optionalDependencies/Audio.ts
+++ b/package/native-package/src/optionalDependencies/Audio.ts
@@ -170,7 +170,6 @@ const verifyAndroidPermissions = async () => {
 
 export const Audio = AudioRecorderPackage
   ? class {
-      constructor() {}
       async pausePlayer() {
         await audioRecorderPlayer.pausePlayer();
       }

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -737,12 +737,12 @@ const MessageInputWithContext = <
                 progress={progress}
                 waveformData={waveformData}
               />
-            ) : (
+            ) : micLocked ? (
               <AudioRecordingInProgress
                 recordingDuration={recordingDuration}
                 waveformData={waveformData}
               />
-            )}
+            ) : null}
           </>
         )}
 

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -645,14 +645,16 @@ const MessageInputWithContext = <
         micPositionY.value = newPositionY;
       }
     })
-    .onFinalize(() => {
+    .onEnd(() => {
       const belowThresholdY = micPositionY.value > Y_AXIS_POSITION / 2;
       const belowThresholdX = micPositionX.value > X_AXIS_POSITION / 2;
 
       if (belowThresholdY && belowThresholdX) {
         micPositionY.value = withSpring(0);
         micPositionX.value = withSpring(0);
-        runOnJS(uploadVoiceRecording)(asyncMessagesMultiSendEnabled);
+        if (recordingStatus === 'recording') {
+          runOnJS(uploadVoiceRecording)(asyncMessagesMultiSendEnabled);
+        }
         return;
       }
 

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -2,15 +2,14 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { NativeSyntheticEvent, StyleSheet, TextInputFocusEventData, View } from 'react-native';
 
 import {
-  GestureEvent,
-  PanGestureHandler,
+  Gesture,
+  GestureDetector,
   PanGestureHandlerEventPayload,
 } from 'react-native-gesture-handler';
 import Animated, {
   Extrapolation,
   interpolate,
   runOnJS,
-  useAnimatedGestureHandler,
   useAnimatedStyle,
   useSharedValue,
   withSpring,
@@ -104,6 +103,7 @@ type MessageInputPropsWithContext<
     | 'asyncMessagesLockDistance'
     | 'asyncMessagesMinimumPressDuration'
     | 'asyncMessagesSlideToCancelDistance'
+    | 'asyncMessagesMultiSendEnabled'
     | 'asyncUploads'
     | 'AudioRecorder'
     | 'AudioRecordingInProgress'
@@ -168,6 +168,7 @@ const MessageInputWithContext = <
     asyncIds,
     asyncMessagesLockDistance,
     asyncMessagesMinimumPressDuration,
+    asyncMessagesMultiSendEnabled,
     asyncMessagesSlideToCancelDistance,
     asyncUploads,
     AttachmentPickerSelectionBar,
@@ -624,19 +625,16 @@ const MessageInputWithContext = <
 
   const resetAudioRecording = async () => {
     await deleteVoiceRecording();
-    micPositionX.value = 0;
   };
 
   const micLockHandler = () => {
     setMicLocked(true);
-    micPositionY.value = 0;
     triggerHaptic('impactMedium');
   };
 
-  const handleMicGestureEvent = useAnimatedGestureHandler<
-    GestureEvent<PanGestureHandlerEventPayload>
-  >({
-    onActive: (event) => {
+  const panGestureMic = Gesture.Pan()
+    .activateAfterLongPress(asyncMessagesMinimumPressDuration + 100)
+    .onChange((event: PanGestureHandlerEventPayload) => {
       const newPositionX = event.translationX;
       const newPositionY = event.translationY;
 
@@ -646,27 +644,36 @@ const MessageInputWithContext = <
       if (newPositionY <= 0 && newPositionY >= Y_AXIS_POSITION) {
         micPositionY.value = newPositionY;
       }
-    },
-    onFinish: () => {
-      if (micPositionY.value > Y_AXIS_POSITION / 2) {
+    })
+    .onFinalize(() => {
+      const belowThresholdY = micPositionY.value > Y_AXIS_POSITION / 2;
+      const belowThresholdX = micPositionX.value > X_AXIS_POSITION / 2;
+
+      if (belowThresholdY && belowThresholdX) {
         micPositionY.value = withSpring(0);
-      } else {
+        micPositionX.value = withSpring(0);
+        runOnJS(uploadVoiceRecording)(asyncMessagesMultiSendEnabled);
+        return;
+      }
+
+      if (!belowThresholdY) {
         micPositionY.value = withSpring(Y_AXIS_POSITION);
         runOnJS(micLockHandler)();
       }
-      if (micPositionX.value > X_AXIS_POSITION / 2) {
-        micPositionX.value = withSpring(0);
-      } else {
+
+      if (!belowThresholdX) {
         micPositionX.value = withSpring(X_AXIS_POSITION);
         runOnJS(resetAudioRecording)();
       }
-    },
-    onStart: () => {
+
+      micPositionX.value = 0;
+      micPositionY.value = 0;
+    })
+    .onStart(() => {
       micPositionX.value = 0;
       micPositionY.value = 0;
       runOnJS(setMicLocked)(false);
-    },
-  });
+    });
 
   const animatedStyles = {
     lockIndicator: useAnimatedStyle(() => ({
@@ -720,21 +727,20 @@ const MessageInputWithContext = <
               micLocked={micLocked}
               style={animatedStyles.lockIndicator}
             />
-            {micLocked &&
-              (recordingStatus === 'stopped' ? (
-                <AudioRecordingPreview
-                  onVoicePlayerPlayPause={onVoicePlayerPlayPause}
-                  paused={paused}
-                  position={position}
-                  progress={progress}
-                  waveformData={waveformData}
-                />
-              ) : (
-                <AudioRecordingInProgress
-                  recordingDuration={recordingDuration}
-                  waveformData={waveformData}
-                />
-              ))}
+            {recordingStatus === 'stopped' ? (
+              <AudioRecordingPreview
+                onVoicePlayerPlayPause={onVoicePlayerPlayPause}
+                paused={paused}
+                position={position}
+                progress={progress}
+                waveformData={waveformData}
+              />
+            ) : (
+              <AudioRecordingInProgress
+                recordingDuration={recordingDuration}
+                waveformData={waveformData}
+              />
+            )}
           </>
         )}
 
@@ -818,10 +824,7 @@ const MessageInputWithContext = <
                   </View>
                 ))}
               {audioRecordingEnabled && !micLocked && (
-                <PanGestureHandler
-                  activateAfterLongPress={asyncMessagesMinimumPressDuration + 100}
-                  onGestureEvent={handleMicGestureEvent}
-                >
+                <GestureDetector gesture={panGestureMic}>
                   <Animated.View
                     style={[
                       styles.micButtonContainer,
@@ -835,7 +838,7 @@ const MessageInputWithContext = <
                       startVoiceRecording={startVoiceRecording}
                     />
                   </Animated.View>
-                </PanGestureHandler>
+                </GestureDetector>
               )}
             </>
           )}
@@ -1042,6 +1045,7 @@ export const MessageInput = <
     asyncIds,
     asyncMessagesLockDistance,
     asyncMessagesMinimumPressDuration,
+    asyncMessagesMultiSendEnabled,
     asyncMessagesSlideToCancelDistance,
     asyncUploads,
     AudioRecorder,
@@ -1118,6 +1122,7 @@ export const MessageInput = <
         asyncIds,
         asyncMessagesLockDistance,
         asyncMessagesMinimumPressDuration,
+        asyncMessagesMultiSendEnabled,
         asyncMessagesSlideToCancelDistance,
         asyncUploads,
         AttachmentPickerSelectionBar,

--- a/package/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/package/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -16,6 +16,7 @@ import {
 import { generateChannelResponse } from '../../../mock-builders/generator/channel';
 import { generateUser } from '../../../mock-builders/generator/user';
 import { getTestClientWithUser } from '../../../mock-builders/mock';
+import { Audio } from '../../../native';
 import { AttachmentPickerSelectionBar } from '../../AttachmentPicker/components/AttachmentPickerSelectionBar';
 import { CameraSelectorIcon } from '../../AttachmentPicker/components/CameraSelectorIcon';
 import { FileSelectorIcon } from '../../AttachmentPicker/components/FileSelectorIcon';
@@ -128,11 +129,13 @@ describe('MessageInput', () => {
     expect(Alert.alert).toHaveBeenCalledTimes(4);
   });
 
-  it('should start the audio recorder on long press', async () => {
+  it('should start the audio recorder on long press and cleanup on unmount', async () => {
+    jest.clearAllMocks();
+
     await initializeChannel(generateChannelResponse());
     const userBot = userEvent.setup();
 
-    const { queryByTestId } = render(
+    const { queryByTestId, unmount } = render(
       <Chat client={chatClient}>
         <Channel audioRecordingEnabled channel={channel}>
           <MessageInput />
@@ -143,12 +146,24 @@ describe('MessageInput', () => {
     await userBot.longPress(queryByTestId('audio-button'), { duration: 1000 });
 
     await waitFor(() => {
+      expect(Audio.startRecording).toHaveBeenCalledTimes(1);
+      expect(Audio.stopRecording).not.toHaveBeenCalled();
       expect(queryByTestId('recording-active-container')).toBeTruthy();
       expect(Alert.alert).not.toHaveBeenCalledWith('Hold to start recording.');
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      expect(Audio.stopRecording).toHaveBeenCalledTimes(1);
+      // once when starting the recording, once on unmount
+      expect(Audio.stopPlayer).toHaveBeenCalledTimes(2);
     });
   });
 
   it('should trigger an alert if a normal press happened on audio recording', async () => {
+    jest.clearAllMocks();
+
     await initializeChannel(generateChannelResponse());
     const userBot = userEvent.setup();
 
@@ -163,7 +178,11 @@ describe('MessageInput', () => {
     await userBot.press(queryByTestId('audio-button'));
 
     await waitFor(() => {
+      expect(Audio.startRecording).not.toHaveBeenCalled();
+      expect(Audio.stopRecording).not.toHaveBeenCalled();
       expect(queryByTestId('recording-active-container')).not.toBeTruthy();
+      // This is sort of a brittle test, but there doesn't seem to be another way
+      // to target alerts. The reason why it's here is because we had a bug with it.
       expect(Alert.alert).toHaveBeenCalledWith('Hold to start recording.');
     });
   });

--- a/package/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/package/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -140,7 +140,7 @@ describe('MessageInput', () => {
         <Channel audioRecordingEnabled channel={channel}>
           <MessageInput />
         </Channel>
-      </Chat>
+      </Chat>,
     );
 
     await userBot.longPress(queryByTestId('audio-button'), { duration: 1000 });
@@ -172,7 +172,7 @@ describe('MessageInput', () => {
         <Channel audioRecordingEnabled channel={channel}>
           <MessageInput />
         </Channel>
-      </Chat>
+      </Chat>,
     );
 
     await userBot.press(queryByTestId('audio-button'));

--- a/package/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/package/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Alert } from 'react-native';
 
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { cleanup, fireEvent, render, userEvent, waitFor } from '@testing-library/react-native';
 
 import * as AttachmentPickerUtils from '../../../contexts/attachmentPickerContext/AttachmentPickerContext';
 import { OverlayProvider } from '../../../contexts/overlayContext/OverlayProvider';
@@ -126,5 +126,45 @@ describe('MessageInput', () => {
 
     // Both for files and for images triggered in one test itself.
     expect(Alert.alert).toHaveBeenCalledTimes(4);
+  });
+
+  it('should start the audio recorder on long press', async () => {
+    await initializeChannel(generateChannelResponse());
+    const userBot = userEvent.setup();
+
+    const { queryByTestId } = render(
+      <Chat client={chatClient}>
+        <Channel audioRecordingEnabled channel={channel}>
+          <MessageInput />
+        </Channel>
+      </Chat>
+    );
+
+    await userBot.longPress(queryByTestId('audio-button'), { duration: 1000 });
+
+    await waitFor(() => {
+      expect(queryByTestId('recording-active-container')).toBeTruthy();
+      expect(Alert.alert).not.toHaveBeenCalledWith('Hold to start recording.');
+    });
+  });
+
+  it('should trigger an alert if a normal press happened on audio recording', async () => {
+    await initializeChannel(generateChannelResponse());
+    const userBot = userEvent.setup();
+
+    const { queryByTestId } = render(
+      <Chat client={chatClient}>
+        <Channel audioRecordingEnabled channel={channel}>
+          <MessageInput />
+        </Channel>
+      </Chat>
+    );
+
+    await userBot.press(queryByTestId('audio-button'));
+
+    await waitFor(() => {
+      expect(queryByTestId('recording-active-container')).not.toBeTruthy();
+      expect(Alert.alert).toHaveBeenCalledWith('Hold to start recording.');
+    });
   });
 });

--- a/package/src/components/MessageInput/components/AudioRecorder/AudioRecorder.tsx
+++ b/package/src/components/MessageInput/components/AudioRecorder/AudioRecorder.tsx
@@ -180,7 +180,7 @@ const AudioRecorderWithContext = <
   } else {
     return (
       <>
-        <View style={[styles.micContainer, micContainer]}>
+        <View style={[styles.micContainer, micContainer]} testID='recording-active-container'>
           <Mic fill={recordingDuration !== 0 ? accent_red : grey_dark} size={32} {...micIcon} />
           <Text style={[styles.durationLabel, { color: grey_dark }]}>
             {recordingDuration ? dayjs.duration(recordingDuration).format('mm:ss') : null}

--- a/package/src/components/MessageInput/hooks/useAudioController.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioController.tsx
@@ -45,7 +45,6 @@ export const useAudioController = () => {
   // and cleanup during unmounting (stopping both the player and a potential recording).
   useEffect(() => {
     if (AudioClass) {
-      // @ts-ignore
       Audio = new AudioClass();
     }
     return () => {

--- a/package/src/components/MessageInput/hooks/useAudioController.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioController.tsx
@@ -163,9 +163,7 @@ export const useAudioController = () => {
    * Function to start voice recording.
    */
   const startVoiceRecording = async () => {
-    console.log('ISE: START RECORDING')
     if (!Audio) return;
-    setRecordingStatus('recording');
     const recordingInfo = await Audio.startRecording(
       {
         isMeteringEnabled: true,
@@ -173,7 +171,6 @@ export const useAudioController = () => {
       onRecordingStatusUpdate,
     );
     const accessGranted = recordingInfo.accessGranted;
-    console.log('ACCESS GRANTED: ', accessGranted)
     if (accessGranted) {
       setPermissionsGranted(true);
       const recording = recordingInfo.recording;
@@ -181,6 +178,7 @@ export const useAudioController = () => {
         recording.setProgressUpdateInterval(Platform.OS === 'android' ? 100 : 60);
       }
       setRecording(recording);
+      setRecordingStatus('recording');
       await stopVoicePlayer();
     } else {
       setPermissionsGranted(false);
@@ -243,7 +241,6 @@ export const useAudioController = () => {
     if (!paused) {
       await stopVoicePlayer();
     }
-    console.log('ISE: R: ', recordingStatus)
     if (recordingStatus === 'recording') {
       await stopVoiceRecording();
     }

--- a/package/src/components/MessageInput/hooks/useAudioController.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioController.tsx
@@ -4,9 +4,8 @@ import { Alert, Platform } from 'react-native';
 
 import { useMessageInputContext } from '../../../contexts/messageInputContext/MessageInputContext';
 import {
-  Audio as AudioClass,
+  Audio,
   AudioRecordingReturnType,
-  AudioType,
   PlaybackStatus,
   RecordingStatus,
   Sound,
@@ -18,8 +17,6 @@ import { resampleWaveformData } from '../utils/audioSampling';
 import { normalizeAudioLevel } from '../utils/normalizeAudioLevel';
 
 export type RecordingStatusStates = 'idle' | 'recording' | 'stopped';
-
-let Audio: AudioType;
 
 /**
  * The hook that controls all the async audio core features including start/stop or recording, player, upload/delete of the recorded audio.
@@ -41,17 +38,15 @@ export const useAudioController = () => {
   // For playback support in Expo CLI apps
   const soundRef = useRef<SoundReturnType | null>(null);
 
-  // This effect controls the creation of an AudioClass instance during mounting
-  // and cleanup during unmounting (stopping both the player and a potential recording).
-  useEffect(() => {
-    if (AudioClass) {
-      Audio = new AudioClass();
-    }
-    return () => {
+  // This effect stop the player from playing and stops audio recording on
+  // the audio SDK side on unmount.
+  useEffect(
+    () => () => {
       stopVoicePlayer();
       stopSDKVoiceRecording();
-    };
-  }, []);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (isScheduledForSubmit) {

--- a/package/src/components/MessageInput/hooks/useAudioController.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioController.tsx
@@ -42,6 +42,7 @@ export const useAudioController = () => {
   useEffect(
     () => () => {
       stopVoicePlayer();
+      deleteVoiceRecording();
     },
     [],
   );
@@ -162,6 +163,7 @@ export const useAudioController = () => {
    * Function to start voice recording.
    */
   const startVoiceRecording = async () => {
+    console.log('ISE: START RECORDING')
     if (!Audio) return;
     setRecordingStatus('recording');
     const recordingInfo = await Audio.startRecording(
@@ -171,6 +173,7 @@ export const useAudioController = () => {
       onRecordingStatusUpdate,
     );
     const accessGranted = recordingInfo.accessGranted;
+    console.log('ACCESS GRANTED: ', accessGranted)
     if (accessGranted) {
       setPermissionsGranted(true);
       const recording = recordingInfo.recording;
@@ -240,6 +243,7 @@ export const useAudioController = () => {
     if (!paused) {
       await stopVoicePlayer();
     }
+    console.log('ISE: R: ', recordingStatus)
     if (recordingStatus === 'recording') {
       await stopVoiceRecording();
     }

--- a/package/src/native.ts
+++ b/package/src/native.ts
@@ -240,9 +240,7 @@ export type AudioType = {
   stopPlayer?: () => Promise<void>;
 };
 
-type AudioConstructSignature = new () => AudioType;
-
-export let Audio: AudioConstructSignature;
+export let Audio: AudioType;
 
 export let Sound: SoundType;
 
@@ -290,7 +288,7 @@ export type VideoType = {
 export let Video: React.ComponentType<VideoType>;
 
 type Handlers = {
-  Audio?: AudioConstructSignature;
+  Audio?: AudioType;
   compressImage?: CompressImage;
   deleteFile?: DeleteFile;
   FlatList?: typeof DefaultFlatList;

--- a/package/src/native.ts
+++ b/package/src/native.ts
@@ -240,6 +240,10 @@ export type AudioType = {
   stopPlayer?: () => Promise<void>;
 };
 
+type AudioConstructSignature = new () => AudioType;
+
+export let Audio: AudioConstructSignature;
+
 export let Sound: SoundType;
 
 export type VideoProgressData = {
@@ -286,7 +290,7 @@ export type VideoType = {
 export let Video: React.ComponentType<VideoType>;
 
 type Handlers = {
-  Audio?: AudioType;
+  Audio?: AudioConstructSignature;
   compressImage?: CompressImage;
   deleteFile?: DeleteFile;
   FlatList?: typeof DefaultFlatList;

--- a/package/src/native.ts
+++ b/package/src/native.ts
@@ -240,8 +240,6 @@ export type AudioType = {
   stopPlayer?: () => Promise<void>;
 };
 
-export let Audio: AudioType;
-
 export let Sound: SoundType;
 
 export type VideoProgressData = {


### PR DESCRIPTION
## 🎯 Goal

This PR addresses the issues mentioned in [this Github issue](https://github.com/GetStream/stream-chat-react-native/issues/2636). In addition to this, it also takes care of a variety of additional bugs and odd behaviours I found with async audio recording in particular.

## 🛠 Implementation details

Provided below is a list of the things it fixes.

General (all platforms):

- When letting go of the recording button while below both the threshold for locking and canceling, the recording is sent to the chat as an available attachment
    -  I wasn't too sure if this is the behaviour we want, but it seems a lot more intuitive than having the recording stuck in a weird state so it made sense
    - The difference between locking and doing it like this is that this is the "quick way" to send an audio recording whereas the lock is more of an "advanced view"
- Audio recording would not stop if we navigate away from the screen where it got triggered (where `<MessageList />` is present for example)
- Simply clicking on the recording button instead of doing a long press would sometimes cause issues and would not display the `Hold to start Recording` message
    - Took the chance here to move to the new [`Gesture` API](https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/gesture) since it seems a lot more stable and has quite a few more options

Vanilla React Native:

- Whenever opening the app for the first time and being asked for permissions, clicking "Accept" would cause the app to be stuck in an irrecoverable state of recording until we completely unmount the `AudioRecorder` twice
    - The behaviour of starting recording automatically after we've accepted on the permissions dialog is still there (it's actually not trivial to skip this, since a lot of intertwined state is causing it) but now we can safely take over the controls again by doing a long press on the recording button and either cancel the recording, open the microphone locked view or simply do a quick send of it
- If permissions were specifically denied, pressing the recording button **twice** in a row would cause the audio player to start the recording process in the background but not actually record, setting the `AudioRecorder` in an unrecoverable state (either unmounting or killing the app entirely would be the only thing that fixes this)
    - This is a bug with the underlying library we're using that's well documented [here](https://github.com/hyochan/react-native-audio-recorder-player/pull/625); feel free to read my comment for more details about our specific usecase

Expo: 

- There was an issue with the `expo-av` library that occurs immediately after accepting permissions if we run `Recording.createAsync()` too quickly before the JS thread taking control again
    - Recording would fail and we would immediately get the message that we haven't provided permissions, despite the fact that we just did (this is a side-effect of the recording erroring out on the `expo-av` side) 
    - The issue is well documented [here](https://github.com/expo/expo/issues/21782)
- A slight optimization whenever permission has been declined where we now exit early instead of proceeding with the process again

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


