### PR TITLE
fix: request image access permissions for iOS only for native image picking

### DIFF
--- a/package/expo-package/src/optionalDependencies/pickImage.ts
+++ b/package/expo-package/src/optionalDependencies/pickImage.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 let ImagePicker;
 
 try {
@@ -15,15 +16,18 @@ if (!ImagePicker) {
 export const pickImage = ImagePicker
   ? async () => {
       try {
-        const permissionCheck = await ImagePicker.getMediaLibraryPermissionsAsync();
-        const canRequest = permissionCheck.canAskAgain;
-        let permissionGranted = permissionCheck.granted;
-        if (!permissionGranted) {
-          if (canRequest) {
-            const response = await ImagePicker.requestMediaLibraryPermissionsAsync();
-            permissionGranted = response.granted;
-          } else {
-            return { askToOpenSettings: true, cancelled: true };
+        let permissionGranted = true;
+        if (Platform.OS === 'ios') {
+          const permissionCheck = await ImagePicker.getMediaLibraryPermissionsAsync();
+          const canRequest = permissionCheck.canAskAgain;
+          permissionGranted = permissionCheck.granted;
+          if (!permissionGranted) {
+            if (canRequest) {
+              const response = await ImagePicker.requestMediaLibraryPermissionsAsync();
+              permissionGranted = response.granted;
+            } else {
+              return { askToOpenSettings: true, cancelled: true };
+            }
           }
         }
         if (permissionGranted) {


### PR DESCRIPTION
## 🎯 Goal

The `pickImage` utility for Expo previously requested permissions for both Android and iOS, which should not be the case for the native image picker. HingeHealth reported this, and this has been fixed as part of it.

The permission is now requested only for iOS.

Ref: https://getstream.slack.com/archives/C05BNFLTZ33/p1726660030605229?thread_ts=1714148969.598989&cid=C05BNFLTZ33

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


