### PR TITLE
fix: scroll to recent issues

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -1204,7 +1204,7 @@ const ChannelWithContext = <
       if (latestSet) latestSet.messages = [];
     }
     if (channel.state.latestMessages.length === 0) {
-      await channel.query({}, 'latest');
+      await channel.query({ messages: { limit: 30 } }, 'latest');
     }
     await channel.state.loadMessageIntoState('latest');
   });

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -948,8 +948,8 @@ const ChannelWithContext = <
           }
         }
         const hasLatestMessages = channel.state.latestMessages.length > 0;
-        channel.state.setIsUpToDate(!hasLatestMessages);
-        setHasNoMoreRecentMessagesToLoad(!hasLatestMessages);
+        channel.state.setIsUpToDate(hasLatestMessages);
+        setHasNoMoreRecentMessagesToLoad(hasLatestMessages);
         copyChannelState();
         if (scrollToMessageIndex !== -1) {
           // since we need to scroll after immediately do this without throttle
@@ -1204,9 +1204,10 @@ const ChannelWithContext = <
       if (latestSet) latestSet.messages = [];
     }
     if (channel.state.latestMessages.length === 0) {
-      await channel.query({ messages: { limit: 30 } }, 'latest');
+      await channel.query({}, 'latest');
     }
     await channel.state.loadMessageIntoState('latest');
+    setMessages([...channel.state.messages]);
   });
 
   const loadChannel = () =>
@@ -1403,13 +1404,17 @@ const ChannelWithContext = <
   }, [enableOfflineSupport, shouldSyncChannel]);
 
   const reloadChannel = () =>
-    channelQueryCallRef.current(async () => {
-      setLoading(true);
-      await loadLatestMessagesRef.current(true);
-      setLoading(false);
-      channel?.state.setIsUpToDate(true);
-      setHasNoMoreRecentMessagesToLoad(true);
-    });
+    channelQueryCallRef.current(
+      async () => {
+        setLoading(true);
+        await loadLatestMessagesRef.current(true);
+        setLoading(false);
+      },
+      () => {
+        channel?.state.setIsUpToDate(true);
+        setHasNoMoreRecentMessagesToLoad(true);
+      },
+    );
 
   /**
    * @deprecated

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -948,8 +948,8 @@ const ChannelWithContext = <
           }
         }
         const hasLatestMessages = channel.state.latestMessages.length > 0;
-        channel.state.setIsUpToDate(hasLatestMessages);
-        setHasNoMoreRecentMessagesToLoad(hasLatestMessages);
+        channel.state.setIsUpToDate(!hasLatestMessages);
+        setHasNoMoreRecentMessagesToLoad(!hasLatestMessages);
         copyChannelState();
         if (scrollToMessageIndex !== -1) {
           // since we need to scroll after immediately do this without throttle
@@ -1888,10 +1888,12 @@ const ChannelWithContext = <
       const latestLengthBeforeMerge = latestMessageSet?.messages.length || 0;
       const didMerge = mergeOverlappingMessageSetsRef.current(true);
       if (didMerge) {
-        if (latestMessageSet && latestLengthBeforeMerge >= limit) {
+        if (latestMessageSet && latestLengthBeforeMerge > 0) {
+          const shouldSetStateUpToDate =
+            latestMessageSet.messages.length < limit && latestMessageSet.isCurrent;
           setLoadingMoreRecent(true);
-          channel.state.setIsUpToDate(true);
-          setHasNoMoreRecentMessagesToLoad(true);
+          channel.state.setIsUpToDate(shouldSetStateUpToDate);
+          setHasNoMoreRecentMessagesToLoad(shouldSetStateUpToDate);
           loadMoreRecentFinished(channel.state.messages);
           restartSetsMergeFuncRef.current();
           return;

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -862,9 +862,7 @@ const MessageListWithContext = <
 
   const goToNewMessages = async () => {
     const isNotLatestSet = channel.state.messages !== channel.state.latestMessages;
-    if (isNotLatestSet && hasNoMoreRecentMessagesToLoad) {
-      loadChannelAroundMessage({});
-    } else if (!hasNoMoreRecentMessagesToLoad) {
+    if (isNotLatestSet) {
       resetPaginationTrackersRef.current();
       await reloadChannel();
     } else if (flatListRef.current) {


### PR DESCRIPTION
## 🎯 Goal

This PR should resolve: 

- This [GH issue](https://github.com/GetStream/stream-chat-react-native/issues/2591) (and all related to it)
- This [Zendesk ticket](https://getstream.zendesk.com/agent/tickets/57269)
- Possibly any other issues related to scrolling to bottom after loading the first unread message

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


