### PR TITLE
chore: write tests for disallowed sending messages

### DIFF
--- a/package/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/package/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Alert } from 'react-native';
 
-import { cleanup, fireEvent, render, userEvent, waitFor } from '@testing-library/react-native';
+import { act, cleanup, fireEvent, render, userEvent, waitFor } from '@testing-library/react-native';
 
 import * as AttachmentPickerUtils from '../../../contexts/attachmentPickerContext/AttachmentPickerContext';
 import { OverlayProvider } from '../../../contexts/overlayContext/OverlayProvider';
@@ -186,6 +186,85 @@ describe('MessageInput', () => {
       // This is sort of a brittle test, but there doesn't seem to be another way
       // to target alerts. The reason why it's here is because we had a bug with it.
       expect(Alert.alert).toHaveBeenCalledWith('Hold to start recording.');
+    });
+  });
+
+  it('should render the SendMessageDisallowedIndicator if the send-message capability is not present', async () => {
+    await initializeChannel(generateChannelResponse());
+
+    const { queryByTestId } = render(
+      <Chat client={chatClient}>
+        <Channel audioRecordingEnabled channel={channel}>
+          <MessageInput />
+        </Channel>
+      </Chat>,
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId('send-message-disallowed-indicator')).toBeNull();
+    });
+
+    act(() => {
+      chatClient.dispatchEvent({
+        cid: channel.data.cid,
+        own_capabilities: channel.data.own_capabilities.filter(
+          (capability) => capability !== 'send-message',
+        ),
+        type: 'capabilities.changed',
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId('send-message-disallowed-indicator')).toBeTruthy();
+    });
+  });
+
+  it('should not render the SendMessageDisallowedIndicator if the channel is frozen and the send-message capability is present', async () => {
+    await initializeChannel(generateChannelResponse({ channel: { frozen: true } }));
+
+    const { queryByTestId } = render(
+      <Chat client={chatClient}>
+        <Channel audioRecordingEnabled channel={channel}>
+          <MessageInput />
+        </Channel>
+      </Chat>,
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId('send-message-disallowed-indicator')).toBeNull();
+    });
+  });
+
+  it('should render the SendMessageDisallowedIndicator only if the send-message capability is not present', async () => {
+    await initializeChannel(generateChannelResponse({ channel: { frozen: true } }));
+
+    const { queryByTestId } = render(
+      <Chat client={chatClient}>
+        <Channel audioRecordingEnabled channel={channel}>
+          <MessageInput />
+        </Channel>
+      </Chat>,
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId('send-message-disallowed-indicator')).toBeNull();
+    });
+
+    act(() => {
+      chatClient.dispatchEvent({
+        channel: {
+          ...channel.data,
+          own_capabilities: channel.data.own_capabilities.filter(
+            (capability) => capability !== 'send-message',
+          ),
+        },
+        cid: channel.data.cid,
+        type: 'channel.updated',
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId('send-message-disallowed-indicator')).toBeTruthy();
     });
   });
 });

--- a/package/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/package/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -246,10 +246,6 @@ describe('MessageInput', () => {
       </Chat>,
     );
 
-    await waitFor(() => {
-      expect(queryByTestId('send-message-disallowed-indicator')).toBeNull();
-    });
-
     act(() => {
       chatClient.dispatchEvent({
         channel: {

--- a/package/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/package/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -235,7 +235,7 @@ describe('MessageInput', () => {
     });
   });
 
-  it('should render the SendMessageDisallowedIndicator only if the send-message capability is not present', async () => {
+  it('should render the SendMessageDisallowedIndicator in a frozen channel only if the send-message capability is not present', async () => {
     await initializeChannel(generateChannelResponse({ channel: { frozen: true } }));
 
     const { queryByTestId } = render(


### PR DESCRIPTION
## 🎯 Goal

This is a followup to [this PR](https://github.com/GetStream/stream-chat-react-native/pull/2836), as we were trying to get it out as soon as possible in order to fix an incident. Tests were lacking in this department, causing the regression.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


