### PR TITLE
fix: message list connection reconciliation

### DIFF
--- a/package/src/components/AITypingIndicatorView/hooks/useAIState.ts
+++ b/package/src/components/AITypingIndicatorView/hooks/useAIState.ts
@@ -4,7 +4,6 @@ import { AIState, Channel, Event } from 'stream-chat';
 
 import { useChatContext } from '../../../contexts';
 import type { DefaultStreamChatGenerics } from '../../../types/types';
-import { useIsOnline } from '../../Chat/hooks/useIsOnline';
 
 export const AIStates = {
   Error: 'AI_STATE_ERROR',
@@ -24,8 +23,7 @@ export const useAIState = <
 >(
   channel?: Channel<StreamChatGenerics>,
 ): { aiState: AIState } => {
-  const { client } = useChatContext<StreamChatGenerics>();
-  const { isOnline } = useIsOnline<StreamChatGenerics>(client);
+  const { isOnline } = useChatContext<StreamChatGenerics>();
 
   const [aiState, setAiState] = useState<AIState>(AIStates.Idle);
 

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -985,6 +985,14 @@ const ChannelWithContext = <
     syncingChannelRef.current = true;
     setError(false);
 
+    if (channelMessagesState?.messages) {
+      await channel?.watch({
+        messages: {
+          limit: channelMessagesState.messages.length + 30,
+        },
+      });
+    }
+
     const parseMessage = (message: FormatMessageResponse<StreamChatGenerics>) =>
       ({
         ...message,
@@ -1003,6 +1011,7 @@ const ChannelWithContext = <
         if (failedMessages?.length) {
           channel.state.addMessagesSorted(failedMessages);
         }
+        channel.state.setIsUpToDate(true);
       } else {
         await reloadThread();
 
@@ -1042,7 +1051,7 @@ const ChannelWithContext = <
     if (enableOfflineSupport) {
       connectionChangedSubscription = DBSyncManager.onSyncStatusChange((statusChanged) => {
         if (statusChanged) {
-          copyChannelState();
+          connectionChangedHandler();
         }
       });
     } else {


### PR DESCRIPTION
## 🎯 Goal

This PR fixes the problems mentioned in [this GH issue](https://github.com/GetStream/stream-chat-react-native/issues/2894).

- The reconnect issue is a regression that happened in V6 of our SDK, where no actual HTTP calls were being done when trying to reconcile the state when recovering connection
- The other one is an improper use of a hook within the SDK, causing the property to be ignored altogether (as the second time it is being invoked is deeper within the DOM tree)

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


