### PR TITLE
fix: native picker max images

### DIFF
--- a/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentPickerItem.tsx
@@ -5,6 +5,7 @@ import { Alert, ImageBackground, Platform, StyleSheet, Text, View } from 'react-
 import { TouchableOpacity } from '@gorhom/bottom-sheet';
 import { lookup } from 'mime-types';
 
+import { useTranslationContext } from '../../../contexts';
 import { AttachmentPickerContextValue } from '../../../contexts/attachmentPickerContext/AttachmentPickerContext';
 import { useTheme } from '../../../contexts/themeContext/ThemeContext';
 import { useViewport } from '../../../hooks/useViewport';
@@ -39,6 +40,7 @@ const AttachmentVideo = (props: AttachmentVideoProps) => {
     setSelectedFiles,
   } = props;
   const { vw } = useViewport();
+  const { t } = useTranslationContext();
 
   const {
     theme: {
@@ -76,7 +78,7 @@ const AttachmentVideo = (props: AttachmentVideoProps) => {
 
   const updateSelectedFiles = async () => {
     if (numberOfUploads >= maxNumberOfFiles) {
-      Alert.alert('Maximum number of files reached');
+      Alert.alert(t('Maximum number of files reached'));
       return;
     }
     const files = await patchVideoFile(selectedFiles);
@@ -143,6 +145,7 @@ const AttachmentImage = (props: AttachmentImageProps) => {
     },
   } = useTheme();
   const { vw } = useViewport();
+  const { t } = useTranslationContext();
 
   const size = vw(100) / (numberOfAttachmentPickerImageColumns || 3) - 2;
 
@@ -165,7 +168,7 @@ const AttachmentImage = (props: AttachmentImageProps) => {
 
   const updateSelectedImages = async () => {
     if (numberOfUploads >= maxNumberOfFiles) {
-      Alert.alert('Maximum number of files reached');
+      Alert.alert(t('Maximum number of files reached'));
       return;
     }
     const images = await patchImageFile(selectedImages);

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -697,14 +697,14 @@ export const MessageInputProvider = <
 
     // RN CLI
     if (numberOfUploads >= value.maxNumberOfFiles) {
-      Alert.alert('Maximum number of files reached');
+      Alert.alert(t('Maximum number of files reached'));
       return;
     }
 
     if (result.assets && result.assets.length > 0) {
       // Expo
       if (result.assets.length > value.maxNumberOfFiles) {
-        Alert.alert('Maximum number of files reached');
+        Alert.alert(t('Maximum number of files reached'));
         return;
       }
       result.assets.forEach(async (asset) => {
@@ -758,7 +758,7 @@ export const MessageInputProvider = <
     }
 
     if (numberOfUploads >= value.maxNumberOfFiles) {
-      Alert.alert('Maximum number of files reached');
+      Alert.alert(t('Maximum number of files reached'));
       return;
     }
 

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -695,12 +695,14 @@ export const MessageInputProvider = <
       );
     }
 
+    // RN CLI
     if (numberOfUploads >= value.maxNumberOfFiles) {
       Alert.alert('Maximum number of files reached');
       return;
     }
 
     if (result.assets && result.assets.length > 0) {
+      // Expo
       if (result.assets.length > value.maxNumberOfFiles) {
         Alert.alert('Maximum number of files reached');
         return;

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -694,7 +694,17 @@ export const MessageInputProvider = <
         ],
       );
     }
+
+    if (numberOfUploads >= value.maxNumberOfFiles) {
+      Alert.alert('Maximum number of files reached');
+      return;
+    }
+
     if (result.assets && result.assets.length > 0) {
+      if (result.assets.length > value.maxNumberOfFiles) {
+        Alert.alert('Maximum number of files reached');
+        return;
+      }
       result.assets.forEach(async (asset) => {
         if (asset.type.includes('image')) {
           await uploadNewImage(asset);

--- a/package/src/i18n/en.json
+++ b/package/src/i18n/en.json
@@ -40,6 +40,7 @@
   "Loading messages...": "Loading messages...",
   "Loading threads...": "Loading threads...",
   "Loading...": "Loading...",
+  "Maximum number of files reached": "Maximum number of files reached",
   "Message Reactions": "Message Reactions",
   "Message deleted": "Message deleted",
   "Message flagged": "Message flagged",

--- a/package/src/i18n/es.json
+++ b/package/src/i18n/es.json
@@ -40,6 +40,7 @@
   "Loading messages...": "Cargando mensajes...",
   "Loading threads...": "Cargando hilos...",
   "Loading...": "Cargando...",
+  "Maximum number of files reached": "Número máximo de archivos alcanzado",
   "Message Reactions": "Reacciones al mensaje",
   "Message deleted": "Mensaje eliminado",
   "Message flagged": "Mensaje reportado",

--- a/package/src/i18n/fr.json
+++ b/package/src/i18n/fr.json
@@ -40,6 +40,7 @@
   "Loading messages...": "Chargement des messages...",
   "Loading threads...": "Chargement des fils...",
   "Loading...": "Chargement...",
+  "Maximum number of files reached": "Nombre maximal de fichiers atteint",
   "Message Reactions": "Réactions aux messages",
   "Message deleted": "Message supprimé",
   "Message flagged": "Message signalé",

--- a/package/src/i18n/he.json
+++ b/package/src/i18n/he.json
@@ -40,6 +40,7 @@
   "Loading messages...": "ההודעות בטעינה..",
   "Loading threads...": "טוען שרשורים...",
   "Loading...": "טוען...",
+  "Maximum number of files reached": "הגעת למספר המרבי של קבצים",
   "Message Reactions": "תגובות להודעה",
   "Message deleted": "ההודעה נמחקה",
   "Message flagged": "ההודעה סומנה",

--- a/package/src/i18n/hi.json
+++ b/package/src/i18n/hi.json
@@ -40,6 +40,7 @@
   "Loading messages...": "मेसेजस लोड हो रहे हैं...",
   "Loading threads...": "थ्रेड्स लोड हो रहे हैं...",
   "Loading...": "लोड हो रहा है...",
+  "Maximum number of files reached": "फ़ाइलों की अधिकतम संख्या पहुँच गई",
   "Message Reactions": "संदेश प्रतिक्रियाएँ",
   "Message deleted": "मैसेज हटा दिया गया",
   "Message flagged": "संदेश को ध्वजांकित किया गया",

--- a/package/src/i18n/it.json
+++ b/package/src/i18n/it.json
@@ -40,6 +40,7 @@
   "Loading messages...": "Caricamento messaggi...",
   "Loading threads...": "Caricamento dei thread...",
   "Loading...": "Caricamento...",
+  "Maximum number of files reached": "Numero massimo di file raggiunto",
   "Message Reactions": "Reazioni ai Messaggi",
   "Message deleted": "Messaggio cancellato",
   "Message flagged": "Messaggio contrassegnato",

--- a/package/src/i18n/ja.json
+++ b/package/src/i18n/ja.json
@@ -40,6 +40,7 @@
   "Loading messages...": "メッセージを読み込み中。。。",
   "Loading threads...": "スレッドを読み込み中...",
   "Loading...": "読み込み中。。。",
+  "Maximum number of files reached": "ファイルの最大数に達しました",
   "Message Reactions": "メッセージのリアクション",
   "Message deleted": "メッセージが削除されました",
   "Message flagged": "メッセージにフラグが付けられました",

--- a/package/src/i18n/ko.json
+++ b/package/src/i18n/ko.json
@@ -40,6 +40,7 @@
   "Loading messages...": "메시지를 로딩 중...",
   "Loading threads...": "스레드 로딩 중...",
   "Loading...": "로딩 중...",
+  "Maximum number of files reached": "최대 파일 수에 도달했습니다",
   "Message Reactions": "메시지의 리액션",
   "Message deleted": "메시지가 삭제되었습니다.",
   "Message flagged": "메시지에 플래그가 지정되었습니다",

--- a/package/src/i18n/nl.json
+++ b/package/src/i18n/nl.json
@@ -40,6 +40,7 @@
   "Loading messages...": "Berichten aan het laden...",
   "Loading threads...": "Threads laden...",
   "Loading...": "Aan het laden...",
+  "Maximum number of files reached": "Maximaal aantal bestanden bereikt",
   "Message Reactions": "Bericht Reacties",
   "Message deleted": "Bericht verwijderd",
   "Message flagged": "Bericht gemarkeerd",

--- a/package/src/i18n/pt-br.json
+++ b/package/src/i18n/pt-br.json
@@ -40,6 +40,7 @@
   "Loading messages...": "Carregando mensagens...",
   "Loading threads...": "Carregando tópicos...",
   "Loading...": "Carregando...",
+  "Maximum number of files reached": "Número máximo de arquivos atingido",
   "Message Reactions": "Reações à Mensagem",
   "Message deleted": "Mensagem excluída",
   "Message flagged": "Mensagem sinalizada",

--- a/package/src/i18n/ru.json
+++ b/package/src/i18n/ru.json
@@ -40,6 +40,7 @@
   "Loading messages...": "Загружаю сообщения...",
   "Loading threads...": "Загрузка потоков...",
   "Loading...": "Загружаю...",
+  "Maximum number of files reached": "Достигнуто максимальное количество файлов",
   "Message Reactions": "Сообщения Реакции",
   "Message deleted": "Сообщение удалено",
   "Message flagged": "Сообщение отмечено",

--- a/package/src/i18n/tr.json
+++ b/package/src/i18n/tr.json
@@ -40,6 +40,7 @@
   "Loading messages...": "Mesajlar yükleniyor...",
   "Loading threads...": "Akışlar yükleniyor...",
   "Loading...": "Yükleniyor...",
+  "Maximum number of files reached": "Maksimum dosya sayısına ulaşıldı",
   "Message Reactions": "Mesaj Tepkileri",
   "Message deleted": "Mesaj silindi",
   "Message flagged": "Mesaj işaretlendi",


### PR DESCRIPTION
## 🎯 Goal

Fixes an issue where the `maxNumberOfFiles` property was not respected by the native file picker for images. It should now properly stop the user if they're trying to upload too many images.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


