### PR TITLE
fix: disable typing events when offline

### DIFF
--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -538,7 +538,8 @@ export const MessageInputProvider = <
     setSelectedImages,
     setSelectedPicker,
   } = useAttachmentPickerContext();
-  const { appSettings, client, enableOfflineSupport } = useChatContext<StreamChatGenerics>();
+  const { appSettings, client, enableOfflineSupport, isOnline } =
+    useChatContext<StreamChatGenerics>();
   const { removeMessage } = useMessagesContext();
 
   const getFileUploadConfig = () => {
@@ -652,7 +653,7 @@ export const MessageInputProvider = <
     }
     setText(newText);
 
-    if (newText && channel && channelCapabities.sendTypingEvents) {
+    if (newText && channel && channelCapabities.sendTypingEvents && isOnline) {
       logChatPromiseExecution(channel.keystroke(thread?.id), 'start typing event');
     }
 

--- a/package/src/contexts/messageInputContext/__tests__/pickFile.test.tsx
+++ b/package/src/contexts/messageInputContext/__tests__/pickFile.test.tsx
@@ -61,7 +61,7 @@ describe("MessageInputContext's pickFile", () => {
     maxNumberOfFiles: 2,
   };
 
-  it.each([[3, 2]])(
+  it.each([[3, 1]])(
     'run pickFile when numberOfUploads is %d and alert is triggered %d number of times',
     async (numberOfUploads, numberOfTimesCalled) => {
       const { rerender, result } = renderHook(() => useMessageInputContext(), {
@@ -87,6 +87,7 @@ describe("MessageInputContext's pickFile", () => {
       });
 
       expect(Alert.alert).toHaveBeenCalledTimes(numberOfTimesCalled);
+      expect(Alert.alert).toHaveBeenCalledWith('Maximum number of files reached');
     },
   );
 

--- a/package/src/contexts/messageInputContext/hooks/useCreateMessageInputContext.ts
+++ b/package/src/contexts/messageInputContext/hooks/useCreateMessageInputContext.ts
@@ -258,6 +258,7 @@ export const useCreateMessageInputContext = <
       text,
       threadId,
       showPollCreationDialog,
+      onChange,
     ],
   );
 


### PR DESCRIPTION
## 🎯 Goal

Solves the `typing` errors mentioned in [this GH issue](https://github.com/GetStream/stream-chat-react-native/issues/2737).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


