### PR TITLE
fix: changing orientation attachment picker issues

### DIFF
--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { BackHandler, Keyboard, Platform, StyleSheet } from 'react-native';
 
 import BottomSheet, { BottomSheetFlatList } from '@gorhom/bottom-sheet';

--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -256,15 +256,11 @@ export const AttachmentPicker = React.forwardRef(
      * Snap points changing cause a rerender of the position,
      * this is an issue if you are calling close on the bottom sheet.
      */
-    const snapPoints = useMemo(
-      () => [initialSnapPoint, finalSnapPoint],
-      [initialSnapPoint, finalSnapPoint],
-    );
+    const snapPoints = [initialSnapPoint, finalSnapPoint];
 
     return (
       <>
         <BottomSheet
-          containerHeight={fullScreenHeight}
           enablePanDownToClose={true}
           handleComponent={
             /**


### PR DESCRIPTION
## 🎯 Goal

Solves [this GH issue](https://github.com/GetStream/stream-chat-react-native/issues/2663#issuecomment-2360252605). Details of the reproduction steps can be found in the issue itself.

## 🛠 Implementation details

Here is a brief summary of why this issue is happening:

- Looking at the [`containerHeight` property](https://gorhom.dev/react-native-bottom-sheet/props#containerheight) in the library as well as looking at the implementation for a bit, we can clearly see that:
    - This value is not meant to be used as a dynamic one
    - It completely prevents recalculation from the library itself and relies on this value solely
- Typically, whenever we change landscape the value for the top area insets changes (as well as the screen height) and this is passed as a dynamic value to the `containerHeight`; the `BottomSheet` is however not shown as it's being controlled entirely by our `OverlayProvider`
- Whenever we come back from background mode of the app however, we have a refresh in values that happens "late", and the initial value passed to `containerHeight` is wrong; only to be updated soon after
- This however causes the wrong value to be used within the library itself (instead of calculations) and the new value is not respected at all (nor should it, considering that it skips extra rerenders due to calculations) and we end up in a weird state where the `BottomSheet` is displayed without any of its actual functionalities

The issue is reproducible on virtually any screen by the way, since the `OverlayProvider` is basically the `root` of our DOM tree.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


