### PR TITLE
fix: warn users about new google policy and to replace cameraroll with image-picker

### DIFF
--- a/package/expo-package/src/optionalDependencies/getPhotos.ts
+++ b/package/expo-package/src/optionalDependencies/getPhotos.ts
@@ -27,6 +27,11 @@ type ReturnType = {
 export const getPhotos = MediaLibrary
   ? async ({ after, first }): Promise<ReturnType> => {
       try {
+        if (Platform.OS === 'android') {
+          console.warn(
+            'expo-media-library can be removed in favour of new google policy(https://support.google.com/googleplay/android-developer/answer/14115180?hl=en) if you do not have gallery as your core feature of the app.\nYou can replace it with expo-image-picker and uninstall it. Guide - https://getstream.io/chat/docs/sdk/react-native/guides/native-image-picker/.',
+          );
+        }
         // NOTE:
         // should always check first before requesting permission
         // because always requesting permission will cause

--- a/package/native-package/src/optionalDependencies/getPhotos.ts
+++ b/package/native-package/src/optionalDependencies/getPhotos.ts
@@ -73,6 +73,9 @@ export const getPhotos = CameraRollDependency
   ? async ({ after, first }): Promise<ReturnType> => {
       try {
         if (Platform.OS === 'android') {
+          console.warn(
+            '@react-native-camera-roll/camera-roll can be removed in favour of new google policy(https://support.google.com/googleplay/android-developer/answer/14115180?hl=en) if you do not have gallery as your core feature of the app.\nYou can replace it with react-native-image-picker and uninstall it. Guide - https://getstream.io/chat/docs/sdk/react-native/guides/native-image-picker/.',
+          );
           const granted = await verifyAndroidPermissions();
           if (!granted) {
             throw new Error('getPhotos Error');


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


