### PR TITLE
fix: load channel at the very end when messageId is undefined

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -676,8 +676,8 @@ const ChannelWithContext = <
       }
       // If the messageId is undefined and the last message and the current message id do not match we load the channel at the very bottom.
       else if (
-        channel.state.messages[channel.state.messages.length - 1].id !==
-          channel.state.latestMessages[channel.state.latestMessages.length - 1].id &&
+        channel.state.messages?.[channel.state.messages.length - 1]?.id !==
+          channel.state.latestMessages?.[channel.state.latestMessages.length - 1]?.id &&
         !messageId
       ) {
         await loadChannel();

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -674,6 +674,14 @@ const ChannelWithContext = <
       ) {
         loadChannelAtFirstUnreadMessage();
       }
+      // If the messageId is undefined and the last message and the current message id do not match we load the channel at the very bottom.
+      else if (
+        channel.state.messages[channel.state.messages.length - 1].id !==
+          channel.state.latestMessages[channel.state.latestMessages.length - 1].id &&
+        !messageId
+      ) {
+        await loadChannel();
+      }
     };
 
     initChannel();


### PR DESCRIPTION
## 🎯 Goal

The goal of the PR is to load the channel at the very end when the messageId is undefined, making sure the messages in the state doesn't match the latest message.

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


