### PR TITLE
fix: is muted hook crash

### DIFF
--- a/package/src/components/ChannelPreview/hooks/__tests__/useChannelPreviewMuted.test.tsx
+++ b/package/src/components/ChannelPreview/hooks/__tests__/useChannelPreviewMuted.test.tsx
@@ -29,12 +29,17 @@ describe('useChannelPreviewMuted', () => {
   });
 
   const mockChannel = {
-    muteStatus: jest.fn().mockReturnValue(false),
+    initialized: true,
+    muteStatus: jest.fn().mockReturnValue({
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 5000,
+      muted: false,
+    }),
   } as unknown as Channel<DefaultStreamChatGenerics>;
 
   it('should return the correct mute status', () => {
     const { result } = renderHook(() => useIsChannelMuted(mockChannel));
-    expect(result.current).toBe(false);
+    expect(result.current.muted).toBe(false);
   });
 
   it("should update the mute status when the notification.channel_mutes_updated event is emitted'", () => {

--- a/package/src/components/ChannelPreview/hooks/useChannelPreviewData.ts
+++ b/package/src/components/ChannelPreview/hooks/useChannelPreviewData.ts
@@ -19,7 +19,7 @@ export const useChannelPreviewData = <
     | MessageResponse<StreamChatGenerics>
   >(channel.state.messages[channel.state.messages.length - 1]);
   const [unread, setUnread] = useState(channel.countUnread());
-  const { muted } = useIsChannelMuted(channel);
+  const muted = useIsChannelMuted(channel);
 
   /**
    * This effect listens for the `notification.mark_read` event and sets the unread count to 0

--- a/package/src/components/ChannelPreview/hooks/useChannelPreviewData.ts
+++ b/package/src/components/ChannelPreview/hooks/useChannelPreviewData.ts
@@ -19,7 +19,7 @@ export const useChannelPreviewData = <
     | MessageResponse<StreamChatGenerics>
   >(channel.state.messages[channel.state.messages.length - 1]);
   const [unread, setUnread] = useState(channel.countUnread());
-  const muted = useIsChannelMuted(channel);
+  const { muted } = useIsChannelMuted(channel);
 
   /**
    * This effect listens for the `notification.mark_read` event and sets the unread count to 0

--- a/package/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
+++ b/package/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
@@ -14,16 +14,16 @@ export const useIsChannelMuted = <
   const { client } = useChatContext<StreamChatGenerics>();
   const initialized = channel?.initialized;
 
-  const [muted, setMuted] = useState(() => initialized && channel.muteStatus()?.muted);
+  const [muted, setMuted] = useState(() => initialized && channel.muteStatus());
 
   useEffect(() => {
     const handleEvent = () => {
-      setMuted(initialized && channel.muteStatus()?.muted);
+      setMuted(initialized && channel.muteStatus());
     };
 
     client.on('notification.channel_mutes_updated', handleEvent);
     return () => client.off('notification.channel_mutes_updated', handleEvent);
   }, [channel, client, initialized, muted]);
 
-  return muted;
+  return muted || { createdAt: null, expiresAt: null, muted: false };
 };

--- a/package/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
+++ b/package/src/components/ChannelPreview/hooks/useIsChannelMuted.ts
@@ -12,18 +12,18 @@ export const useIsChannelMuted = <
   channel: Channel<StreamChatGenerics>,
 ) => {
   const { client } = useChatContext<StreamChatGenerics>();
+  const initialized = channel?.initialized;
 
-  const [muted, setMuted] = useState(channel.muteStatus());
+  const [muted, setMuted] = useState(() => initialized && channel.muteStatus()?.muted);
 
   useEffect(() => {
     const handleEvent = () => {
-      setMuted(channel.muteStatus());
+      setMuted(initialized && channel.muteStatus()?.muted);
     };
 
     client.on('notification.channel_mutes_updated', handleEvent);
     return () => client.off('notification.channel_mutes_updated', handleEvent);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [muted]);
+  }, [channel, client, initialized, muted]);
 
   return muted;
 };


### PR DESCRIPTION
## 🎯 Goal

This addresses 2 issues:

- Makes sure `muteStatus().muted` is used to determine whether the channel is muted (and not just the object returned)
- Makes sure `channel.muteStatus()` is not invoked before the channel is initialized

The latter should almost never happen as we have control over this, however there was an instance of this happening when going from background -> foreground with the app.

Note: Will also be backported to V5.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


