### PR TITLE
fix: android poll creation modal size

### DIFF
--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -894,21 +894,23 @@ const MessageInputWithContext = <
         </View>
       )}
       {showPollCreationDialog ? (
-        <Modal
-          animationType='slide'
-          onRequestClose={closePollCreationDialog}
-          visible={showPollCreationDialog}
-        >
-          <GestureHandlerRootView style={{ flex: 1 }}>
-            <SafeAreaView style={{ backgroundColor: white, flex: 1 }}>
-              <CreatePoll
-                closePollCreationDialog={closePollCreationDialog}
-                CreatePollContent={CreatePollContent}
-                sendMessage={sendMessage}
-              />
-            </SafeAreaView>
-          </GestureHandlerRootView>
-        </Modal>
+        <View style={{ alignItems: 'center', flex: 1, justifyContent: 'center' }}>
+          <Modal
+            animationType='slide'
+            onRequestClose={closePollCreationDialog}
+            visible={showPollCreationDialog}
+          >
+            <GestureHandlerRootView style={{ flex: 1 }}>
+              <SafeAreaView style={{ backgroundColor: white, flex: 1 }}>
+                <CreatePoll
+                  closePollCreationDialog={closePollCreationDialog}
+                  CreatePollContent={CreatePollContent}
+                  sendMessage={sendMessage}
+                />
+              </SafeAreaView>
+            </GestureHandlerRootView>
+          </Modal>
+        </View>
       ) : null}
     </>
   );


### PR DESCRIPTION
## 🎯 Goal

It appears that on version `0.76.0` of React Native and onwards Android modals are known to bug out if it is not immediately clear what the size of their parent is, even if it's enclosed and completely predictable. It's not entirely clear to me (yet) if this is a new architecture thing or something else. The change makes sure that the `Modal`'s immediate parent is correct and signals the Android internals to properly calculate the size of the modal. 

Special styling overrides to the modal are not given because:

- This is something that is meant to be used internally (and I want it to stay that way), since integrators can always override the behaviour of the poll creation button and spin up their own modal if they need something specific
- We anyway want to enforce the proper use of navigation components (through popular navigation libraries) to be the thing our integrators do for any type of navigation as it's impossible to handle every case with our own

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


