### PR TITLE
fix: change default value of audioRecordingEnabled and not rely on package availability for default value

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -85,7 +85,6 @@ import {
 } from '../../icons';
 import {
   FlatList as FlatListDefault,
-  isAudioRecorderAvailable,
   isDocumentPickerAvailable,
   isImageMediaLibraryAvailable,
   isImagePickerAvailable,
@@ -494,7 +493,7 @@ const ChannelWithContext = <
     AudioAttachment = AudioAttachmentDefault,
     AudioAttachmentUploadPreview = AudioAttachmentDefault,
     AudioRecorder = AudioRecorderDefault,
-    audioRecordingEnabled = isAudioRecorderAvailable(),
+    audioRecordingEnabled = false,
     AudioRecordingInProgress = AudioRecordingInProgressDefault,
     AudioRecordingLockIndicator = AudioRecordingLockIndicatorDefault,
     AudioRecordingPreview = AudioRecordingPreviewDefault,

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -56,7 +56,11 @@ import {
   useTranslationContext,
 } from '../../contexts/translationContext/TranslationContext';
 
-import { isImageMediaLibraryAvailable, triggerHaptic } from '../../native';
+import {
+  isAudioRecorderAvailable,
+  isImageMediaLibraryAvailable,
+  triggerHaptic,
+} from '../../native';
 import type { Asset, DefaultStreamChatGenerics } from '../../types/types';
 import { AIStates, useAIState } from '../AITypingIndicatorView';
 import { AutoCompleteInput } from '../AutoCompleteInput/AutoCompleteInput';
@@ -624,7 +628,7 @@ const MessageInputWithContext = <
   } = useAudioController();
 
   const isSendingButtonVisible = () => {
-    if (audioRecordingEnabled) {
+    if (audioRecordingEnabled && isAudioRecorderAvailable()) {
       if (recording) {
         return false;
       }
@@ -856,7 +860,7 @@ const MessageInputWithContext = <
                   </View>
                 ))
               )}
-              {audioRecordingEnabled && !micLocked && (
+              {audioRecordingEnabled && isAudioRecorderAvailable() && !micLocked && (
                 <GestureDetector gesture={panGestureMic}>
                   <Animated.View
                     style={[

--- a/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingButton.tsx
+++ b/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingButton.tsx
@@ -8,11 +8,7 @@ import {
 import { useTheme } from '../../../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../../../contexts/translationContext/TranslationContext';
 import { Mic } from '../../../../icons/Mic';
-import {
-  AudioRecordingReturnType,
-  isAudioRecorderAvailable,
-  triggerHaptic,
-} from '../../../../native';
+import { AudioRecordingReturnType, triggerHaptic } from '../../../../native';
 
 import type { DefaultStreamChatGenerics } from '../../../../types/types';
 
@@ -101,8 +97,6 @@ const AudioRecordingButtonWithContext = <
       if (startVoiceRecording) startVoiceRecording();
     }
   };
-
-  if (!isAudioRecorderAvailable()) return null;
 
   return (
     <Pressable

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -2136,21 +2136,9 @@ exports[`Thread should match thread snapshot 1`] = `
           </View>
         </View>
         <View
-          collapsable={false}
           style={
             [
               {},
-              {
-                "opacity": undefined,
-                "transform": [
-                  {
-                    "translateX": 0,
-                  },
-                  {
-                    "translateY": 0,
-                  },
-                ],
-              },
               {},
             ]
           }
@@ -2160,7 +2148,7 @@ exports[`Thread should match thread snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": undefined,
+                "disabled": true,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -2187,26 +2175,16 @@ exports[`Thread should match thread snapshot 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               [
-                {
-                  "alignItems": "center",
-                  "borderRadius": 50,
-                  "justifyContent": "center",
-                },
-                {
-                  "backgroundColor": "#FFFFFF",
-                  "height": 40,
-                  "width": 40,
-                },
                 {},
               ]
             }
-            testID="audio-button"
+            testID="send-button"
           >
             <RNSVGSvgView
               align="xMidYMid"
               bbHeight={32}
               bbWidth={32}
-              fill="#7A7A7A"
+              fill="#DBDBDB"
               focusable={false}
               height={32}
               meetOrSlice={0}
@@ -2232,7 +2210,7 @@ exports[`Thread should match thread snapshot 1`] = `
               <RNSVGGroup
                 fill={
                   {
-                    "payload": 4286216826,
+                    "payload": 4292598747,
                     "type": 0,
                   }
                 }
@@ -2242,30 +2220,39 @@ exports[`Thread should match thread snapshot 1`] = `
                   ]
                 }
               >
-                <RNSVGGroup
+                <RNSVGCircle
+                  cx={16}
+                  cy={16}
                   fill={
                     {
-                      "payload": 4278190080,
+                      "payload": 4292598747,
                       "type": 0,
                     }
                   }
-                  name="24 / mic_iOS"
-                >
-                  <RNSVGPath
-                    d="M11.5234 13.9922C11.5234 16.8047 13.375 18.7734 16 18.7734C18.6367 18.7734 20.4766 16.8047 20.4766 13.9922V6.69141C20.4766 3.86719 18.6367 1.89844 16 1.89844C13.375 1.89844 11.5234 3.86719 11.5234 6.69141V13.9922ZM13.7383 14.0273V6.64453C13.7383 5.08594 14.6172 4.01953 16 4.01953C17.3828 4.01953 18.2617 5.08594 18.2617 6.64453V14.0273C18.2617 15.5977 17.3828 16.6523 16 16.6523C14.6172 16.6523 13.7383 15.5977 13.7383 14.0273ZM7.10547 14.5078C7.10547 19.3242 10.3047 22.6289 14.9336 23.0742V25.4766H10.6211C10.0234 25.4766 9.51953 25.9688 9.51953 26.5781C9.51953 27.1758 10.0234 27.668 10.6211 27.668H21.3789C21.9883 27.668 22.4922 27.1758 22.4922 26.5781C22.4922 25.9688 21.9883 25.4766 21.3789 25.4766H17.0781V23.0742C21.6953 22.6289 24.9062 19.3242 24.9062 14.5078V12.1875C24.9062 11.5781 24.4141 11.0977 23.8047 11.0977C23.1953 11.0977 22.6914 11.5781 22.6914 12.1875V14.4258C22.6914 18.4102 19.9961 21.0469 16 21.0469C12.0039 21.0469 9.30859 18.4102 9.30859 14.4258V12.1875C9.30859 11.5781 8.81641 11.0977 8.20703 11.0977C7.59766 11.0977 7.10547 11.5781 7.10547 12.1875V14.5078Z"
-                    fill={
-                      {
-                        "payload": 4286216826,
-                        "type": 0,
-                      }
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                  r={16}
+                />
+                <RNSVGPath
+                  clipRule={0}
+                  d="M9.33398 14.6666H16.0007V9.33325L22.6673 15.9999L16.0007 22.6666V17.3333H9.33398V14.6666Z"
+                  fill={
+                    {
+                      "payload": 4294967295,
+                      "type": 0,
                     }
-                    propList={
-                      [
-                        "fill",
-                      ]
-                    }
-                  />
-                </RNSVGGroup>
+                  }
+                  fillRule={0}
+                  propList={
+                    [
+                      "fill",
+                      "fillRule",
+                    ]
+                  }
+                />
               </RNSVGGroup>
             </RNSVGSvgView>
           </View>


### PR DESCRIPTION
There was a bug, lets say you have the `expo-av` package but disabled the async audio feature using the prop on Channel component but it would still show the recording button. This is fixed in the PR.