### PR TITLE
fix: properly sync own reads while offline mode is enabled

### DIFF
--- a/package/src/components/ChannelList/hooks/useCreateChannelsContext.ts
+++ b/package/src/components/ChannelList/hooks/useCreateChannelsContext.ts
@@ -41,7 +41,9 @@ export const useCreateChannelsContext = <
   const channelValueString = channels
     ?.map(
       (channel) =>
-        `${channel.data?.name ?? ''}${channel.id ?? ''}${Object.values(channel.state.members)
+        `${channel.data?.name ?? ''}${channel.id ?? ''}${
+          channel?.state?.unreadCount ?? ''
+        }${Object.values(channel.state.members)
           .map((member) => member.user?.online)
           .join()}`,
     )

--- a/package/src/components/ChannelPreview/hooks/useChannelPreviewData.ts
+++ b/package/src/components/ChannelPreview/hooks/useChannelPreviewData.ts
@@ -47,8 +47,7 @@ export const useChannelPreviewData = <
     }
     const newUnreadCount = channel.countUnread();
     setUnread(newUnreadCount);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [channel, channelLastMessageString, channelListForceUpdate]);
+  }, [channel, channelLastMessage, channelLastMessageString, channelListForceUpdate, lastMessage]);
 
   /**
    * This effect listens for the `notification.mark_read` event and sets the unread count to 0

--- a/package/src/components/Chat/hooks/handleEventToSyncDB.ts
+++ b/package/src/components/Chat/hooks/handleEventToSyncDB.ts
@@ -130,7 +130,9 @@ export const handleEventToSyncDB = async <
         });
         if (cid && client.user && client.user.id !== user?.id) {
           const userId = client.user.id;
-          const ownReads = client.activeChannels[cid]?.state.read[userId];
+          const channel = client.activeChannels[cid];
+          const ownReads = channel?.state.read[userId];
+          const unreadCount = channel?.state.unreadCount;
           const upsertReadsQueries = await upsertReads({
             cid,
             flush: flushOverride,
@@ -138,7 +140,7 @@ export const handleEventToSyncDB = async <
               {
                 last_read: ownReads.last_read.toString() as string,
                 last_read_message_id: ownReads.last_read_message_id,
-                unread_messages: ownReads?.unread_messages,
+                unread_messages: unreadCount,
                 user: client.user,
               },
             ],


### PR DESCRIPTION
## 🎯 Goal

Fixes [this Zendesk issue](https://getstream.zendesk.com/agent/tickets/60502).

## 🛠 Implementation details

It appears that this underlying issue may represent itself in various manners, all appearing in integrations where `enableOfflineSupport={true}`:

- If you receive messages across multiple channels while the `ChannelList` specifically is open, reading one will break the state for all others
- Sometimes, `channel` reads get stuck in a weird state where it's not possible to trigger a read
- Receiving a new message while not at the bottom of `MessageList` (which count as unread) while having it open will cause these to not be counted in the `ChannelPreview`s if we go back to our `ChannelList`

Although the issues seem different, they all have the same underlying cause - the fact that we don't update reads whenever we receive new messages within the SDK, but rather we update them only whenever we query channels. This leads to the following happening:

- We open the app and first load the data from the offline DB
- We then query channels, which updates the local DB with up to date data (which does not contain any unreads yet)
- We receive messages in a couple of channels (this does NOT update the offline DB)
- We try to read a channel and then go back
- Steps 1 and 2 are repeated, as we need to resync the `ChannelList`
- However, the offline DB data is now stale and does not have any unreads so everything resets in the `ChannelList`

The reason why the second channels query did not update the `ChannelList` either is due to an improper list of dependencies in our hooks as well as bad values used for memoization. So the underlying causes were 2 issues:

- Bad memo/hook dependency management
- Not writing to the offline DB whenever we receive a new message

Both of these issues should be fixed.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


