### PR TITLE
fix: listen to correct channel read events

### DIFF
--- a/package/src/components/ChannelPreview/hooks/useChannelPreviewData.ts
+++ b/package/src/components/ChannelPreview/hooks/useChannelPreviewData.ts
@@ -31,6 +31,13 @@ export const useChannelPreviewData = <
   const channelLastMessageString = `${channelLastMessage?.id}${channelLastMessage?.updated_at}`;
 
   useEffect(() => {
+    const { unsubscribe } = client.on('notification.mark_read', () => {
+      setUnread(channel.countUnread());
+    });
+    return unsubscribe;
+  }, [channel, client]);
+
+  useEffect(() => {
     if (
       channelLastMessage &&
       (channelLastMessage.id !== lastMessage?.id ||
@@ -56,7 +63,7 @@ export const useChannelPreviewData = <
         setForceUpdate((prev) => prev + 1);
       }
     };
-    const { unsubscribe } = client.on('notification.mark_read', handleReadEvent);
+    const { unsubscribe } = client.on('message.read', handleReadEvent);
     return unsubscribe;
   }, [client, channel]);
 


### PR DESCRIPTION
## 🎯 Goal

Reverts back to the changes discussed in [this Slack thread](https://getstream.slack.com/archives/C06CF5TKRGA/p1732023470613829) (thanks @myandrienko ).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


