### PR TITLE
fix: image gallery issues

### DIFF
--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -458,7 +458,7 @@ const GalleryImageThumbnail = <
               setLoadingImage(false);
               setLoadingImageError(true);
             }}
-            onLoadEnd={() => setLoadingImage(false)}
+            onLoadEnd={() => setTimeout(() => setLoadingImage(false), 0)}
             onLoadStart={() => setLoadingImage(true)}
             resizeMode={thumbnail.resizeMode}
             style={[

--- a/package/src/components/ImageGallery/hooks/useAnimatedGalleryStyle.tsx
+++ b/package/src/components/ImageGallery/hooks/useAnimatedGalleryStyle.tsx
@@ -72,12 +72,12 @@ export const useAnimatedGalleryStyle = ({
         { scaleX: -1 },
         { translateY: yScaleOffset },
         {
-          translateX: -translateX.value - xScaleOffset,
+          translateX: -xScaleOffset,
         },
         { scale: oneEighth },
       ],
     };
-  }, []);
+  }, [index]);
 
   return [animatedGalleryStyle, animatedStyles];
 };


### PR DESCRIPTION
## 🎯 Goal

This PR fixes 2 issues on V6 and new architecture:

- The closing animations of our image gallery being completely broken (with ghost animations happening after the fact)
- An issue of having an infinite loading spinner of images within image thumbnail components for `Gallery` attachment messages

More details on the actual changes.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


