### PR TITLE
fix: regex max stack depth crash

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -584,7 +584,7 @@ const ChannelWithContext = <
     MessageStatus = MessageStatusDefault,
     MessageSystem = MessageSystemDefault,
     MessageText,
-    messageTextNumberOfLines = 5,
+    messageTextNumberOfLines,
     MessageTimestamp = MessageTimestampDefault,
     MessageUserReactions = MessageUserReactionsDefault,
     MessageUserReactionsAvatar = MessageUserReactionsAvatarDefault,

--- a/package/src/components/Message/MessageSimple/utils/generateMarkdownText.ts
+++ b/package/src/components/Message/MessageSimple/utils/generateMarkdownText.ts
@@ -35,5 +35,11 @@ export const generateMarkdownText = (text?: string) => {
 
   resultText = resultText.replace(/[<"'>]/g, '\\$&');
 
+  // Remove whitespaces that come directly after newlines except in code blocks where we deem this allowed.
+  resultText = resultText.replace(/(```[\s\S]*?```|`.*?`)|\n[ ]{2,}/g, (_, code) => {
+    if (code) return code;
+    return '\n';
+  });
+
   return resultText;
 };

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -475,9 +475,12 @@ exports[`Thread should match thread snapshot 1`] = `
                                   }
                                 >
                                   <Text
-                                    numberOfLines={5}
                                     style={
                                       {
+                                        "alignItems": "flex-start",
+                                        "flexDirection": "row",
+                                        "flexWrap": "wrap",
+                                        "justifyContent": "flex-start",
                                         "marginBottom": 8,
                                         "marginTop": 8,
                                       }
@@ -823,9 +826,12 @@ exports[`Thread should match thread snapshot 1`] = `
                                   }
                                 >
                                   <Text
-                                    numberOfLines={5}
                                     style={
                                       {
+                                        "alignItems": "flex-start",
+                                        "flexDirection": "row",
+                                        "flexWrap": "wrap",
+                                        "justifyContent": "flex-start",
                                         "marginBottom": 8,
                                         "marginTop": 8,
                                       }
@@ -1171,9 +1177,12 @@ exports[`Thread should match thread snapshot 1`] = `
                                   }
                                 >
                                   <Text
-                                    numberOfLines={5}
                                     style={
                                       {
+                                        "alignItems": "flex-start",
+                                        "flexDirection": "row",
+                                        "flexWrap": "wrap",
+                                        "justifyContent": "flex-start",
                                         "marginBottom": 8,
                                         "marginTop": 8,
                                       }
@@ -1553,9 +1562,12 @@ exports[`Thread should match thread snapshot 1`] = `
                                       }
                                     >
                                       <Text
-                                        numberOfLines={5}
                                         style={
                                           {
+                                            "alignItems": "flex-start",
+                                            "flexDirection": "row",
+                                            "flexWrap": "wrap",
+                                            "justifyContent": "flex-start",
                                             "marginBottom": 8,
                                             "marginTop": 8,
                                           }


### PR DESCRIPTION
## 🎯 Goal

Fixes the occasional `regex maximum depth reached` error. 

Not going to go into the specifics on why this happens as they're complicated, but I will add a few bullet points:

- Tried porting the latest version of `simple-markdown` available [here](https://github.com/Khan/perseus/tree/main/packages/simple-markdown), but nothing changed with that and the issue is still noticeable
- The issue typically happens whenever we have one (or more) `\n` characters, followed by many white spaces; the regex state machine runs something similar to `/\s+/g` at one point, which considers both. However, despite treating them both as the same character under `\s`, it actually does a ridiculous amount of backtracking and combinations while all that's going on, even due to a single `\n` character as it tries to look for every possible scenario.
- Ironically, simply a long sequence of whitespaces finishes in a single go since it manages to match everything in `O(n)`.

Note: We should really look into upgrading our markdown package in general. I was successful in doing so, but decided to separate this fix and the migration since deeper testing would be required.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


