### PR TITLE
fix: android modal size

### DIFF
--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -895,21 +895,23 @@ const MessageInputWithContext = <
         </View>
       )}
       {showPollCreationDialog ? (
-        <Modal
-          animationType='slide'
-          onRequestClose={closePollCreationDialog}
-          visible={showPollCreationDialog}
-        >
-          <GestureHandlerRootView style={{ flex: 1 }}>
-            <SafeAreaView style={{ backgroundColor: white, flex: 1 }}>
-              <CreatePoll
-                closePollCreationDialog={closePollCreationDialog}
-                CreatePollContent={CreatePollContent}
-                sendMessage={sendMessage}
-              />
-            </SafeAreaView>
-          </GestureHandlerRootView>
-        </Modal>
+        <View style={{ alignItems: 'center', flex: 1, justifyContent: 'center' }}>
+          <Modal
+            animationType='slide'
+            onRequestClose={closePollCreationDialog}
+            visible={showPollCreationDialog}
+          >
+            <GestureHandlerRootView style={{ flex: 1 }}>
+              <SafeAreaView style={{ backgroundColor: white, flex: 1 }}>
+                <CreatePoll
+                  closePollCreationDialog={closePollCreationDialog}
+                  CreatePollContent={CreatePollContent}
+                  sendMessage={sendMessage}
+                />
+              </SafeAreaView>
+            </GestureHandlerRootView>
+          </Modal>
+        </View>
       ) : null}
     </>
   );


### PR DESCRIPTION
## 🎯 Goal

This is a backport of [this PR](https://github.com/GetStream/stream-chat-react-native/pull/2783), currently available only on V6.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


