### PR TITLE
fix: only disable message input ui when capabilities change

### DIFF
--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -1103,7 +1103,7 @@ export const MessageInput = <
   const { isOnline } = useChatContext();
   const ownCapabilities = useOwnCapabilitiesContext();
 
-  const { disabled, members, threadList, watchers } = useChannelContext<StreamChatGenerics>();
+  const { members, threadList, watchers } = useChannelContext<StreamChatGenerics>();
 
   const {
     additionalTextInputProps,
@@ -1182,7 +1182,7 @@ export const MessageInput = <
    * Disable the message input if the channel is frozen, or the user doesn't have the capability to send a message.
    * Enable it in frozen mode, if it the input has editing state.
    */
-  if ((disabled || !ownCapabilities.sendMessage) && !editing && SendMessageDisallowedIndicator) {
+  if (!ownCapabilities.sendMessage && !editing && SendMessageDisallowedIndicator) {
     return <SendMessageDisallowedIndicator />;
   }
 


### PR DESCRIPTION
## 🎯 Goal

Fixes [this Zendesk issue](https://getstream.zendesk.com/agent/tickets/59176).

This technically gets rid of the behaviour that we can override how the UI behaves regardless of capabilities. The reason why we need to do it is because of the fact that:

- The `disableIfFrozenChannel` override can override how the UI behaves but it will still never allow you to actually send messages (if no permissions/capabilities are present you will always have the message bounced back by our backend)
- Due to its default being `true`, it would also mean that having frozen channels that can receive messages from certain roles (that have the correct permissions) would not be possible unless specifically set to `false`, which is not the default behaviour we preach and want to have

Instead, we should have:

- The `MessageInput` UI depending entirely on the `own_capabilities` provided to the user (as they automatically get updated according to permissions)
- Not relying on checking whether the channel is `frozen` or not anymore since it's actually breaking in some usecases
- Not relying on the override at all as it mustn't change this specific behaviour

The prop will be removed entirely in V6.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


