### PR TITLE
fix: properly resolve sendMessage during memoization

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -2219,6 +2219,17 @@ const ChannelWithContext = <
     watchers,
   });
 
+  // This is mainly a hack to get around an issue with sendMessage not being passed correctly as a
+  // useMemo() dependency. The easy fix is to add it to the dependency array, however that would mean
+  // that this (very used) context is essentially going to cause rerenders on pretty much every Channel
+  // render, since sendMessage is an inline function. Wrapping it in useCallback() is one way to fix it
+  // but it is definitely not trivial, especially considering it depends on other inline functions that
+  // are not wrapped in a useCallback() themselves hence creating a huge cascading change. Can be removed
+  // once our memoization issues are fixed in most places in the app or we move to a reactive state store.
+  const sendMessageRef =
+    useRef<InputMessageInputContextValue<StreamChatGenerics>['sendMessage']>(sendMessage);
+  sendMessageRef.current = sendMessage;
+
   const inputMessageInputContext = useCreateInputMessageInputContext<StreamChatGenerics>({
     additionalTextInputProps,
     asyncMessagesLockDistance,
@@ -2269,7 +2280,7 @@ const ChannelWithContext = <
     quotedMessage,
     SendButton,
     sendImageAsync,
-    sendMessage,
+    sendMessage: (...args) => sendMessageRef.current(...args),
     SendMessageDisallowedIndicator,
     setInputRef,
     setQuotedMessageState,

--- a/package/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
+++ b/package/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
@@ -134,15 +134,7 @@ export const useCreateInputMessageInputContext = <
       UploadProgressIndicator,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      compressImageQuality,
-      channelId,
-      editingDep,
-      initialValue,
-      maxMessageLength,
-      quotedMessageId,
-      sendMessage,
-    ],
+    [compressImageQuality, channelId, editingDep, initialValue, maxMessageLength, quotedMessageId],
   );
 
   return inputMessageInputContext;

--- a/package/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
+++ b/package/src/components/Channel/hooks/useCreateInputMessageInputContext.ts
@@ -134,7 +134,15 @@ export const useCreateInputMessageInputContext = <
       UploadProgressIndicator,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [compressImageQuality, channelId, editingDep, initialValue, maxMessageLength, quotedMessageId],
+    [
+      compressImageQuality,
+      channelId,
+      editingDep,
+      initialValue,
+      maxMessageLength,
+      quotedMessageId,
+      sendMessage,
+    ],
   );
 
   return inputMessageInputContext;


### PR DESCRIPTION
## 🎯 Goal

We have an issue with memoization where if you do the following:

- Override `doSendMessageRequest` on the `Channel` level
- Make `doSendMessageRequest` depend on some local state that gets updated later

only the initial value of that state would be memoized.

Zendesk ticket: https://getstream.zendesk.com/agent/tickets/55303

## 🛠 Implementation details

The reason why we wrap `sendMessage` in a `ref` is due to the fact that simply adding it to the dependency array will likely cause a ton of rerenders of components everywhere. I realise it's a hacky way to solve this, but more conventional methods such as wrapping it inside a `useCallback` are a bit difficult since we would need to wrap all of its other dependencies in callbacks as well, causing a cascading effect. Ideally, this should be solved by getting rid of the `useMemo` entirely in the `MessageInputContext`, but for now this'll have to do.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


