### PR TITLE
fix: add safeguard for querying app settings

### DIFF
--- a/package/src/components/Chat/hooks/__tests__/useAppSettings.test.tsx
+++ b/package/src/components/Chat/hooks/__tests__/useAppSettings.test.tsx
@@ -18,6 +18,7 @@ describe('useAppSettings', () => {
               auto_translation_enabled: true,
             }),
           ),
+          userID: 'some-user-id',
         } as unknown as StreamChat,
         isOnline,
         false,

--- a/package/src/components/Chat/hooks/useAppSettings.ts
+++ b/package/src/components/Chat/hooks/useAppSettings.ts
@@ -22,6 +22,8 @@ export const useAppSettings = <
      * Fetches app settings from the backend when offline support is disabled.
      */
     const enforceAppSettingsWithoutOfflineSupport = async () => {
+      if (!client.userID) return;
+
       try {
         const appSettings = await client.getAppSettings();
         if (isMounted.current) {


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


