### PR TITLE
fix: export useFetchReaction hook from SDK and TS improvements

### DIFF
--- a/package/src/components/MessageMenu/MessageReactionPicker.tsx
+++ b/package/src/components/MessageMenu/MessageReactionPicker.tsx
@@ -3,6 +3,7 @@ import { FlatList, StyleSheet, View } from 'react-native';
 
 import { ReactionButton } from './ReactionButton';
 
+import { MessageContextValue } from '../../contexts/messageContext/MessageContext';
 import {
   MessagesContextValue,
   useMessagesContext,
@@ -16,23 +17,13 @@ import { ReactionData } from '../../utils/utils';
 
 export type MessageReactionPickerProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
-> = Pick<MessagesContextValue<StreamChatGenerics>, 'supportedReactions'> & {
-  /**
-   * Function to dismiss the action bottom sheet.
-   * @returns void
-   */
-  dismissOverlay: () => void;
-  /**
-   * An array of reaction types that the current user has reacted with
-   */
-  ownReactionTypes: string[];
-  /**
-   * Function to handle reaction on press
-   * @param reactionType
-   * @returns
-   */
-  handleReaction?: (reactionType: string) => Promise<void>;
-};
+> = Pick<MessagesContextValue<StreamChatGenerics>, 'supportedReactions'> &
+  Pick<MessageContextValue<StreamChatGenerics>, 'handleReaction' | 'dismissOverlay'> & {
+    /**
+     * An array of reaction types that the current user has reacted with
+     */
+    ownReactionTypes: string[];
+  };
 
 export type ReactionPickerItemType = ReactionData & {
   onSelectReaction: (type: string) => void;

--- a/package/src/components/MessageMenu/MessageUserReactions.tsx
+++ b/package/src/components/MessageMenu/MessageUserReactions.tsx
@@ -6,6 +6,7 @@ import { ReactionSortBase } from 'stream-chat';
 import { useFetchReactions } from './hooks/useFetchReactions';
 import { ReactionButton } from './ReactionButton';
 
+import { MessageContextValue } from '../../contexts/messageContext/MessageContext';
 import {
   MessagesContextValue,
   useMessagesContext,
@@ -14,7 +15,6 @@ import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
 import { DefaultStreamChatGenerics, Reaction } from '../../types/types';
 import { ReactionData } from '../../utils/utils';
-import { MessageType } from '../MessageList/hooks/useMessageList';
 
 export type MessageUserReactionsProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -23,16 +23,13 @@ export type MessageUserReactionsProps<
     MessagesContextValue<StreamChatGenerics>,
     'MessageUserReactionsAvatar' | 'MessageUserReactionsItem' | 'supportedReactions'
   >
-> & {
-  /**
-   * The message object
-   */
-  message?: MessageType<StreamChatGenerics>;
-  /**
-   * An array of reactions
-   */
-  reactions?: Reaction[];
-};
+> &
+  Partial<Pick<MessageContextValue<StreamChatGenerics>, 'message'>> & {
+    /**
+     * An array of reactions
+     */
+    reactions?: Reaction[];
+  };
 
 const sort: ReactionSortBase = {
   created_at: -1,

--- a/package/src/components/index.ts
+++ b/package/src/components/index.ts
@@ -162,6 +162,7 @@ export * from './MessageMenu/MessageMenu';
 export * from './MessageMenu/MessageUserReactions';
 export * from './MessageMenu/MessageUserReactionsAvatar';
 export * from './MessageMenu/MessageReactionPicker';
+export * from './MessageMenu/hooks/useFetchReactions';
 
 export * from './ProgressControl/ProgressControl';
 export * from './Poll';


### PR DESCRIPTION
The goal of the PR is to export useFetchReaction hook from the SDK and unify a couple of TS types.