### PR TITLE
fix: expo media library permissions race conditions

### DIFF
--- a/package/expo-package/src/optionalDependencies/pickImage.ts
+++ b/package/expo-package/src/optionalDependencies/pickImage.ts
@@ -53,8 +53,10 @@ export const pickImage = ImagePicker
             return { cancelled: true };
           }
         }
+        return { cancelled: true };
       } catch (error) {
         console.log('Error while picking image', error);
+        return { cancelled: true };
       }
     }
   : null;

--- a/package/native-package/src/optionalDependencies/pickImage.ts
+++ b/package/native-package/src/optionalDependencies/pickImage.ts
@@ -35,6 +35,7 @@ export const pickImage = ImagePicker
         }
       } catch (error) {
         console.log('Error picking image: ', error);
+        return { cancelled: true };
       }
     }
   : null;


### PR DESCRIPTION
## 🎯 Goal

Fixes this [Zendesk ticket](https://getstream.zendesk.com/agent/tickets/58471).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


