### PR TITLE
fix: add thumbnail info on gallery press handlers

### DIFF
--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -332,6 +332,7 @@ const GalleryThumbnail = <
       onLongPress={(event) => {
         if (onLongPress) {
           onLongPress({
+            additionalInfo: { thumbnail },
             emitter: 'gallery',
             event,
           });
@@ -340,6 +341,7 @@ const GalleryThumbnail = <
       onPress={(event) => {
         if (onPress) {
           onPress({
+            additionalInfo: { thumbnail },
             defaultHandler: defaultOnPress,
             emitter: 'gallery',
             event,
@@ -349,6 +351,7 @@ const GalleryThumbnail = <
       onPressIn={(event) => {
         if (onPressIn) {
           onPressIn({
+            additionalInfo: { thumbnail },
             defaultHandler: defaultOnPress,
             emitter: 'gallery',
             event,

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -40,6 +40,7 @@ import {
   isEditedMessage,
   MessageStatusTypes,
 } from '../../utils/utils';
+import type { Thumbnail } from '../Attachment/utils/buildGallery/types';
 
 import {
   isMessageWithStylesReadByAndDateSeparator,
@@ -74,16 +75,25 @@ export type FileAttachmentTouchableHandlerPayload<
   additionalInfo?: { attachment?: Attachment<StreamChatGenerics> };
 };
 
+export type GalleryThumbnailTouchableHandlerPayload = {
+  emitter: 'gallery';
+  additionalInfo?: { thumbnail?: Thumbnail };
+};
+
 export type PressableHandlerPayload = {
   defaultHandler?: () => void;
   event?: GestureResponderEvent;
 } & (
   | {
-      emitter?: Exclude<TouchableEmitter, 'textMention' | 'textLink' | 'card' | 'fileAttachment'>;
+      emitter?: Exclude<
+        TouchableEmitter,
+        'textMention' | 'textLink' | 'card' | 'fileAttachment' | 'gallery'
+      >;
     }
   | TextMentionTouchableHandlerPayload
   | UrlTouchableHandlerPayload
   | FileAttachmentTouchableHandlerPayload
+  | GalleryThumbnailTouchableHandlerPayload
 );
 
 export type MessagePressableHandlerPayload<

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -56,28 +56,40 @@ export type TouchableEmitter =
   | 'messageReplies'
   | 'reactionList';
 
+export type TextMentionTouchableHandlerAdditionalInfo<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+> = { user?: UserResponse<StreamChatGenerics> };
+
 export type TextMentionTouchableHandlerPayload<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 > = {
   emitter: 'textMention';
-  additionalInfo?: { user?: UserResponse<StreamChatGenerics> };
+  additionalInfo?: TextMentionTouchableHandlerAdditionalInfo<StreamChatGenerics>;
 };
+
+export type UrlTouchableHandlerAdditionalInfo = { url?: string };
 
 export type UrlTouchableHandlerPayload = {
   emitter: 'textLink' | 'card';
-  additionalInfo?: { url?: string };
+  additionalInfo?: UrlTouchableHandlerAdditionalInfo;
 };
+
+export type FileAttachmentTouchableHandlerAdditionalInfo<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+> = { attachment?: Attachment<StreamChatGenerics> };
 
 export type FileAttachmentTouchableHandlerPayload<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 > = {
   emitter: 'fileAttachment';
-  additionalInfo?: { attachment?: Attachment<StreamChatGenerics> };
+  additionalInfo?: FileAttachmentTouchableHandlerAdditionalInfo<StreamChatGenerics>;
 };
+
+export type GalleryThumbnailTouchableHandlerAdditionalInfo = { thumbnail?: Thumbnail };
 
 export type GalleryThumbnailTouchableHandlerPayload = {
   emitter: 'gallery';
-  additionalInfo?: { thumbnail?: Thumbnail };
+  additionalInfo?: GalleryThumbnailTouchableHandlerAdditionalInfo;
 };
 
 export type PressableHandlerPayload = {


### PR DESCRIPTION
## 🎯 Goal

Resolves [this Zendesk issue](https://getstream.zendesk.com/agent/tickets/60784).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


