### PR TITLE
fix: theme for the message bubble and replies

### DIFF
--- a/package/src/components/Message/MessageSimple/MessageContent.tsx
+++ b/package/src/components/Message/MessageSimple/MessageContent.tsx
@@ -149,7 +149,7 @@ const MessageContentWithContext = <
 
   const {
     theme: {
-      colors: { blue_alice, grey_gainsboro, grey_whisper, transparent, white },
+      colors: { blue_alice, grey_whisper, light_gray, transparent, white_snow },
       messageSimple: {
         content: {
           container: {
@@ -214,20 +214,20 @@ const MessageContentWithContext = <
 
   const isMessageReceivedOrErrorType = !isMyMessage || error;
 
-  let backgroundColor = senderMessageBackgroundColor || grey_gainsboro;
+  let backgroundColor = senderMessageBackgroundColor || light_gray;
   if (onlyEmojis && !message.quoted_message) {
     backgroundColor = transparent;
   } else if (otherAttachments.length) {
     if (otherAttachments[0].type === 'giphy') {
-      backgroundColor = message.quoted_message ? grey_gainsboro : transparent;
+      backgroundColor = message.quoted_message ? light_gray : transparent;
     } else {
       backgroundColor = blue_alice;
     }
   } else if (isMessageReceivedOrErrorType) {
-    backgroundColor = receiverMessageBackgroundColor || white;
+    backgroundColor = receiverMessageBackgroundColor || white_snow;
   }
 
-  const repliesCurveColor = !isMessageReceivedOrErrorType ? backgroundColor : grey_gainsboro;
+  const repliesCurveColor = !isMessageReceivedOrErrorType ? backgroundColor : light_gray;
 
   const getBorderRadius = () => {
     // enum('top', 'middle', 'bottom', 'single')

--- a/package/src/components/Message/MessageSimple/MessageContent.tsx
+++ b/package/src/components/Message/MessageSimple/MessageContent.tsx
@@ -214,7 +214,7 @@ const MessageContentWithContext = <
 
   const isMessageReceivedOrErrorType = !isMyMessage || error;
 
-  let backgroundColor = senderMessageBackgroundColor || light_gray;
+  let backgroundColor = senderMessageBackgroundColor ?? light_gray;
   if (onlyEmojis && !message.quoted_message) {
     backgroundColor = transparent;
   } else if (otherAttachments.length) {
@@ -224,7 +224,7 @@ const MessageContentWithContext = <
       backgroundColor = blue_alice;
     }
   } else if (isMessageReceivedOrErrorType) {
-    backgroundColor = receiverMessageBackgroundColor || white_snow;
+    backgroundColor = receiverMessageBackgroundColor ?? white_snow;
   }
 
   const repliesCurveColor = !isMessageReceivedOrErrorType ? backgroundColor : light_gray;

--- a/package/src/components/Message/MessageSimple/MessageReplies.tsx
+++ b/package/src/components/Message/MessageSimple/MessageReplies.tsx
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
   },
   messageRepliesCurve: {
     borderTopWidth: 0,
-    borderWidth: 1,
+    borderWidth: 2,
     height: 16,
     width: 16,
   },
@@ -181,6 +181,7 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
     message: prevMessage,
     noBorder: prevNoBorder,
     onOpenThread: prevOnOpenThread,
+    repliesCurveColor: prevRepliesCurveColor,
     t: prevT,
     threadList: prevThreadList,
   } = prevProps;
@@ -188,6 +189,7 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
     message: nextMessage,
     noBorder: nextNoBorder,
     onOpenThread: nextOnOpenThread,
+    repliesCurveColor: nextRepliesCurveColor,
     t: nextT,
     threadList: nextThreadList,
   } = nextProps;
@@ -200,6 +202,9 @@ const areEqual = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
 
   const noBorderEqual = prevNoBorder === nextNoBorder;
   if (!noBorderEqual) return false;
+
+  const repliesCurveColorEqual = prevRepliesCurveColor === nextRepliesCurveColor;
+  if (!repliesCurveColorEqual) return false;
 
   const tEqual = prevT === nextT;
   if (!tEqual) return false;

--- a/package/src/components/MessageOverlay/MessageOverlay.tsx
+++ b/package/src/components/MessageOverlay/MessageOverlay.tsx
@@ -170,7 +170,7 @@ const MessageOverlayWithContext = <
   );
 
   const {
-    colors: { blue_alice, grey_gainsboro, grey_whisper, transparent },
+    colors: { blue_alice, grey_gainsboro, grey_whisper, light_gray, transparent, white_snow },
     messageSimple: {
       content: {
         container: { borderRadiusL, borderRadiusS },
@@ -364,8 +364,8 @@ const MessageOverlayWithContext = <
                             : grey_gainsboro
                           : blue_alice
                         : alignment === 'left'
-                        ? receiverMessageBackgroundColor
-                        : senderMessageBackgroundColor,
+                        ? receiverMessageBackgroundColor ?? white_snow
+                        : senderMessageBackgroundColor ?? light_gray,
                     borderBottomLeftRadius:
                       (groupStyle === 'left_bottom' || groupStyle === 'left_single') &&
                       (!hasThreadReplies || threadList)

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -416,7 +416,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                   "overflow": "hidden",
                                 },
                                 {
-                                  "backgroundColor": "#F2F2F2",
+                                  "backgroundColor": "#FCFCFC",
                                   "borderBottomLeftRadius": 0,
                                   "borderBottomRightRadius": 16,
                                   "borderColor": "#ECEBEB",
@@ -742,7 +742,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                   "overflow": "hidden",
                                 },
                                 {
-                                  "backgroundColor": "#F2F2F2",
+                                  "backgroundColor": "#FCFCFC",
                                   "borderBottomLeftRadius": 0,
                                   "borderBottomRightRadius": 16,
                                   "borderColor": "#ECEBEB",
@@ -1068,7 +1068,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                   "overflow": "hidden",
                                 },
                                 {
-                                  "backgroundColor": "#F2F2F2",
+                                  "backgroundColor": "#FCFCFC",
                                   "borderBottomLeftRadius": 0,
                                   "borderBottomRightRadius": 16,
                                   "borderColor": "#ECEBEB",
@@ -1422,7 +1422,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                       "overflow": "hidden",
                                     },
                                     {
-                                      "backgroundColor": "#F2F2F2",
+                                      "backgroundColor": "#FCFCFC",
                                       "borderBottomLeftRadius": 0,
                                       "borderBottomRightRadius": 16,
                                       "borderColor": "#ECEBEB",

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -1218,10 +1218,8 @@ export const defaultTheme: Theme = {
       metaText: {
         fontSize: 12,
       },
-      receiverMessageBackgroundColor: Colors.white_smoke,
       replyBorder: {},
       replyContainer: {},
-      senderMessageBackgroundColor: Colors.grey_gainsboro,
       textContainer: {
         onlyEmojiMarkdown: { text: { fontSize: 50 } },
       },


### PR DESCRIPTION
## 🎯 Goal

The goal of the PR is to fix the theme around the sender and receiver colour of the message bubble.

## Light Mode

| Previous | Now |
| - | - |
| ![simulator_screenshot_52CF461B-D545-4E3A-B9AA-7E1A6214BC4E](https://github.com/user-attachments/assets/348b4362-c01b-487e-8349-de948028d666) | ![simulator_screenshot_FBB1051C-AA4C-422F-8A9E-349121F1BF3C](https://github.com/user-attachments/assets/43608b67-7713-41c5-ab29-af24f731d2d5) |


## Dark Mode

| Previous | Now |
| - | - |
| ![simulator_screenshot_008D4EC3-2EC4-423F-BF84-608106F9127D](https://github.com/user-attachments/assets/e604d47f-308d-444a-b22c-489edf8e974a) | ![simulator_screenshot_41613DB6-87A2-4DD7-9579-39C3B883515C](https://github.com/user-attachments/assets/d5a88ab0-4215-443d-b639-a1533f54e6ef) |




