### PR TITLE
fix: poll edge cases

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -852,13 +852,7 @@ const ChannelWithContext = <
             setThreadMessages(updatedThreadMessages);
           }
 
-          if (
-            channel &&
-            thread?.id &&
-            event.message?.id === thread.id &&
-            !threadInstance &&
-            !thread.poll_id
-          ) {
+          if (channel && thread?.id && event.message?.id === thread.id && !threadInstance) {
             const updatedThread = channel.state.formatMessage(event.message);
             setThread(updatedThread);
           }

--- a/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
+++ b/package/src/components/ChannelPreview/hooks/useLatestMessagePreview.ts
@@ -40,6 +40,7 @@ export type LatestMessagePreview<
 export type LatestMessagePreviewSelectorReturnType = {
   createdBy?: UserResponse | null;
   latestVotesByOption?: Record<string, PollVote[]>;
+  name?: string;
 };
 
 const selector = <StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics>(
@@ -47,6 +48,7 @@ const selector = <StreamChatGenerics extends DefaultStreamChatGenerics = Default
 ): LatestMessagePreviewSelectorReturnType => ({
   createdBy: nextValue.created_by,
   latestVotesByOption: nextValue.latest_votes_by_option,
+  name: nextValue.name,
 });
 
 const getMessageSenderName = <
@@ -145,8 +147,8 @@ const getLatestMessageDisplayText = <
       { bold: false, text: t('🏙 Attachment...') },
     ];
   }
-  if (message.poll && pollState) {
-    const { createdBy, latestVotesByOption } = pollState;
+  if (message.poll_id && pollState) {
+    const { createdBy, latestVotesByOption, name } = pollState;
     let latestVotes;
     if (latestVotesByOption) {
       latestVotes = Object.values(latestVotesByOption)
@@ -161,7 +163,7 @@ const getLatestMessageDisplayText = <
     }
     const previewMessage = `${
       client.userID === previewUser?.id ? 'You' : previewUser?.name
-    } ${previewAction}: ${message.poll.name}`;
+    } ${previewAction}: ${name}`;
     return [
       { bold: false, text: '📊 ' },
       { bold: false, text: previewMessage },
@@ -310,7 +312,7 @@ export const useLatestMessagePreview = <
   const poll = client.polls.fromState(pollId);
   const pollState: LatestMessagePreviewSelectorReturnType =
     useStateStore(poll?.state, selector) ?? {};
-  const { createdBy, latestVotesByOption } = pollState;
+  const { createdBy, latestVotesByOption, name } = pollState;
 
   useEffect(
     () =>
@@ -325,7 +327,15 @@ export const useLatestMessagePreview = <
         }),
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [channelLastMessageString, forceUpdate, readEvents, readStatus, latestVotesByOption, createdBy],
+    [
+      channelLastMessageString,
+      forceUpdate,
+      readEvents,
+      readStatus,
+      latestVotesByOption,
+      createdBy,
+      name,
+    ],
   );
 
   return latestMessagePreview;

--- a/package/src/components/Chat/hooks/handleEventToSyncDB.ts
+++ b/package/src/components/Chat/hooks/handleEventToSyncDB.ts
@@ -233,13 +233,14 @@ export const handleEventToSyncDB = <
       'poll.vote_removed',
     ].includes(type)
   ) {
-    const { poll, poll_vote } = event;
+    const { poll, poll_vote, type } = event;
     if (poll) {
       return updatePollMessage({
-        client,
+        eventType: type,
         flush,
         poll,
         poll_vote,
+        userID: client?.userID || '',
       });
     }
   }

--- a/package/src/components/Chat/hooks/handleEventToSyncDB.ts
+++ b/package/src/components/Chat/hooks/handleEventToSyncDB.ts
@@ -233,11 +233,13 @@ export const handleEventToSyncDB = <
       'poll.vote_removed',
     ].includes(type)
   ) {
-    const poll = event.poll;
+    const { poll, poll_vote } = event;
     if (poll) {
       return updatePollMessage({
+        client,
         flush,
         poll,
+        poll_vote,
       });
     }
   }

--- a/package/src/components/Poll/CreatePollContent.tsx
+++ b/package/src/components/Poll/CreatePollContent.tsx
@@ -164,7 +164,12 @@ export const CreatePollContent = () => {
               {t<string>('Multiple answers')}
             </Text>
             <Switch
-              onValueChange={() => setMultipleAnswersAllowed(!multipleAnswersAllowed)}
+              onValueChange={() => {
+                if (multipleAnswersAllowed) {
+                  setMaxVotesPerPersonEnabled(false);
+                }
+                setMultipleAnswersAllowed(!multipleAnswersAllowed);
+              }}
               value={multipleAnswersAllowed}
             />
           </View>

--- a/package/src/components/Reply/Reply.tsx
+++ b/package/src/components/Reply/Reply.tsx
@@ -6,8 +6,9 @@ import dayjs from 'dayjs';
 
 import merge from 'lodash/merge';
 
-import type { Attachment } from 'stream-chat';
+import type { Attachment, PollState } from 'stream-chat';
 
+import { useChatContext } from '../../contexts';
 import { useMessageContext } from '../../contexts/messageContext/MessageContext';
 import {
   MessageInputContext,
@@ -22,6 +23,7 @@ import {
   TranslationContextValue,
   useTranslationContext,
 } from '../../contexts/translationContext/TranslationContext';
+import { useStateStore } from '../../hooks';
 import { DefaultStreamChatGenerics, FileTypes } from '../../types/types';
 import { getResizedImageUrl } from '../../utils/getResizedImageUrl';
 import { getTrimmedAttachmentTitle } from '../../utils/getTrimmedAttachmentTitle';
@@ -31,6 +33,7 @@ import { FileIcon as FileIconDefault } from '../Attachment/FileIcon';
 import { VideoThumbnail } from '../Attachment/VideoThumbnail';
 import { MessageAvatar as MessageAvatarDefault } from '../Message/MessageSimple/MessageAvatar';
 import { MessageTextContainer } from '../Message/MessageSimple/MessageTextContainer';
+import { MessageType } from '../MessageList/hooks/useMessageList';
 
 const styles = StyleSheet.create({
   container: {
@@ -70,6 +73,16 @@ const styles = StyleSheet.create({
   videoThumbnailImageStyle: {
     borderRadius: 10,
   },
+});
+
+export type ReplySelectorReturnType = {
+  name?: string;
+};
+
+const selector = <StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics>(
+  nextValue: PollState<StreamChatGenerics>,
+): ReplySelectorReturnType => ({
+  name: nextValue.name,
 });
 
 type ReplyPropsWithContext<
@@ -134,6 +147,7 @@ const ReplyWithContext = <
 >(
   props: ReplyPropsWithContext<StreamChatGenerics>,
 ) => {
+  const { client } = useChatContext();
   const {
     attachmentSize = 40,
     FileAttachmentIcon,
@@ -166,6 +180,9 @@ const ReplyWithContext = <
       },
     },
   } = useTheme();
+
+  const poll = client.polls.fromState((quotedMessage as MessageType)?.poll_id ?? '');
+  const { name: pollName }: ReplySelectorReturnType = useStateStore(poll?.state, selector) ?? {};
 
   const messageText = typeof quotedMessage === 'boolean' ? '' : quotedMessage.text || '';
 
@@ -262,8 +279,8 @@ const ReplyWithContext = <
               text:
                 quotedMessage.type === 'deleted'
                   ? `_${t('Message deleted')}_`
-                  : quotedMessage.poll
-                  ? `📊 ${quotedMessage.poll.name}`
+                  : pollName
+                  ? `📊 ${pollName}`
                   : quotedMessage.text
                   ? quotedMessage.text.length > 170
                     ? `${quotedMessage.text.slice(0, 170)}...`

--- a/package/src/store/QuickSqliteClient.ts
+++ b/package/src/store/QuickSqliteClient.ts
@@ -30,7 +30,7 @@ import type { PreparedQueries, Table } from './types';
  *
  */
 export class QuickSqliteClient {
-  static dbVersion = 6;
+  static dbVersion = 7;
 
   static dbName = DB_NAME;
   static dbLocation = DB_LOCATION;

--- a/package/src/store/apis/updateMessage.ts
+++ b/package/src/store/apis/updateMessage.ts
@@ -30,11 +30,7 @@ export const updateMessage = ({
     return queries;
   }
 
-  const { poll, poll_id } = messages[0];
-
   const storableMessage = mapMessageToStorable({
-    ...(poll ? { poll: JSON.parse(poll) } : {}),
-    ...(poll_id ? { poll_id } : {}),
     ...message,
   });
 

--- a/package/src/store/apis/updateMessage.ts
+++ b/package/src/store/apis/updateMessage.ts
@@ -30,7 +30,13 @@ export const updateMessage = ({
     return queries;
   }
 
-  const storableMessage = mapMessageToStorable(message);
+  const { poll, poll_id } = messages[0];
+
+  const storableMessage = mapMessageToStorable({
+    ...(poll ? { poll: JSON.parse(poll) } : {}),
+    ...(poll_id ? { poll_id } : {}),
+    ...message,
+  });
 
   queries.push(
     createUpdateQuery('messages', storableMessage, {

--- a/package/src/store/apis/updatePollMessage.ts
+++ b/package/src/store/apis/updatePollMessage.ts
@@ -35,7 +35,6 @@ export const updatePollMessage = <
   for (const pollFromDB of pollsFromDB) {
     const serializedPoll = mapStorableToPoll(pollFromDB);
     const { latest_answers = [], own_votes = [] } = serializedPoll;
-    console.log(eventType);
     let newOwnVotes = own_votes;
     if (poll_vote && poll_vote.user?.id === userID) {
       newOwnVotes =

--- a/package/src/store/apis/updatePollMessage.ts
+++ b/package/src/store/apis/updatePollMessage.ts
@@ -57,8 +57,6 @@ export const updatePollMessage = <
       own_votes: newOwnVotes,
     });
 
-    console.log('STORABLE POLL: ', newOwnVotes);
-
     queries.push(
       createUpdateQuery('poll', storablePoll, {
         id: poll.id,

--- a/package/src/store/apis/updatePollMessage.ts
+++ b/package/src/store/apis/updatePollMessage.ts
@@ -1,5 +1,6 @@
-import type { PollResponse } from 'stream-chat';
+import { isVoteAnswer, PollAnswer, PollResponse, PollVote, StreamChat } from 'stream-chat';
 
+import { DefaultStreamChatGenerics } from '../../types/types';
 import { mapPollToStorable } from '../mappers/mapPollToStorable';
 import { mapStorableToPoll } from '../mappers/mapStorableToPoll';
 import { QuickSqliteClient } from '../QuickSqliteClient';
@@ -7,12 +8,18 @@ import { createSelectQuery } from '../sqlite-utils/createSelectQuery';
 import { createUpdateQuery } from '../sqlite-utils/createUpdateQuery';
 import type { PreparedQueries } from '../types';
 
-export const updatePollMessage = ({
+export const updatePollMessage = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+>({
+  client,
   flush = true,
   poll,
+  poll_vote,
 }: {
-  poll: PollResponse;
+  client: StreamChat<StreamChatGenerics>;
+  poll: PollResponse<StreamChatGenerics>;
   flush?: boolean;
+  poll_vote?: PollVote<StreamChatGenerics> | PollAnswer<StreamChatGenerics>;
 }) => {
   const queries: PreparedQueries[] = [];
 
@@ -25,12 +32,19 @@ export const updatePollMessage = ({
 
   for (const pollFromDB of pollsFromDB) {
     const serializedPoll = mapStorableToPoll(pollFromDB);
-    const { latest_votes, own_votes } = serializedPoll;
-    console.log(own_votes);
+    const { latest_answers = [], own_votes = [] } = serializedPoll;
+    const newOwnVotes =
+      poll_vote && poll_vote.user?.id === client.userID
+        ? [poll_vote, ...own_votes.filter((vote) => vote.id !== poll_vote.id)]
+        : own_votes;
+    const newLatestAnswers =
+      poll_vote && isVoteAnswer(poll_vote)
+        ? [poll_vote, ...latest_answers.filter((answer) => answer.id !== poll_vote?.id)]
+        : latest_answers;
     const storablePoll = mapPollToStorable({
       ...poll,
-      // latest_votes: latest_votes ?? [],
-      // own_votes: own_votes ?? [],
+      latest_answers: newLatestAnswers,
+      own_votes: newOwnVotes,
     });
 
     console.log('STORABLE POLL: ', storablePoll);

--- a/package/src/store/apis/updatePollMessage.ts
+++ b/package/src/store/apis/updatePollMessage.ts
@@ -50,14 +50,6 @@ export const updatePollMessage = <
           ? newLatestAnswers.filter((answer) => answer.id !== poll_vote?.id)
           : [poll_vote, ...newLatestAnswers.filter((answer) => answer.id !== poll_vote?.id)];
     }
-    // const newOwnVotes =
-    //   poll_vote && poll_vote.user?.id === userID
-    //     ? [poll_vote, ...own_votes.filter((vote) => vote.id !== poll_vote.id)]
-    //     : own_votes;
-    // const newLatestAnswers =
-    //   poll_vote && isVoteAnswer(poll_vote)
-    //     ? [poll_vote, ...latest_answers.filter((answer) => answer.id !== poll_vote?.id)]
-    //     : latest_answers;
 
     const storablePoll = mapPollToStorable({
       ...poll,

--- a/package/src/store/apis/updatePollMessage.ts
+++ b/package/src/store/apis/updatePollMessage.ts
@@ -1,6 +1,7 @@
 import type { PollResponse } from 'stream-chat';
 
 import { mapPollToStorable } from '../mappers/mapPollToStorable';
+import { mapStorableToPoll } from '../mappers/mapStorableToPoll';
 import { QuickSqliteClient } from '../QuickSqliteClient';
 import { createSelectQuery } from '../sqlite-utils/createSelectQuery';
 import { createUpdateQuery } from '../sqlite-utils/createUpdateQuery';
@@ -23,13 +24,16 @@ export const updatePollMessage = ({
   );
 
   for (const pollFromDB of pollsFromDB) {
-    const { latest_votes, own_votes } = pollFromDB;
+    const serializedPoll = mapStorableToPoll(pollFromDB);
+    const { latest_votes, own_votes } = serializedPoll;
     console.log(own_votes);
     const storablePoll = mapPollToStorable({
-      ...pollFromDB,
-      latest_votes: latest_votes ? JSON.parse(latest_votes) : [],
-      own_votes: own_votes ? JSON.parse(own_votes) : [],
+      ...poll,
+      // latest_votes: latest_votes ?? [],
+      // own_votes: own_votes ?? [],
     });
+
+    console.log('STORABLE POLL: ', storablePoll);
 
     queries.push(
       createUpdateQuery('poll', storablePoll, {

--- a/package/src/store/apis/updatePollMessage.ts
+++ b/package/src/store/apis/updatePollMessage.ts
@@ -22,10 +22,11 @@ export const updatePollMessage = ({
   );
 
   for (const message of messagesWithPoll) {
+    const { latest_votes, own_votes } = JSON.parse(message.poll);
     const storablePoll = JSON.stringify({
       ...poll,
-      latest_votes: message.poll.latest_votes,
-      own_votes: message.poll.own_votes,
+      latest_votes,
+      own_votes,
     });
     const storableMessage = { ...message, poll: storablePoll };
 

--- a/package/src/store/apis/upsertMessages.ts
+++ b/package/src/store/apis/upsertMessages.ts
@@ -1,6 +1,7 @@
 import type { MessageResponse } from 'stream-chat';
 
 import { mapMessageToStorable } from '../mappers/mapMessageToStorable';
+import { mapPollToStorable } from '../mappers/mapPollToStorable';
 import { mapReactionToStorable } from '../mappers/mapReactionToStorable';
 import { mapUserToStorable } from '../mappers/mapUserToStorable';
 import { QuickSqliteClient } from '../QuickSqliteClient';
@@ -16,6 +17,7 @@ export const upsertMessages = ({
   const storableMessages: Array<ReturnType<typeof mapMessageToStorable>> = [];
   const storableUsers: Array<ReturnType<typeof mapUserToStorable>> = [];
   const storableReactions: Array<ReturnType<typeof mapReactionToStorable>> = [];
+  const storablePolls: Array<ReturnType<typeof mapPollToStorable>> = [];
 
   messages?.forEach((message: MessageResponse) => {
     storableMessages.push(mapMessageToStorable(message));
@@ -28,6 +30,9 @@ export const upsertMessages = ({
       }
       storableReactions.push(mapReactionToStorable(r));
     });
+    if (message.poll) {
+      storablePolls.push(mapPollToStorable(message.poll));
+    }
   });
 
   const finalQueries = [
@@ -36,11 +41,13 @@ export const upsertMessages = ({
     ...storableReactions.map((storableReaction) =>
       createUpsertQuery('reactions', storableReaction),
     ),
+    ...storablePolls.map((storablePoll) => createUpsertQuery('poll', storablePoll)),
   ];
 
   QuickSqliteClient.logger?.('info', 'upsertMessages', {
     flush,
     messages: storableMessages,
+    polls: storablePolls,
     reactions: storableReactions,
     users: storableUsers,
   });

--- a/package/src/store/mappers/mapMessageToStorable.ts
+++ b/package/src/store/mappers/mapMessageToStorable.ts
@@ -2,8 +2,6 @@ import type { FormatMessageResponse, MessageResponse } from 'stream-chat';
 
 import { mapDateTimeToStorable } from './mapDateTimeToStorable';
 
-import { mapPollToStorable } from './mapPollToStorable';
-
 import type { TableRow } from '../types';
 
 export const mapMessageToStorable = (
@@ -20,6 +18,7 @@ export const mapMessageToStorable = (
     message_text_updated_at,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     own_reactions,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     poll,
     poll_id,
     reaction_groups,
@@ -29,8 +28,6 @@ export const mapMessageToStorable = (
     user,
     ...extraData
   } = message;
-
-  const pollInMessage = poll && mapPollToStorable(poll);
 
   return {
     attachments: JSON.stringify(attachments),
@@ -46,6 +43,5 @@ export const mapMessageToStorable = (
     type,
     updatedAt: mapDateTimeToStorable(updated_at),
     userId: user?.id,
-    ...(pollInMessage ? { poll: pollInMessage } : {}),
   };
 };

--- a/package/src/store/mappers/mapMessageToStorable.ts
+++ b/package/src/store/mappers/mapMessageToStorable.ts
@@ -2,6 +2,8 @@ import type { FormatMessageResponse, MessageResponse } from 'stream-chat';
 
 import { mapDateTimeToStorable } from './mapDateTimeToStorable';
 
+import { mapPollToStorable } from './mapPollToStorable';
+
 import type { TableRow } from '../types';
 
 export const mapMessageToStorable = (
@@ -28,6 +30,8 @@ export const mapMessageToStorable = (
     ...extraData
   } = message;
 
+  const pollInMessage = poll && mapPollToStorable(poll);
+
   return {
     attachments: JSON.stringify(attachments),
     cid: cid || '',
@@ -36,12 +40,12 @@ export const mapMessageToStorable = (
     extraData: JSON.stringify(extraData),
     id,
     messageTextUpdatedAt: mapDateTimeToStorable(message_text_updated_at),
-    poll: JSON.stringify(poll),
     poll_id: poll_id || '',
     reactionGroups: JSON.stringify(reaction_groups),
     text,
     type,
     updatedAt: mapDateTimeToStorable(updated_at),
     userId: user?.id,
+    ...(pollInMessage ? { poll: pollInMessage } : {}),
   };
 };

--- a/package/src/store/mappers/mapPollToStorable.ts
+++ b/package/src/store/mappers/mapPollToStorable.ts
@@ -1,0 +1,53 @@
+import type { PollResponse } from 'stream-chat';
+
+import { mapDateTimeToStorable } from './mapDateTimeToStorable';
+
+import type { TableRow } from '../types';
+
+export const mapPollToStorable = (poll: PollResponse): TableRow<'poll'> => {
+  const {
+    allow_answers,
+    allow_user_suggested_options,
+    answers_count,
+    created_at,
+    created_by,
+    created_by_id,
+    description,
+    enforce_unique_vote,
+    id,
+    is_closed,
+    latest_answers,
+    latest_votes_by_option,
+    max_votes_allowed,
+    name,
+    options,
+    own_votes,
+    updated_at,
+    vote_count,
+    vote_counts_by_option,
+    voting_visibility,
+  } = poll;
+
+  return {
+    allow_answers,
+    allow_user_suggested_options,
+    answers_count,
+    created_at: mapDateTimeToStorable(created_at),
+    created_by: JSON.stringify(created_by), // decouple the users from the actual poll
+    created_by_id,
+    description,
+    enforce_unique_vote,
+    id,
+    is_closed,
+    latest_answers: JSON.stringify(latest_answers),
+    latest_votes_by_option: JSON.stringify(latest_votes_by_option),
+    max_votes_allowed,
+    name,
+    options: JSON.stringify(options),
+    own_votes: JSON.stringify(own_votes),
+    updated_at,
+    vote_count,
+    vote_counts_by_option: JSON.stringify(vote_counts_by_option),
+    voting_visibility,
+  };
+};

--- a/package/src/store/mappers/mapStorableToMessage.ts
+++ b/package/src/store/mappers/mapStorableToMessage.ts
@@ -1,22 +1,25 @@
 import type { MessageResponse } from 'stream-chat';
 
+import { mapStorableToPoll } from './mapStorableToPoll';
 import { mapStorableToReaction } from './mapStorableToReaction';
 
 import { mapStorableToUser } from './mapStorableToUser';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
 
-import type { TableRowJoinedUser } from '../types';
+import type { TableRow, TableRowJoinedUser } from '../types';
 
 export const mapStorableToMessage = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 >({
   currentUserId,
   messageRow,
+  pollRow,
   reactionRows,
 }: {
   currentUserId: string;
   messageRow: TableRowJoinedUser<'messages'>;
+  pollRow: TableRow<'poll'>;
   reactionRows: TableRowJoinedUser<'reactions'>[];
 }): MessageResponse<StreamChatGenerics> => {
   const {
@@ -24,7 +27,6 @@ export const mapStorableToMessage = <
     deletedAt,
     extraData,
     messageTextUpdatedAt,
-    poll,
     poll_id,
     reactionGroups,
     updatedAt,
@@ -44,11 +46,11 @@ export const mapStorableToMessage = <
     latest_reactions: latestReactions,
     message_text_updated_at: messageTextUpdatedAt,
     own_reactions: ownReactions,
-    poll: JSON.parse(poll),
     poll_id,
     reaction_groups: reactionGroups ? JSON.parse(reactionGroups) : {},
     updated_at: updatedAt,
     user: mapStorableToUser(user),
+    ...(pollRow ? { poll: mapStorableToPoll(pollRow) } : {}),
     ...(extraData ? JSON.parse(extraData) : {}),
   };
 };

--- a/package/src/store/mappers/mapStorableToPoll.ts
+++ b/package/src/store/mappers/mapStorableToPoll.ts
@@ -1,0 +1,56 @@
+import { PollResponse, VotingVisibility } from 'stream-chat';
+
+import type { DefaultStreamChatGenerics } from '../../types/types';
+import type { TableRow } from '../types';
+
+export const mapStorableToPoll = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+>(
+  pollRow: TableRow<'poll'>,
+): PollResponse<StreamChatGenerics> => {
+  const {
+    allow_answers,
+    allow_user_suggested_options,
+    answers_count,
+    created_at,
+    created_by,
+    created_by_id,
+    description,
+    enforce_unique_vote,
+    id,
+    is_closed,
+    latest_answers,
+    latest_votes_by_option,
+    max_votes_allowed,
+    name,
+    options,
+    own_votes,
+    updated_at,
+    vote_count,
+    vote_counts_by_option,
+    voting_visibility,
+  } = pollRow;
+
+  return {
+    allow_answers,
+    allow_user_suggested_options,
+    answers_count,
+    created_at,
+    created_by: JSON.parse(created_by),
+    created_by_id,
+    description,
+    enforce_unique_vote,
+    id,
+    is_closed,
+    latest_answers: JSON.parse(latest_answers),
+    latest_votes_by_option: JSON.parse(latest_votes_by_option),
+    max_votes_allowed,
+    name,
+    options: JSON.parse(options),
+    own_votes: own_votes ? JSON.parse(own_votes) : [],
+    updated_at,
+    vote_count,
+    vote_counts_by_option: JSON.parse(vote_counts_by_option),
+    voting_visibility: voting_visibility as VotingVisibility | undefined,
+  };
+};

--- a/package/src/store/schema.ts
+++ b/package/src/store/schema.ts
@@ -103,7 +103,6 @@ export const tables: Tables = {
       extraData: 'TEXT',
       id: 'TEXT',
       messageTextUpdatedAt: 'TEXT',
-      poll: 'TEXT',
       poll_id: 'TEXT',
       reactionGroups: 'TEXT',
       text: "TEXT DEFAULT ''",
@@ -298,7 +297,6 @@ export type Schema = {
     extraData: string;
     id: string;
     messageTextUpdatedAt: string;
-    poll: string;
     poll_id: string;
     reactionGroups: string;
     type: MessageLabel;

--- a/package/src/store/schema.ts
+++ b/package/src/store/schema.ts
@@ -161,13 +161,6 @@ export const tables: Tables = {
       vote_counts_by_option: 'TEXT',
       voting_visibility: 'TEXT',
     },
-    indexes: [
-      {
-        columns: ['id'],
-        name: 'index_poll',
-        unique: false,
-      },
-    ],
     primaryKey: ['id'],
   },
   reactions: {

--- a/package/src/store/schema.ts
+++ b/package/src/store/schema.ts
@@ -139,6 +139,38 @@ export const tables: Tables = {
       type: 'TEXT',
     },
   },
+  poll: {
+    columns: {
+      allow_answers: 'BOOLEAN DEFAULT FALSE',
+      allow_user_suggested_options: 'BOOLEAN DEFAULT FALSE',
+      answers_count: 'INTEGER DEFAULT 0',
+      created_at: 'TEXT',
+      created_by: 'TEXT',
+      created_by_id: 'TEXT',
+      description: 'TEXT',
+      enforce_unique_vote: 'BOOLEAN DEFAULT FALSE',
+      id: 'TEXT NOT NULL',
+      is_closed: 'BOOLEAN DEFAULT FALSE',
+      latest_answers: 'TEXT',
+      latest_votes_by_option: 'TEXT',
+      max_votes_allowed: 'INTEGER DEFAULT 1',
+      name: 'TEXT',
+      options: 'TEXT',
+      own_votes: 'TEXT',
+      updated_at: 'TEXT',
+      vote_count: 'INTEGER DEFAULT 0',
+      vote_counts_by_option: 'TEXT',
+      voting_visibility: 'TEXT',
+    },
+    indexes: [
+      {
+        columns: ['id'],
+        name: 'index_poll',
+        unique: false,
+      },
+    ],
+    primaryKey: ['id'],
+  },
   reactions: {
     columns: {
       createdAt: 'TEXT',
@@ -282,6 +314,28 @@ export type Schema = {
     messageId: string;
     payload: string;
     type: ValueOf<PendingTaskTypes>;
+  };
+  poll: {
+    answers_count: number;
+    created_at: string;
+    created_by: string;
+    created_by_id: string;
+    enforce_unique_vote: boolean;
+    id: string;
+    latest_answers: string;
+    latest_votes_by_option: string;
+    max_votes_allowed: number;
+    name: string;
+    options: string;
+    updated_at: string;
+    vote_count: number;
+    vote_counts_by_option: string;
+    allow_answers?: boolean;
+    allow_user_suggested_options?: boolean;
+    description?: string;
+    is_closed?: boolean;
+    own_votes?: string;
+    voting_visibility?: string;
   };
   reactions: {
     createdAt: string;


### PR DESCRIPTION
## 🎯 Goal

This PR addresses a couple of issues related to polls that I've found:

- The offline storage was kind of wonky, so I opted into moving polls to a separate table in the DB; this should both improve performance and data persistence
- A bug where leaving the max votes switch toggled but the upstream one not would cause the lower switch to be preferred
- Issues when thread replying to a poll (the message disappearing as well as replies not working)
- Latest messages in `ChannelList` fixes too

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


