### PR TITLE
fix: copy message action type for message actions

### DIFF
--- a/package/src/components/Message/hooks/useMessageActions.tsx
+++ b/package/src/components/Message/hooks/useMessageActions.tsx
@@ -23,7 +23,6 @@ import {
   Unpin,
   UserDelete,
 } from '../../../icons';
-import { setClipboardString } from '../../../native';
 import type { DefaultStreamChatGenerics } from '../../../types/types';
 import { removeReservedFields } from '../../../utils/removeReservedFields';
 import { MessageStatusTypes } from '../../../utils/utils';
@@ -175,21 +174,18 @@ export const useMessageActions = <
     title: message.user?.banned ? t('Unblock User') : t('Block User'),
   };
 
-  const copyMessage: MessageActionType | undefined =
-    setClipboardString !== null
-      ? {
-          action: () => {
-            setOverlay('none');
-            if (handleCopy) {
-              handleCopy(message);
-            }
-            handleCopyMessage();
-          },
-          actionType: 'copyMessage',
-          icon: <Copy pathFill={grey} />,
-          title: t('Copy Message'),
-        }
-      : undefined;
+  const copyMessage: MessageActionType = {
+    action: () => {
+      setOverlay('none');
+      if (handleCopy) {
+        handleCopy(message);
+      }
+      handleCopyMessage();
+    },
+    actionType: 'copyMessage',
+    icon: <Copy pathFill={grey} />,
+    title: t('Copy Message'),
+  };
 
   const deleteMessage: MessageActionType = {
     action: () => {

--- a/package/src/components/Message/utils/messageActions.ts
+++ b/package/src/components/Message/utils/messageActions.ts
@@ -1,5 +1,6 @@
 import type { MessageContextValue } from '../../../contexts/messageContext/MessageContext';
 import type { OwnCapabilitiesContextValue } from '../../../contexts/ownCapabilitiesContext/OwnCapabilitiesContext';
+import { setClipboardString } from '../../../native';
 import type { DefaultStreamChatGenerics } from '../../../types/types';
 import type { MessageActionType } from '../../MessageOverlay/MessageActionListItem';
 
@@ -7,6 +8,7 @@ export type MessageActionsParams<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 > = {
   banUser: MessageActionType;
+  copyMessage: MessageActionType;
   deleteMessage: MessageActionType;
   dismissOverlay: () => void;
   editMessage: MessageActionType;
@@ -32,7 +34,6 @@ export type MessageActionsParams<
    * @deprecated use `banUser` instead.
    */
   blockUser?: MessageActionType;
-  copyMessage?: MessageActionType;
 } & Pick<MessageContextValue<StreamChatGenerics>, 'message' | 'isMyMessage'>;
 
 export type MessageActionsProp<
@@ -86,7 +87,7 @@ export const messageActions = <
     actions.push(editMessage);
   }
 
-  if (copyMessage !== undefined && message.text && !error) {
+  if (setClipboardString !== null && message.text && !error) {
     actions.push(copyMessage);
   }
 


### PR DESCRIPTION
## 🎯 Goal

The goal of the PR is to make the type of the `copyMessage` to be always defined. The check for the `setClipboardString` function can be checked at the `messageActions.ts` itself, and the TS does not have to be handled explicitly.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


