### PR TITLE
refactor: remove stale subscriber count logic and types refactor

### DIFF
--- a/package/src/components/MessageList/hooks/useMessageList.ts
+++ b/package/src/components/MessageList/hooks/useMessageList.ts
@@ -1,9 +1,6 @@
 import type { ChannelState, MessageResponse } from 'stream-chat';
 
-import {
-  ChannelContextValue,
-  useChannelContext,
-} from '../../../contexts/channelContext/ChannelContext';
+import { useChannelContext } from '../../../contexts/channelContext/ChannelContext';
 import { useChatContext } from '../../../contexts/chatContext/ChatContext';
 import {
   DeletedMessagesVisibilityType,
@@ -61,7 +58,7 @@ export const useMessageList = <
   const { threadMessages } = useThreadContext<StreamChatGenerics>();
 
   const messageList = threadList ? threadMessages : messages;
-  const readList: ChannelContextValue<StreamChatGenerics>['read'] | undefined = threadList
+  const readList: ChannelState<StreamChatGenerics>['read'] | undefined = threadList
     ? undefined
     : read;
 

--- a/package/src/components/MessageList/utils/getReadStates.ts
+++ b/package/src/components/MessageList/utils/getReadStates.ts
@@ -1,4 +1,4 @@
-import type { ChannelContextValue } from '../../../contexts/channelContext/ChannelContext';
+import { ChannelState } from 'stream-chat';
 import type { PaginatedMessageListContextValue } from '../../../contexts/paginatedMessageListContext/PaginatedMessageListContext';
 import type { ThreadContextValue } from '../../../contexts/threadContext/ThreadContext';
 import type { DefaultStreamChatGenerics } from '../../../types/types';
@@ -10,7 +10,7 @@ export const getReadStates = <
   messages:
     | PaginatedMessageListContextValue<StreamChatGenerics>['messages']
     | ThreadContextValue<StreamChatGenerics>['threadMessages'],
-  read?: ChannelContextValue<StreamChatGenerics>['read'],
+  read?: ChannelState<StreamChatGenerics>['read'],
 ) => {
   const readData: Record<string, number> = {};
 

--- a/package/src/contexts/channelsStateContext/useChannelState.ts
+++ b/package/src/contexts/channelsStateContext/useChannelState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import type { Channel as ChannelType } from 'stream-chat';
 
@@ -11,15 +11,12 @@ import type { DefaultStreamChatGenerics } from '../../types/types';
 type StateManagerParams<
   Key extends Keys,
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
-> = Omit<
-  ChannelsStateContextValue<StreamChatGenerics>,
-  'increaseSubscriberCount' | 'decreaseSubscriberCount'
-> & {
+> = ChannelsStateContextValue<StreamChatGenerics> & {
   cid: string;
   key: Key;
 };
 
-/* 
+/*
   This hook takes care of creating a useState-like interface which can be used later to call
   updates to the ChannelsStateContext reducer. It receives the cid and key which it wants to update
   and perform the state updates. Also supports a initialState.
@@ -28,15 +25,7 @@ function useStateManager<
   Key extends Keys,
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 >(
-  {
-    cid,
-    key,
-    setState,
-    state,
-  }: Omit<
-    StateManagerParams<Key, StreamChatGenerics>,
-    'increaseSubscriberCount' | 'decreaseSubscriberCount'
-  >,
+  { cid, key, setState, state }: StateManagerParams<Key, StreamChatGenerics>,
   initialValue?: ChannelState<StreamChatGenerics>[Key],
 ) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -79,17 +68,7 @@ export function useChannelState<
   threadId?: string,
 ): UseChannelStateValue<StreamChatGenerics> {
   const cid = channel?.id || 'id'; // in case channel is not initialized, use generic id string for indexing
-  const { decreaseSubscriberCount, increaseSubscriberCount, setState, state } =
-    useChannelsStateContext<StreamChatGenerics>();
-
-  // Keeps track of how many Channel components are subscribed to this Channel state (Channel vs Thread concurrency)
-  useEffect(() => {
-    increaseSubscriberCount({ cid });
-    return () => {
-      decreaseSubscriberCount({ cid });
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const { setState, state } = useChannelsStateContext<StreamChatGenerics>();
 
   const [members, setMembers] = useStateManager(
     {


### PR DESCRIPTION
The goal of the PR is to remove the subscriber count increase/decrease logic, which is redundant, and improve types to use the client directly rather than rely on ChannelContext.