### PR TITLE
fix: add FlatList default for Expo

### DIFF
--- a/package/expo-package/src/index.js
+++ b/package/expo-package/src/index.js
@@ -1,3 +1,5 @@
+import { FlatList } from 'react-native';
+
 import { registerNativeHandlers } from 'stream-chat-react-native-core';
 
 import { compressImage } from './handlers';
@@ -24,6 +26,7 @@ registerNativeHandlers({
   Audio,
   compressImage,
   deleteFile,
+  FlatList,
   getLocalAssetUri,
   getPhotos,
   iOS14RefreshGallerySelection,


### PR DESCRIPTION
## 🎯 Goal

Fixes a critical issue on expo where the `MessageList` component was not rendering anything due to a missing native dependency being exported from the upstream package. 

We need to do this now since we handle defaults directly in the variants themselves.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


