### PR TITLE
fix: issue with loading app settings when the connectUser is not called on app

### DIFF
--- a/package/src/components/Chat/hooks/__tests__/useAppSettings.test.tsx
+++ b/package/src/components/Chat/hooks/__tests__/useAppSettings.test.tsx
@@ -18,7 +18,6 @@ describe('useAppSettings', () => {
               auto_translation_enabled: true,
             }),
           ),
-          userID: 'some-user-id',
         } as unknown as StreamChat,
         isOnline,
         false,

--- a/package/src/components/Chat/hooks/useAppSettings.ts
+++ b/package/src/components/Chat/hooks/useAppSettings.ts
@@ -18,6 +18,9 @@ export const useAppSettings = <
   const isMounted = useIsMountedRef();
 
   useEffect(() => {
+    /**
+     * Fetches app settings from the backend when offline support is disabled.
+     */
     const enforceAppSettingsWithoutOfflineSupport = async () => {
       try {
         const appSettings = await client.getAppSettings();
@@ -31,6 +34,10 @@ export const useAppSettings = <
       }
     };
 
+    /**
+     * Fetches app settings from the local database when offline support is enabled if internet is off else fetches from the backend.
+     * Note: We need to set the app settings from the local database when offline as the client will not have the app settings in memory. For this we store it for the `client.userID`.
+     */
     const enforceAppSettingsWithOfflineSupport = async () => {
       if (!client.userID) return;
 

--- a/package/src/components/Chat/hooks/useAppSettings.ts
+++ b/package/src/components/Chat/hooks/useAppSettings.ts
@@ -37,6 +37,8 @@ export const useAppSettings = <
     /**
      * Fetches app settings from the local database when offline support is enabled if internet is off else fetches from the backend.
      * Note: We need to set the app settings from the local database when offline as the client will not have the app settings in memory. For this we store it for the `client.userID`.
+     *
+     * TODO: Remove client.userID usage for offline support case.
      */
     const enforceAppSettingsWithOfflineSupport = async () => {
       if (!client.userID) return;


### PR DESCRIPTION
## 🎯 Goal

The goal of the PR is to allow to fetch app settings for the api key even when the connect user is not done. Ideally the app settings has nothing to do with userId so this should not be checked when fetching the app settings. This has been fixed in the PR.

Note: This PR handles the case for non-offline cases and could be a temporary fix. For offline cases, we will have a look into it later.

cc: @isekovanic 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


