### PR TITLE
fix: avoid prepending http before native supported url schemes

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/parseLinks.test.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.test.ts
@@ -31,6 +31,7 @@ describe('parseLinksFromText', () => {
     ['[https://www.google.com](https://www.google.com)', undefined],
     ['[abc]()', undefined],
     ['[](https://www.google.com)', undefined],
+    ['slack:some-slack', undefined],
   ])('Returns the encoded value of %p as %p', (link, expected) => {
     const result = parseLinksFromText(link);
     expect(result[0]?.url).toBe(expected);

--- a/package/src/components/Message/MessageSimple/utils/parseLinks.ts
+++ b/package/src/components/Message/MessageSimple/utils/parseLinks.ts
@@ -26,10 +26,19 @@ export const parseLinksFromText = (input: string): LinkInfo[] => {
   const links = find(strippedInput, 'url');
   const emails = find(strippedInput, 'email');
 
-  const result: LinkInfo[] = [...links, ...emails].map(({ href, value }) => ({
-    raw: value,
-    url: href,
-  }));
+  const result: LinkInfo[] = [...links, ...emails].map(({ href, value }) => {
+    let hrefWithProtocol = href;
+    // Matching these: https://reactnative.dev/docs/0.73/linking?syntax=ios#built-in-url-schemes
+    const pattern = new RegExp(/^(mailto:|tel:|sms:|\S+:\/\/)/);
+    if (!pattern.test(hrefWithProtocol)) {
+      hrefWithProtocol = 'http://' + hrefWithProtocol;
+    }
+
+    return {
+      raw: value,
+      url: hrefWithProtocol,
+    };
+  });
 
   return result;
 };

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -132,17 +132,10 @@ export const renderText = <
     },
   };
 
-  const onLink = (url: string) => {
-    // Matching these: https://reactnative.dev/docs/0.73/linking?syntax=ios#built-in-url-schemes
-    const pattern = new RegExp(/^(mailto:|tel:|sms:|\S+:\/\/)/);
-    if (!pattern.test(url)) {
-      url = 'http://' + url;
-    }
-
-    return onLinkParams
+  const onLink = (url: string) =>
+    onLinkParams
       ? onLinkParams(url)
       : Linking.canOpenURL(url).then((canOpenUrl) => canOpenUrl && Linking.openURL(url));
-  };
 
   let previousLink: string | undefined;
   const linkReact: ReactNodeOutput = (node, output, { ...state }) => {

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -133,7 +133,8 @@ export const renderText = <
   };
 
   const onLink = (url: string) => {
-    const pattern = new RegExp(/^\S+:\/\//);
+    // Matching these: https://reactnative.dev/docs/0.73/linking?syntax=ios#built-in-url-schemes
+    const pattern = new RegExp(/^(mailto:|tel:|sms:|\S+:\/\/)/);
     if (!pattern.test(url)) {
       url = 'http://' + url;
     }


### PR DESCRIPTION
## 🎯 Goal

This PR fixes [this issue](https://getstream.slack.com/archives/C07ASFG19SL/p1725646018734349) posted in a client channel.

## 🛠 Implementation details

Essentially, we modify the regex so that we respect the [built-in url schemes](https://reactnative.dev/docs/0.73/linking?syntax=ios#built-in-url-schemes) the OS provides.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


