### PR TITLE
fix: bump fastlane plugin version

### DIFF
--- a/examples/SampleApp/Gemfile.lock
+++ b/examples/SampleApp/Gemfile.lock
@@ -163,7 +163,7 @@ GEM
       google-apis-firebaseappdistribution_v1 (~> 0.3.0)
       google-apis-firebaseappdistribution_v1alpha (~> 0.2.0)
     fastlane-plugin-load_json (0.0.1)
-    fastlane-plugin-stream_actions (0.3.67)
+    fastlane-plugin-stream_actions (0.3.68)
       xctest_list (= 1.2.1)
     ffi (1.17.0)
     fourflusher (2.3.1)
@@ -320,7 +320,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-firebase_app_distribution
   fastlane-plugin-load_json
-  fastlane-plugin-stream_actions (= 0.3.67)
+  fastlane-plugin-stream_actions (= 0.3.68)
   rubocop-performance
   rubocop-require_tools
 

--- a/examples/SampleApp/fastlane/Pluginfile
+++ b/examples/SampleApp/fastlane/Pluginfile
@@ -4,4 +4,4 @@
 
 gem 'fastlane-plugin-firebase_app_distribution'
 gem 'fastlane-plugin-load_json'
-gem 'fastlane-plugin-stream_actions', '0.3.67'
+gem 'fastlane-plugin-stream_actions', '0.3.68'


### PR DESCRIPTION
Relates to https://github.com/GetStream/fastlane-plugin-stream_actions/pull/9