### PR TITLE
fix: double loading when targetting a message

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -983,7 +983,9 @@ const MessageListWithContext = <
         });
       }
       // the message we want to scroll to has not been loaded in the state yet
-      loadChannelAroundMessage({ messageId: messageIdToScroll });
+      if (indexOfParentInMessageList === -1) {
+        loadChannelAroundMessage({ messageId: messageIdToScroll });
+      }
     }, 50);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [targetedMessage, initialScrollToFirstUnreadMessage]);

--- a/package/src/components/MessageList/__tests__/MessageList.test.js
+++ b/package/src/components/MessageList/__tests__/MessageList.test.js
@@ -372,8 +372,8 @@ describe('MessageList', () => {
       mockedLongMessagesList.push(generateMessage({ timestamp: new Date(), user: user1 }));
     }
     // could be any message that is not within the initially processed ones
-    const { id: targetedMessageId, text: targetedMessageText } = mockedLongMessagesList[3];
-    const latestMessageText = mockedLongMessagesList[mockedLongMessagesList.length - 1].text;
+    const latestMessageText = mockedLongMessagesList[0].text;
+    const { id: targetedMessageId, text: targetedMessageText } = mockedLongMessagesList[mockedLongMessagesList.length - 4];
 
     const mockedChannel = generateChannelResponse({
       members: [generateMember({ user: user1 })],

--- a/package/src/components/MessageList/__tests__/MessageList.test.js
+++ b/package/src/components/MessageList/__tests__/MessageList.test.js
@@ -373,7 +373,8 @@ describe('MessageList', () => {
     }
     // could be any message that is not within the initially processed ones
     const latestMessageText = mockedLongMessagesList[0].text;
-    const { id: targetedMessageId, text: targetedMessageText } = mockedLongMessagesList[mockedLongMessagesList.length - 4];
+    const { id: targetedMessageId, text: targetedMessageText } =
+      mockedLongMessagesList[mockedLongMessagesList.length - 4];
 
     const mockedChannel = generateChannelResponse({
       members: [generateMember({ user: user1 })],


### PR DESCRIPTION
## 🎯 Goal

Fixes an issue where the `MessageList` would be loaded twice whenever we target a message specifically through `messageId` on the `Channel`. The `targetedMessage` prop still works as intended.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


