### PR TITLE
fix: channel.state break on going to background

### DIFF
--- a/package/src/components/Chat/hooks/useIsOnline.ts
+++ b/package/src/components/Chat/hooks/useIsOnline.ts
@@ -29,11 +29,6 @@ export const useIsOnline = <
   const onBackground = useCallback(() => {
     if (!closeConnectionOnBackground || !clientExists) return;
 
-    for (const cid in client.activeChannels) {
-      const channel = client.activeChannels[cid];
-      channel?.state.setIsUpToDate(false);
-    }
-
     client.closeConnection();
     setIsOnline(false);
   }, [closeConnectionOnBackground, client, clientExists]);


### PR DESCRIPTION
## 🎯 Goal

Fixes a very old and prominent issue we've had in the SDK where sometimes upon a very specific queue of actions messages would stop updating in real time. 

The issue is well documented in the following issues:

- This [GH issue](https://github.com/GetStream/stream-chat-react-native/issues/2305)
- This [Zendesk ticket](https://getstream.zendesk.com/agent/tickets/57225)
- Many other scattered comments across other issues that I'm unable to find right now

Despite the oneliner fix, this issue was incredibly difficult to reproduce consistently - especially because typically it would manifest differently across different integrations.

The TL;DR version of it is:

- Whenever we put the app using the SDK in background (either through going to background, locking the phone or whatever) we close the WS connection due to various reasons (the ability to receive push notifications, not wanting to endlessly keep the connection alive for long etc)
- When this happens, we would preemptively mark all channels as "out of date" in the hope of them resyncing by default when we're back
- However, whenever coming back from BG this state would never be cleared and properly set
- Then, in various circumstances [this particular check](https://github.com/GetStream/stream-chat-js/blob/master/src/channel.ts#L1444) of the `channel` logic in our low level client would fail and so we'd never receive new messages, unable to recover unless we manually trigger loading to more recent messages or simply reload the app

Removing it is completely safe as we handle the resyncing of channels elsewhere.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


