### PR TITLE
fix: ChannelAvatar crash when used outside of ChannelList

### DIFF
--- a/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
@@ -212,6 +212,7 @@ export const ChannelPreviewMessenger = <
   props: ChannelPreviewMessengerProps<StreamChatGenerics>,
 ) => {
   const {
+    forceUpdate,
     maxUnreadCount,
     onSelect,
     PreviewAvatar,
@@ -224,6 +225,7 @@ export const ChannelPreviewMessenger = <
   return (
     <MemoizedChannelPreviewMessengerWithContext
       {...{
+        forceUpdate,
         maxUnreadCount,
         onSelect,
         PreviewAvatar,

--- a/package/src/components/ChannelPreview/hooks/useChannelPreviewDisplayPresence.ts
+++ b/package/src/components/ChannelPreview/hooks/useChannelPreviewDisplayPresence.ts
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 
 import type { Channel, StreamChat } from 'stream-chat';
 
-import { useChannelsContext } from '../../../contexts';
 import { useChatContext } from '../../../contexts/chatContext/ChatContext';
 
 import type { DefaultStreamChatGenerics } from '../../../types/types';
@@ -38,7 +37,6 @@ export const useChannelPreviewDisplayPresence = <
   channel: Channel<StreamChatGenerics>,
 ) => {
   const { client } = useChatContext<StreamChatGenerics>();
-  const { forceUpdate } = useChannelsContext<StreamChatGenerics>();
 
   const currentUserId = client.userID;
   const members = Object.values(channel.state.members).filter(
@@ -50,7 +48,7 @@ export const useChannelPreviewDisplayPresence = <
 
   useEffect(() => {
     setDisplayPresence(getChannelPreviewDisplayPresence(channel, client));
-  }, [channel, channelMemberOnline, client, forceUpdate]);
+  }, [channel, channelMemberOnline, client]);
 
   return displayPresence;
 };


### PR DESCRIPTION
## 🎯 Goal

Fixes an issue of an app crash when `ChannelAvatar` is used outside of `ChannelList`. 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


