### PR TITLE
fix: increase native attachment picker button sizes for better touchability

### DIFF
--- a/package/src/components/MessageInput/components/NativeAttachmentPicker.tsx
+++ b/package/src/components/MessageInput/components/NativeAttachmentPicker.tsx
@@ -19,16 +19,16 @@ type NativeAttachmentPickerProps = {
   attachButtonLayoutRectangle?: LayoutRectangle;
 };
 
-const TOP_PADDING = 4;
-const ATTACH_MARGIN_BOTTOM = 4;
+const TOP_PADDING = 8;
+const ATTACH_MARGIN_BOTTOM = 8;
 
 export const NativeAttachmentPicker = ({
   attachButtonLayoutRectangle,
   onRequestedClose,
 }: NativeAttachmentPickerProps) => {
   const size = attachButtonLayoutRectangle?.width ?? 0;
-  const attachButtonItemSize = 40;
-  const NUMBER_OF_BUTTONS = 3;
+  const attachButtonItemSize = 48;
+  const NUMBER_OF_BUTTONS = 4;
   const {
     theme: {
       colors: { grey_whisper },
@@ -200,7 +200,6 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     justifyContent: 'flex-end',
-    paddingTop: TOP_PADDING,
     position: 'absolute',
   },
 });


### PR DESCRIPTION
New:
![IMG_0130](https://github.com/user-attachments/assets/658f5553-da88-42ec-8984-8943d5fa5af8)
Old:
![simulator_screenshot_F2ADB74A-86B2-4673-8117-B5D2EA333677](https://github.com/user-attachments/assets/1d3ba8a8-4a96-4669-8f7c-26cf65868e16)
