### PR TITLE
fix: backport attachment thumbnail fix

### DIFF
--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -330,6 +330,7 @@ const GalleryThumbnail = <
       onLongPress={(event) => {
         if (onLongPress) {
           onLongPress({
+            additionalInfo: { thumbnail },
             emitter: 'gallery',
             event,
           });
@@ -338,6 +339,7 @@ const GalleryThumbnail = <
       onPress={(event) => {
         if (onPress) {
           onPress({
+            additionalInfo: { thumbnail },
             defaultHandler: defaultOnPress,
             emitter: 'gallery',
             event,
@@ -347,6 +349,7 @@ const GalleryThumbnail = <
       onPressIn={(event) => {
         if (onPressIn) {
           onPressIn({
+            additionalInfo: { thumbnail },
             defaultHandler: defaultOnPress,
             emitter: 'gallery',
             event,

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -48,6 +48,7 @@ import {
   isEditedMessage,
   MessageStatusTypes,
 } from '../../utils/utils';
+import type { Thumbnail } from '../Attachment/utils/buildGallery/types';
 
 import {
   isMessageWithStylesReadByAndDateSeparator,
@@ -65,23 +66,40 @@ export type TouchableEmitter =
   | 'messageReplies'
   | 'reactionList';
 
+export type TextMentionTouchableHandlerAdditionalInfo<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+> = { user?: UserResponse<StreamChatGenerics> };
+
 export type TextMentionTouchableHandlerPayload<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 > = {
   emitter: 'textMention';
-  additionalInfo?: { user?: UserResponse<StreamChatGenerics> };
+  additionalInfo?: TextMentionTouchableHandlerAdditionalInfo<StreamChatGenerics>;
 };
+
+export type UrlTouchableHandlerAdditionalInfo = { url?: string };
 
 export type UrlTouchableHandlerPayload = {
   emitter: 'textLink' | 'card';
-  additionalInfo?: { url?: string };
+  additionalInfo?: UrlTouchableHandlerAdditionalInfo;
 };
+
+export type FileAttachmentTouchableHandlerAdditionalInfo<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
+> = { attachment?: Attachment<StreamChatGenerics> };
 
 export type FileAttachmentTouchableHandlerPayload<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 > = {
   emitter: 'fileAttachment';
-  additionalInfo?: { attachment?: Attachment<StreamChatGenerics> };
+  additionalInfo?: FileAttachmentTouchableHandlerAdditionalInfo<StreamChatGenerics>;
+};
+
+export type GalleryThumbnailTouchableHandlerAdditionalInfo = { thumbnail?: Thumbnail };
+
+export type GalleryThumbnailTouchableHandlerPayload = {
+  emitter: 'gallery';
+  additionalInfo?: GalleryThumbnailTouchableHandlerAdditionalInfo;
 };
 
 export type TouchableHandlerPayload = {
@@ -89,11 +107,15 @@ export type TouchableHandlerPayload = {
   event?: GestureResponderEvent;
 } & (
   | {
-      emitter?: Exclude<TouchableEmitter, 'textMention' | 'textLink' | 'card' | 'fileAttachment'>;
+      emitter?: Exclude<
+        TouchableEmitter,
+        'textMention' | 'textLink' | 'card' | 'fileAttachment' | 'gallery'
+      >;
     }
   | TextMentionTouchableHandlerPayload
   | UrlTouchableHandlerPayload
   | FileAttachmentTouchableHandlerPayload
+  | GalleryThumbnailTouchableHandlerPayload
 );
 
 export type MessageTouchableHandlerPayload<


### PR DESCRIPTION
## 🎯 Goal

A backport of [this PR](https://github.com/GetStream/stream-chat-react-native/pull/2911) to V5.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


