### PR TITLE
fix: unable to upload file due to special characters in the file name

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/generateMarkdownText.ts
+++ b/package/src/components/Message/MessageSimple/utils/generateMarkdownText.ts
@@ -2,10 +2,7 @@ import truncate from 'lodash/truncate';
 
 import { parseLinksFromText } from './parseLinks';
 
-// If you need to use any of the special characters literally (actually searching for a "*", for instance), you must escape it by putting a backslash in front of it.
-function escapeRegExp(text: string) {
-  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
-}
+import { escapeRegExp } from '../../../../utils/utils';
 
 export const generateMarkdownText = (text?: string) => {
   if (!text) return null;

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -23,6 +23,7 @@ import { generateMarkdownText } from './generateMarkdownText';
 import type { MessageContextValue } from '../../../../contexts/messageContext/MessageContext';
 import type { Colors, MarkdownStyle } from '../../../../contexts/themeContext/utils/theme';
 import type { DefaultStreamChatGenerics } from '../../../../types/types';
+import { escapeRegExp } from '../../../../utils/utils';
 import type { MessageType } from '../../../MessageList/hooks/useMessageList';
 
 const defaultMarkdownStyles: MarkdownStyle = {
@@ -210,10 +211,6 @@ export const renderText = <
       </Text>
     );
   };
-
-  function escapeRegExp(text: string) {
-    return text.replace(/[-[\]{}()*+?.,/\\^$|#]/g, '\\$&');
-  }
 
   // take the @ mentions and turn them into markdown?
   // translate links

--- a/package/src/utils/utils.ts
+++ b/package/src/utils/utils.ts
@@ -677,3 +677,12 @@ export const getDurationLabelFromDuration = (duration: number) => {
 
   return durationLabel;
 };
+
+/**
+ * Utility to escape special characters in a string.
+ * @param text
+ * @returns string
+ */
+export function escapeRegExp(text: string) {
+  return text.replace(/[-[\]{}()*+?.,/\\^$|#]/g, '\\$&');
+}


### PR DESCRIPTION
## 🎯 Goal

The goal of the PR is to allow uploading images/files that have special characters in their file names. This PR tends to fix the issue by escaping the character by replacing those characters with `_`.


## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


