### PR TITLE
fix: add theme properties for EmptyStateIndicator for message list

### DIFF
--- a/package/src/components/Indicators/EmptyStateIndicator.tsx
+++ b/package/src/components/Indicators/EmptyStateIndicator.tsx
@@ -6,33 +6,6 @@ import { useTranslationContext } from '../../contexts/translationContext/Transla
 import { useViewport } from '../../hooks/useViewport';
 import { ChatIcon, MessageIcon } from '../../icons';
 
-const styles = StyleSheet.create({
-  channelContainer: {
-    alignItems: 'center',
-    flex: 1,
-    justifyContent: 'center',
-  },
-  channelDetails: {
-    fontSize: 14,
-    textAlign: 'center',
-  },
-  channelTitle: {
-    fontSize: 16,
-    paddingBottom: 8,
-    paddingTop: 16,
-  },
-  messageContainer: {
-    alignItems: 'center',
-    flex: 1,
-    justifyContent: 'center',
-  },
-  messageTitle: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    paddingBottom: 8,
-  },
-});
-
 export type EmptyStateProps = {
   listType?: 'channel' | 'message' | 'default';
 };
@@ -41,7 +14,13 @@ export const EmptyStateIndicator = ({ listType }: EmptyStateProps) => {
   const {
     theme: {
       colors: { black, grey, grey_gainsboro },
-      emptyStateIndicator: { channelContainer, channelDetails, channelTitle },
+      emptyStateIndicator: {
+        channelContainer,
+        channelDetails,
+        channelTitle,
+        messageContainer,
+        messageTitle,
+      },
     },
   } = useTheme();
   const { vw } = useViewport();
@@ -51,7 +30,7 @@ export const EmptyStateIndicator = ({ listType }: EmptyStateProps) => {
   switch (listType) {
     case 'channel':
       return (
-        <View style={[styles.channelContainer, channelContainer]}>
+        <View style={[styles.container, channelContainer]}>
           <MessageIcon height={width} pathFill={grey_gainsboro} width={width} />
           <Text
             style={[styles.channelTitle, { color: black }, channelTitle]}
@@ -69,14 +48,36 @@ export const EmptyStateIndicator = ({ listType }: EmptyStateProps) => {
       );
     case 'message':
       return (
-        <View style={[styles.messageContainer]}>
+        <View style={[styles.container, messageContainer]}>
           <ChatIcon height={width} pathFill={grey_gainsboro} width={width} />
-          <Text style={[styles.messageTitle, { color: grey_gainsboro }]}>
+          <Text style={[styles.messageTitle, { color: grey_gainsboro }, messageTitle]}>
             {t<string>('No chats here yet…')}
           </Text>
         </View>
       );
     default:
-      return <Text style={{ color: black }}>No items exist</Text>;
+      return <Text style={[{ color: black }, messageContainer]}>No items exist</Text>;
   }
 };
+
+const styles = StyleSheet.create({
+  channelDetails: {
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  channelTitle: {
+    fontSize: 16,
+    paddingBottom: 8,
+    paddingTop: 16,
+  },
+  container: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  messageTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    paddingBottom: 8,
+  },
+});

--- a/package/src/components/Indicators/LoadingDot.tsx
+++ b/package/src/components/Indicators/LoadingDot.tsx
@@ -62,8 +62,8 @@ export const LoadingDot = (props: Props) => {
           width: diameter,
         },
         style,
-        loadingDot,
         dotStyle,
+        loadingDot,
       ]}
     />
   );

--- a/package/src/components/Indicators/LoadingErrorIndicator.tsx
+++ b/package/src/components/Indicators/LoadingErrorIndicator.tsx
@@ -4,24 +4,6 @@ import { StyleSheet, Text, TouchableOpacity } from 'react-native';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
 
-const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center',
-    height: '100%',
-    justifyContent: 'center',
-    width: '100%',
-  },
-  errorText: {
-    fontSize: 14,
-    fontWeight: '600',
-    marginTop: 20,
-  },
-  retryText: {
-    fontSize: 30,
-    fontWeight: '600',
-  },
-});
-
 type LoadingErrorWrapperProps = {
   text: string;
   onPress?: () => void;
@@ -85,3 +67,21 @@ export const LoadingErrorIndicator = (props: LoadingErrorProps) => {
 };
 
 LoadingErrorIndicator.displayName = 'LoadingErrorIndicator{loadingErrorIndicator}';
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    height: '100%',
+    justifyContent: 'center',
+    width: '100%',
+  },
+  errorText: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginTop: 20,
+  },
+  retryText: {
+    fontSize: 30,
+    fontWeight: '600',
+  },
+});

--- a/package/src/components/Indicators/LoadingIndicator.tsx
+++ b/package/src/components/Indicators/LoadingIndicator.tsx
@@ -5,19 +5,6 @@ import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
 import { Spinner } from '../Spinner/Spinner';
 
-const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center',
-    flex: 1,
-    justifyContent: 'center',
-  },
-  loadingText: {
-    fontSize: 14,
-    fontWeight: '600',
-    marginTop: 20,
-  },
-});
-
 type LoadingIndicatorWrapperProps = { text: string };
 
 const LoadingIndicatorWrapper = ({ text }: LoadingIndicatorWrapperProps) => {
@@ -66,3 +53,16 @@ export const LoadingIndicator = (props: LoadingProps) => {
 };
 
 LoadingIndicator.displayName = 'LoadingIndicator{loadingIndicator}';
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  loadingText: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginTop: 20,
+  },
+});

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -167,6 +167,8 @@ export type Theme = {
     channelContainer: ViewStyle;
     channelDetails: TextStyle;
     channelTitle: TextStyle;
+    messageContainer: ViewStyle;
+    messageTitle: TextStyle;
   };
   groupAvatar: {
     container: ViewStyle;
@@ -753,6 +755,8 @@ export const defaultTheme: Theme = {
     channelContainer: {},
     channelDetails: {},
     channelTitle: {},
+    messageContainer: {},
+    messageTitle: {},
   },
   groupAvatar: {
     container: {},


### PR DESCRIPTION
## 🎯 Goal

Fixes #2615 

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


