### PR TITLE
fix: bump stream-chat-js version for poll state invalidation bug

### DIFF
--- a/examples/ExpoMessaging/yarn.lock
+++ b/examples/ExpoMessaging/yarn.lock
@@ -7276,10 +7276,10 @@ stream-buffers@2.2.x, stream-buffers@~2.2.0:
   version "0.0.0"
   uid ""
 
-stream-chat-react-native-core@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.3.0.tgz#08ec225e89c04b6306e0c8e4d9bffeca2791ade1"
-  integrity sha512-8WjfRE4GLr5Y6iU21mFw26KyA0edyGbjkZUuVjjdJnQ0HHdVulFLL0bEp1aRH4/VgEdw6Vz7/e7D8i9IMfm3UA==
+stream-chat-react-native-core@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.4.0.tgz#ea39a152328af5f38904c9aa66d849a2c4ffca9e"
+  integrity sha512-dKK3y7vvygEzd7XUKE2QFx2a+jVfd7kZGQL3LmyXNCulKAdGNBMEfk0lh/mXFoxx9c9cBYAY7iydPmmdEwWtQQ==
   dependencies:
     "@gorhom/bottom-sheet" "^5.0.6"
     dayjs "1.10.5"
@@ -7292,16 +7292,17 @@ stream-chat-react-native-core@6.3.0:
     path "0.12.7"
     react-native-markdown-package "1.8.2"
     react-native-url-polyfill "^1.3.0"
-    stream-chat "8.46.0"
+    stream-chat "^8.50.0"
+    use-sync-external-store "^1.4.0"
 
 "stream-chat-react-native-core@link:../../package":
   version "0.0.0"
   uid ""
 
-stream-chat@8.46.0:
-  version "8.46.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.46.0.tgz#416b325e05b144d0937a3527d1e622463113d605"
-  integrity sha512-HQVCRVldrfQFAvsBOHiHR0TKYf+wpsg/cAzRojeZY+buy1vG6eoqk09h6Fl4k2eG3zFLoA0G9W6o7o45jyFE1g==
+stream-chat@^8.50.0:
+  version "8.52.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.52.0.tgz#7cb477433d0eb3d7351852f76b3838f5ce0af000"
+  integrity sha512-u5M9z4m8O0tB82XTQMkOvLp5+OJg6al8k8/sXQaDx1tMCTMnRWzCIXtRXKjBCWIftwB/4SuPV72+Zy9r/zJMng==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"
@@ -7313,10 +7314,10 @@ stream-chat@8.46.0:
     jsonwebtoken "~9.0.0"
     ws "^7.5.10"
 
-stream-chat@^8.50.0:
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.52.0.tgz#7cb477433d0eb3d7351852f76b3838f5ce0af000"
-  integrity sha512-u5M9z4m8O0tB82XTQMkOvLp5+OJg6al8k8/sXQaDx1tMCTMnRWzCIXtRXKjBCWIftwB/4SuPV72+Zy9r/zJMng==
+stream-chat@^8.54.1:
+  version "8.54.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.54.1.tgz#61a7330c9b7401f3e176e55445b29317bca2b108"
+  integrity sha512-BmeN1nq/zbItJXayHz/kBDc36Xvs4rW5pol/ngPXs0Vl8tw7vCuYBI4aFvpthvFU9EhCIJzBn8ISqDlnfWyDkw==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"

--- a/examples/SampleApp/ios/Podfile.lock
+++ b/examples/SampleApp/ios/Podfile.lock
@@ -2164,7 +2164,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.7.1)
-  - stream-chat-react-native (6.2.0):
+  - stream-chat-react-native (6.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2495,7 +2495,7 @@ SPEC CHECKSUMS:
   hermes-engine: 06a9c6900587420b90accc394199527c64259db4
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  op-sqlite: 3cffd1c89eee93406fb428c55d294fbaab6da759
+  op-sqlite: 8ce374788e74aca3f2fb34e00f25da28d34a8170
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
@@ -2505,80 +2505,80 @@ SPEC CHECKSUMS:
   React: fffb3cf1b0d7aee03c4eb4952b2d58783615e9fa
   React-callinvoker: 3c6ecc0315d42924e01b3ddc25cf2e49d33da169
   React-Codegen: 4b8b4817cea7a54b83851d4c1f91f79aa73de30a
-  React-Core: 1a5ddefb00dd72644171dd39bb4bbcd7849c70f0
-  React-CoreModules: 8de64f712fe272ed08f37aaf64633ddf793e70d3
-  React-cxxreact: e204185e1da1c843fec2bbb10bcc5b5800355dfa
+  React-Core: d2143ba58d0c8563cf397f96f699c6069eba951c
+  React-CoreModules: b3cbc5e3090a8c23116c0c7dd8998e0637e29619
+  React-cxxreact: 68fb9193582c4a411ce99d0b23f7b3d8da1c2e4a
   React-debug: 02462c1bc08dae8a2994d1e710adba02c299724c
-  React-defaultsnativemodule: 37f60e245ea500c1a2ce2af3663b07e9cde29262
-  React-domnativemodule: d975200134ab25f0b5c4e2171685c95b35023c70
-  React-Fabric: dec910113e66ecc0bb01ca0450a670057913ea2b
-  React-FabricComponents: 39972a33b0aa0f497c8884904a9d34058c647e1d
-  React-FabricImage: 3bec45a3f523ae88bf94c67a483c1b0e055d0976
+  React-defaultsnativemodule: 15e44150d6d506cec2daf27dc73b935418598c67
+  React-domnativemodule: 65d5f0e9475448ae223b2de89c2a3848ca901fae
+  React-Fabric: d2c89a451f48c97b6eae07a48999ca99cc530d1b
+  React-FabricComponents: 974702ca83bd3e546f51d49b64d33d23d3d8b5d0
+  React-FabricImage: 6644232657cc97599960aa8c79d4b814537c170b
   React-featureflags: 7c440ac7e6bf5f691a39178a3dec335dcca19760
-  React-featureflagsnativemodule: 351359ebec40f680f68c29a6576bb126286bf014
-  React-graphics: e36611400a08814f80b1496fa3e44cb2f4cb212d
-  React-hermes: a12bf33d9915dbe2dcde5b6b781faab6684883fb
-  React-idlecallbacksnativemodule: df4b6ca522d00c566afe9aa723c420460561a068
-  React-ImageManager: c90a16c0b5c9fdaa82d318bf3244f46cc6df4514
-  React-jserrorhandler: 82a56fdcfb3a014915d75f0d14db8f82fcb87b16
-  React-jsi: 217274301608d7fa529bd275c73020b55cf39361
-  React-jsiexecutor: 1bcbc63a8c1d698b35c9fb521ee87aa48a3702d2
-  React-jsinspector: a84b39d1cda7843770c36f11ab370ba33b3f83cc
-  React-jsitracing: 9a32b035bd6399ddc5230bfb8b288d4488c5076c
-  React-logger: ae95f0effa7e1791bd6f7283caddca323d4fbc1e
-  React-Mapbuffer: f0c766c9dfb313c91b07457beb4e4ec9b2e02435
-  React-microtasksnativemodule: 23565fc14a9588c3116cdf279c8124d7285856cc
-  react-native-blob-util: 4f935148b217389fff952096c0f1a6ff67f4bdea
-  react-native-cameraroll: 93e0927932a50007dbd465cb5328edfe4a4c4d41
-  react-native-document-picker: 489aaeb15e9bc11cc31e577997867e93886eb565
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-safe-area-context: ee5c70aeb80909cebc0007f13a1cb44230f8e307
-  react-native-video: b2b486f56cc10d3f262291c301e0b5c7f759f3fd
+  React-featureflagsnativemodule: dfba35999216bfd058705767150ce08d5652754a
+  React-graphics: 076bac016644c9c2e29c59bd45f4b5de0a8e55d0
+  React-hermes: 63678d262d94835f986fa2fac1c835188f14160b
+  React-idlecallbacksnativemodule: 3556dba7c3bb4c3301dfa2bbaeda2f4ad0658732
+  React-ImageManager: 70042623ecb2cdb14076b954e981c70dca5e20df
+  React-jserrorhandler: c23c0599855f31a6d00d06275f5f5a42346e1264
+  React-jsi: d189a2a826fe6700ea1194e1c2b15535d06c8d75
+  React-jsiexecutor: b75a12d37f2bf84f74b5c05131afdef243cfc69d
+  React-jsinspector: 119d4349b02e5322a7cd20e2b71ebd94bcff1afd
+  React-jsitracing: f1a3415e46380a57f202c474e3f717e809b9738a
+  React-logger: 697873f06b8ba436e3cddf28018ab4741e8071b6
+  React-Mapbuffer: c79216258c659d70cdebaf76f8c110cc46dce8db
+  React-microtasksnativemodule: 8d918db5d7c4526de2a0a4692d878a21b338c3f0
+  react-native-blob-util: 356047c561b3506396852bc0d7988243f74dd77d
+  react-native-cameraroll: 276a70e81239a4734ae9beaa47a15f1939a37bc5
+  react-native-document-picker: 1e082836a633ca9e7c75758036ff42535baaf36b
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-safe-area-context: d71edcee579673b370c053804f34c40c1f250976
+  react-native-video: 07ebee84a1b3a3ad9d2e6ba182eb5788eaf5a509
   React-nativeconfig: 565ebf4340d9ede95b523f0e3640f48286985ef5
-  React-NativeModulesApple: 6ec0cac27d99644895c1c22b2b7a33441854a539
-  React-perflogger: 16e049953d21b37e9871ddf0b02f414e12ff14ba
-  React-performancetimeline: 1bd17418509e56758a1b4a363f75ffb17449eafa
+  React-NativeModulesApple: ea083a4663dae82c99fe4c2186b11504ac4147e1
+  React-perflogger: ceb97dd4e5ca6ff20eebb5a6f9e00312dcdea872
+  React-performancetimeline: 1547e9df5603d7461a49805254c48efb89f2b018
   React-RCTActionSheet: a4388035260b01ac38d3647da0433b0455da9bae
-  React-RCTAnimation: 9cc9e88ec5f94d573d3b5d5d9702f47774d8603c
-  React-RCTAppDelegate: b8ca6a50167b71d67c477985597429485f39f964
-  React-RCTBlob: f879b05cf702dd4099054c3c3bf05bd4757de701
-  React-RCTFabric: 24de83b92c14b18db1976d4ac8269f98ea1ccc01
-  React-RCTImage: 8fc2b137d17fb8756cdba38d74f4d40fb9499dee
-  React-RCTLinking: e691e89d8658aaa772c59084a45a96e8c9ef8df1
-  React-RCTNetwork: 749cb659702c3faf3efecfcb982150be0f2c834a
-  React-RCTSettings: 60c431627d37e6d996e0f61a9e84df8e41d898cb
-  React-RCTText: 74cc248bf8d2f6d07beb6196aa4c7055b3eb1a51
-  React-RCTVibration: 81ff3704c7ed66a99e2670167252fd0e9a10980b
+  React-RCTAnimation: 84117cb3521c40e95a4edfeab1c1cb159bc9a7c3
+  React-RCTAppDelegate: df039dffb7adbc2e4a8ce951d1b2842f1846f43e
+  React-RCTBlob: 947cbb49842c9141e2b21f719e83e9197a06e453
+  React-RCTFabric: 7a1033d743c798ded21de9019e3c24b989ac3b47
+  React-RCTImage: 367a7dcca1d37b04e28918c025a0101494fb2a19
+  React-RCTLinking: b9dc797e49683a98ee4f703f1f01ec2bd69ceb7f
+  React-RCTNetwork: 16e92fb59b9cd1e1175ecb2e90aa9e06e82db7a3
+  React-RCTSettings: 20a1c3316956fae137d8178b4c23b7a1d56674cc
+  React-RCTText: 59d8792076b6010f7305f2558d868025004e108b
+  React-RCTVibration: 597d5aba0212d709ec79d12e76285c3d94dc0658
   React-rendererconsistency: daabe06163f9fcef3a3d25883eddc7115098b3b0
-  React-rendererdebug: 215df454a5d1cb3734c8438356302c8031de5d7a
+  React-rendererdebug: e6d710b49d8a0eee0b282f6d8f1071a736cca7e3
   React-rncore: 621a7b222dda9fe85a9922cb88d5e1ddcbd0e12b
-  React-RuntimeApple: 904dc291cd40fa9c616115e7f245b02e8b093145
-  React-RuntimeCore: 68a937463999e07447269d106a4c6891c83ddd39
+  React-RuntimeApple: cf1854a0c463bd93a33c82208132260f44d5d672
+  React-RuntimeCore: 47235731208da3d6f64c4ae05c720cabb4886a6c
   React-runtimeexecutor: 10fae9492194097c99f6e34cedbb42a308922d32
-  React-RuntimeHermes: 9820773d433a8b8f7e47c5b589cd1c64c1003ad2
-  React-runtimescheduler: e20a7a00b1bf8cd15e564474e7fd175e19b1d383
+  React-RuntimeHermes: c41fe43d39152de4215d98ec2f2a187a37a93fec
+  React-runtimescheduler: 46f8c0d41b0e69d4b3350db5d9be1872c4c4b418
   React-timing: 0287e530587639771ca7eb52e2ca897f5755be53
-  React-utils: 89a30618bd38c591900879825de59104ded1e246
-  ReactCodegen: 28abe92ea9a1e277edc25d02d7d53ab3acf5cc07
-  ReactCommon: 7da12c0f59956995a153de45835b64c89e0a4a57
-  RNAudioRecorderPlayer: 11df0c7b614e9767ef24d896465c3a758c592de7
-  RNCAsyncStorage: 05726a4229d0def82e21b6b4282cd8c37a0a4b69
-  RNFastImage: 462a183c4b0b6b26fdfd639e1ed6ba37536c3b87
-  RNFBApp: d43a1f56744d5ad3a20c2127af16b82f8b8f58be
-  RNFBMessaging: 479542d869c03e819ed4e9b9ea5132630c44c5d0
-  RNGestureHandler: 932e0f07ccf470940afa9d0a8b6d8221e7e19cff
-  RNNotifee: dd1c2d40969dd574b75f4a31d5c8e77c36b40d24
-  RNReactNativeHapticFeedback: dddb16e62d4d9c4a5e0ac1d32ede09f6a9083e4c
-  RNReanimated: 2700dbc6f4cbccc005eb85ab7f90b21cd40814ed
-  RNScreens: 303afdda2f789b33f290e060699ff8a769e39525
-  RNShare: dfb766b0ba56e82ab4b01abba842d7992623a918
-  RNSVG: fda2fb96dd529a22bf8cf9a38fc051378fd4866e
+  React-utils: 36d56297591ca4a32b3f83d0ab9900aa4599c4c0
+  ReactCodegen: 8d7f9f05befdeb108948bbaa18d149b25a964f72
+  ReactCommon: 858d61cce81635d57be89348568b603e838b3cac
+  RNAudioRecorderPlayer: 224c7de87722938aedce04000d09baa633148f5b
+  RNCAsyncStorage: e8c2162c53745debaf8b96b7cf71dcf6bad63dcf
+  RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
+  RNFBApp: f54f97b84af43a870372c6d9915ebe6a61a35bed
+  RNFBMessaging: 79d87b7e8ec5695f10b6a913f506e8c3059718e0
+  RNGestureHandler: 15ee1ab573a954c92641877ca946e2680f2e58da
+  RNNotifee: 569d29af4583204ca0d882b69686f98e8fe69797
+  RNReactNativeHapticFeedback: 2db53cf1075a3046227b8131a5cba84f25abccdc
+  RNReanimated: c1e1a4cfb360c774af62b1e45f5cd03e49394ad0
+  RNScreens: f493b156fe5de2434806b5a2c410800b2cd76c0e
+  RNShare: 0cc7cc40681d2a858390552cf8b757f9bb4d460c
+  RNSVG: 16775caac1e5d193c876ee15431494d7a9649aec
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  stream-chat-react-native: 29f9b77cefb31c8c3d96081ea660604826bc3fb1
+  stream-chat-react-native: e7808a904916a49eaa625b46fa5cd6bbc300a997
   Yoga: 7548e4449365bf0ef60db4aefe58abff37fcabec
 
 PODFILE CHECKSUM: 4f662370295f8f9cee909f1a4c59a614999a209d
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -7952,10 +7952,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stream-chat-react-native-core@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.2.0.tgz#3ad5283b88bd92f90ead10d0b2cb29dadbe418c6"
-  integrity sha512-2VUF1caOs2T5lN/44DUkasw8mAKIMPkPWym0FdEDOljp2cHaE6w5A7BR2k43W/S+l/Wk63VRs3bVW+v9zYDhFA==
+stream-chat-react-native-core@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.4.0.tgz#ea39a152328af5f38904c9aa66d849a2c4ffca9e"
+  integrity sha512-dKK3y7vvygEzd7XUKE2QFx2a+jVfd7kZGQL3LmyXNCulKAdGNBMEfk0lh/mXFoxx9c9cBYAY7iydPmmdEwWtQQ==
   dependencies:
     "@gorhom/bottom-sheet" "^5.0.6"
     dayjs "1.10.5"
@@ -7968,7 +7968,8 @@ stream-chat-react-native-core@6.2.0:
     path "0.12.7"
     react-native-markdown-package "1.8.2"
     react-native-url-polyfill "^1.3.0"
-    stream-chat "8.46.0"
+    stream-chat "^8.50.0"
+    use-sync-external-store "^1.4.0"
 
 "stream-chat-react-native-core@link:../../package":
   version "0.0.0"
@@ -7978,10 +7979,10 @@ stream-chat-react-native-core@6.2.0:
   version "0.0.0"
   uid ""
 
-stream-chat@8.46.0:
-  version "8.46.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.46.0.tgz#416b325e05b144d0937a3527d1e622463113d605"
-  integrity sha512-HQVCRVldrfQFAvsBOHiHR0TKYf+wpsg/cAzRojeZY+buy1vG6eoqk09h6Fl4k2eG3zFLoA0G9W6o7o45jyFE1g==
+stream-chat@^8.50.0:
+  version "8.52.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.52.0.tgz#7cb477433d0eb3d7351852f76b3838f5ce0af000"
+  integrity sha512-u5M9z4m8O0tB82XTQMkOvLp5+OJg6al8k8/sXQaDx1tMCTMnRWzCIXtRXKjBCWIftwB/4SuPV72+Zy9r/zJMng==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"
@@ -7993,10 +7994,10 @@ stream-chat@8.46.0:
     jsonwebtoken "~9.0.0"
     ws "^7.5.10"
 
-stream-chat@^8.50.0:
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.52.0.tgz#7cb477433d0eb3d7351852f76b3838f5ce0af000"
-  integrity sha512-u5M9z4m8O0tB82XTQMkOvLp5+OJg6al8k8/sXQaDx1tMCTMnRWzCIXtRXKjBCWIftwB/4SuPV72+Zy9r/zJMng==
+stream-chat@^8.54.1:
+  version "8.54.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.54.1.tgz#61a7330c9b7401f3e176e55445b29317bca2b108"
+  integrity sha512-BmeN1nq/zbItJXayHz/kBDc36Xvs4rW5pol/ngPXs0Vl8tw7vCuYBI4aFvpthvFU9EhCIJzBn8ISqDlnfWyDkw==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"

--- a/examples/TypeScriptMessaging/ios/Podfile.lock
+++ b/examples/TypeScriptMessaging/ios/Podfile.lock
@@ -1991,7 +1991,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.1)
-  - stream-chat-react-native (6.2.0):
+  - stream-chat-react-native (6.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2265,88 +2265,88 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
+  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: 7075bb12898bc3998fd60f4b7ca422496cc2cdf7
-  fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
+  glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
   hermes-engine: 46f1ffbf0297f4298862068dd4c274d4ac17a1fd
-  op-sqlite: 3cffd1c89eee93406fb428c55d294fbaab6da759
-  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
+  op-sqlite: 8ce374788e74aca3f2fb34e00f25da28d34a8170
+  RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
   RCTDeprecation: fde92935b3caa6cb65cbff9fbb7d3a9867ffb259
   RCTRequired: 75c6cee42d21c1530a6f204ba32ff57335d19007
   RCTTypeSafety: 7e6fe47bfb693c50d4669db1a480ca5331795f5b
   React: 8e73704cdd5c7f801936776d2fc434c605a7827b
   React-callinvoker: fa27d1e091e683de88f576e6a5d4efc171929a4c
   React-Codegen: 4b8b4817cea7a54b83851d4c1f91f79aa73de30a
-  React-Core: 948deed7fa720eeb0d901ff9e45c3719767dab5f
-  React-CoreModules: a11ba75f64245d12a0869203664a802c11594c43
-  React-cxxreact: a5ce05f8a0a1398958523f948fce00d4c8ce38ff
+  React-Core: 8dd14bffcc9b877091b698e45701160669a31f91
+  React-CoreModules: b4437acf2ef25ce3689c84df661dc5d806559b35
+  React-cxxreact: 6125cd820da7e18f9ca8343b3c42ee61634a4e0d
   React-debug: f474f5c202a277f76c81bf7cf26284f2c09880d7
-  React-defaultsnativemodule: 41cc9a60277f1bec4b258df324e28705ac00b91a
-  React-domnativemodule: 4fe895d9e4aa99590700c5a5f9ff5706e9481ed7
-  React-Fabric: bbdcc01a98528846efacf0767567a8e76df794bb
-  React-FabricComponents: ab8967c5898d88f37486df0eb0111384c498d821
-  React-FabricImage: 7a06db59488b37f509dee73fa0b2811608a67058
+  React-defaultsnativemodule: 7141fa704531cbf7a7e7af3bc02adfa367e831a7
+  React-domnativemodule: c1806b8584a53ed912012a4d8b2c6f96a84c77a3
+  React-Fabric: ba9636cfc7f9b77df6cb7edb2c70d0237026404b
+  React-FabricComponents: c408da05a4ea5ba071732245b4a7f48f904e610a
+  React-FabricImage: c409858f319f11709b49ffa6c5bca4faf794cb44
   React-featureflags: 929732439d139ac0662e08f009f1a51ed2b91ed3
-  React-featureflagsnativemodule: b88d53b6d63ee037c5cdefb9861edfd16b4afce1
-  React-graphics: 6367275cc82d631c588a7146fd8dc69ec2f447e8
-  React-hermes: b9bbe9c808d7ab1750ce089b243b03e4a099af63
-  React-idlecallbacksnativemodule: 6fff2280f860f29a3c049695d3ef04c8f70212aa
-  React-ImageManager: 5b001b9e974f5ba81f0645d3d799e2a20c61d91e
-  React-jserrorhandler: 35e5e5a5a99b7b36c3802a2d12ca86889ed5982a
-  React-jsi: d0d8c4019fd91d0cb4b432f2518e08dc37433a13
-  React-jsiexecutor: 1cdaf24e36919d899250938f0f6c79ec1a256923
-  React-jsinspector: 2fabeadbd0eb1cbd83a6fc2026fb38c75b200947
-  React-jsitracing: 7c7c89c963893efd25e0d04c23e854b9a93e0b7e
-  React-logger: 7b5b458327a1ff0d7e5a349430d1ed133dcebaa3
-  React-Mapbuffer: 0d88ad9afa9e195dd7634424bde1d38e4129e646
-  React-microtasksnativemodule: 17234f35d37e6ed388e18a6314210b3b9e051219
-  react-native-blob-util: 41e79841711a98f88b9fdda381395219a57eaa3c
-  react-native-document-picker: 0ec4f0abaa488744e6c1d73ef7f47dc6a6861fc1
-  react-native-image-picker: d8b33fb69e98b05da2a41b724fd7b3415379dda3
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-safe-area-context: 819935871d06a80e963546208027f839aa972a85
-  react-native-video: 2468f0f7b968afffa116ca3aac9bfce890204e38
+  React-featureflagsnativemodule: 02dd903d4cbe4fae0e6cd02bc32a09d30543282f
+  React-graphics: a5cad35307286e9f83e212834e95fef4010d03d0
+  React-hermes: 14aafa9630579b84c2167b563bdb8c811970a03e
+  React-idlecallbacksnativemodule: 69581ac44bd355acce3739c3fe380c0f6d7a6d09
+  React-ImageManager: 41945afb3ace0c52255057ec4ae6af6f5a23539f
+  React-jserrorhandler: ecbc4622df7ab3d0066a4313cde4172d45745508
+  React-jsi: ff383df87c7047e976a66be45df59e4e0db5346e
+  React-jsiexecutor: 2bb8b172f226f2f502521d33dd7666e701d45f45
+  React-jsinspector: 4d51b903543f21076b658ef8412f3102778dbc92
+  React-jsitracing: 654f4d9cb9fd99b3d96f239ceb215ae49ce28ac0
+  React-logger: 97c9dafae1f1a638001a9d1d0e93d431f2f9cb7b
+  React-Mapbuffer: 3146a13424f9fec2ea1f1462d49d566e4d69b732
+  React-microtasksnativemodule: 02d218c79c72d373a92a8552183f4ead0d1c6e05
+  react-native-blob-util: e6a3b23a99ac2c3d9fa48722db049a1e1808efc2
+  react-native-document-picker: e9d83c149bdd72dc01cf8dcb8df0389c6bd5fddb
+  react-native-image-picker: ba5067f7d833b9081102c0a33dd0188eb21d92dc
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-safe-area-context: 2500e4fe998caad50ad3bc51ec23ef951308569e
+  react-native-video: dd8db5a31e1bf35e00c5d1c87250d1f16d9a02a1
   React-nativeconfig: 93fe8c85a8c40820c57814e30f3e44b94c995a7b
-  React-NativeModulesApple: a4457b73e63e983db66d66612160006bccb00ad5
-  React-perflogger: 3140b7778984a486db80d4d2aeaa266cae4eb8c7
-  React-performancetimeline: 41c100bc1299d7b150821b99cf26661c51ed9ab0
+  React-NativeModulesApple: b3e076fd0d7b73417fe1e8c8b26e3c57ae9b74aa
+  React-perflogger: 1c55bcd3c392137cbaf0d21d8bb87ce9a0cebb15
+  React-performancetimeline: e89249db10b8f7bf8f72c2e9bd471ac37d48b753
   React-RCTActionSheet: 9407c795fbeee35da2dae3cd6b5c4e5da6ff8bd3
-  React-RCTAnimation: 48e5c6b541fd4c7a96c333e61974c3de34bbe849
-  React-RCTAppDelegate: 602daadf2452a56ca54a6257052ddba89e680486
-  React-RCTBlob: f67be4e0fbe51db1574aec402754054ab9c39668
-  React-RCTFabric: ee6706069cbc4e1ffd5f23553e999a42b08414f7
-  React-RCTImage: 57894a0e42502461d87449bec6cb0f124a49a93b
-  React-RCTLinking: abd71677bc3353327bec26b0ccd0a0c3960efa1c
-  React-RCTNetwork: 2e91efa49b63e54a9782922e5ca1d09ff2789341
-  React-RCTSettings: fd13eebaa3f9af0b56a0ecb053b108e160fbfe07
-  React-RCTText: 4cd7c87db1e1da51a96b86ce39c5468c1dbaae60
-  React-RCTVibration: 579f64ceb06701eca3004a500169e1152c1ef7d2
+  React-RCTAnimation: 7ee1c2a77aab7e5c568611d8092a994cfcbe8410
+  React-RCTAppDelegate: 10c2b0c434baf5a71b53d5c86c4d8d0dbd6bb380
+  React-RCTBlob: 761072706300d22624ec2d6bf860b77d95ebd3da
+  React-RCTFabric: 871d38933a94554d9e27963aa4bb67184dc7529e
+  React-RCTImage: b6614fde902ec9647f15236da94df2d24c40523f
+  React-RCTLinking: 25950eda5d5f786bfb3daf513ea7d848555a2a93
+  React-RCTNetwork: b69407c4119fd7a1cc07db4a94563f2546f8770d
+  React-RCTSettings: b310a4923446c3a8950fa866c8cf83323a9e1b87
+  React-RCTText: 77c6eda5be1dee657f5183f75fe0fdcdb7b2b35d
+  React-RCTVibration: b4889c7702aea1b07316be1ec0de2e36e9a4d077
   React-rendererconsistency: 5ef1c4642fd6365bf6d5d4e29a3ae02c3a1b8980
-  React-rendererdebug: 8952e1ad914c680d4978916a9eed7c6dc85301d7
+  React-rendererdebug: 7f6a24cbb5008a22ccb34a0d031a259b006facf6
   React-rncore: 0e5394ce20a9d2bf12409d14395588c7b9e6e9ce
-  React-RuntimeApple: f5ed38fba1230713313e88e750dcad06948ba625
-  React-RuntimeCore: 0fc488daf136f05d96349772828ccf64f66d6d2a
+  React-RuntimeApple: bbe293f233d17304c9597309acde7505080fd53d
+  React-RuntimeCore: 5a1cbfc3e7af4fbdea2b9b1efd39cd51a4d4006f
   React-runtimeexecutor: ffac5f09795a5e881477e0d72a0fa6385456bed3
-  React-RuntimeHermes: b8f395d41116c3bdf3373e87c39a856f69c3fff8
-  React-runtimescheduler: 933c72afd4f285b2bb473c0de2482ee250f3e735
+  React-RuntimeHermes: 0a1fd1c150faed8341887dd89895eeb8d4d2d3c5
+  React-runtimescheduler: e7df538274de0c65736068e40efc0d2228f42d0d
   React-timing: b3b233fe819d9e5b6ca32b605aa732621bdfa5aa
-  React-utils: 0c825829a8e2ca39bb049d95f270a2dbf39ecb05
-  ReactCodegen: 3b0ff1c9015e3ebcf2bd2f8559995c74bfacf8a1
-  ReactCommon: c21a3d6a8d3e98b6e99730139a52f59f0beea89d
-  RNAudioRecorderPlayer: 11df0c7b614e9767ef24d896465c3a758c592de7
-  RNCClipboard: 65367ee0429c61ea5cb9d819921877730d59b039
-  RNGestureHandler: 16ef3dc2d7ecb09f240f25df5255953c4098819b
-  RNReactNativeHapticFeedback: 8397b76d1ca8d3336545ce8bc8723e3b6cb551eb
-  RNReanimated: e01050e272623a49aba628de3dfd2b539b8cc4c6
-  RNScreens: 74536418fef8086457d39df36a55b36efd5329c9
-  RNShare: 2e17abd938a8aeb0e0739e35ef9795891d046fb9
-  RNSVG: 030717ff82ea8f2117347c2fcf52a2d1eafba9ba
+  React-utils: 5362bd16a9563f9916e7a56c011ddc533507650f
+  ReactCodegen: 865bafc5c17ec2181620ced1a32c39c38ab2951d
+  ReactCommon: 422e364463f33e336fc4db196aeb50fd801d90d6
+  RNAudioRecorderPlayer: 224c7de87722938aedce04000d09baa633148f5b
+  RNCClipboard: 4a32044e0c654faf2b47a86db4f3f4bbf4f44f3c
+  RNGestureHandler: fc5ce5bf284640d3af6431c3a5c3bc121e98d045
+  RNReactNativeHapticFeedback: 73756a3477a5a622fa16862a3ab0d0fc5e5edff5
+  RNReanimated: 77242c6d67416988a2fd9f5cf574bb3e60016362
+  RNScreens: e389d6a6a66a4f0d3662924ecae803073ccce8ec
+  RNShare: 4305edead1b8f614ab994046c68193e8d50aaadc
+  RNSVG: 536cd3c866c878faf72beaba166c8b02fe2b762b
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  stream-chat-react-native: e2f9bbc7dce8c4bb14bcfec1245be978db123243
+  stream-chat-react-native: 15d400fd34f41781a9f18df3610c93f672667090
   Yoga: db69236006b8b1c6d55ab453390c882306cbf219
 
 PODFILE CHECKSUM: 6b7a4b74915b42bfe4ffddaf67cbf5e7a2bfeab3
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/examples/TypeScriptMessaging/yarn.lock
+++ b/examples/TypeScriptMessaging/yarn.lock
@@ -6807,10 +6807,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stream-chat-react-native-core@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.2.0.tgz#3ad5283b88bd92f90ead10d0b2cb29dadbe418c6"
-  integrity sha512-2VUF1caOs2T5lN/44DUkasw8mAKIMPkPWym0FdEDOljp2cHaE6w5A7BR2k43W/S+l/Wk63VRs3bVW+v9zYDhFA==
+stream-chat-react-native-core@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.4.0.tgz#ea39a152328af5f38904c9aa66d849a2c4ffca9e"
+  integrity sha512-dKK3y7vvygEzd7XUKE2QFx2a+jVfd7kZGQL3LmyXNCulKAdGNBMEfk0lh/mXFoxx9c9cBYAY7iydPmmdEwWtQQ==
   dependencies:
     "@gorhom/bottom-sheet" "^5.0.6"
     dayjs "1.10.5"
@@ -6823,7 +6823,8 @@ stream-chat-react-native-core@6.2.0:
     path "0.12.7"
     react-native-markdown-package "1.8.2"
     react-native-url-polyfill "^1.3.0"
-    stream-chat "8.46.0"
+    stream-chat "^8.50.0"
+    use-sync-external-store "^1.4.0"
 
 "stream-chat-react-native-core@link:../../package":
   version "0.0.0"
@@ -6833,10 +6834,10 @@ stream-chat-react-native-core@6.2.0:
   version "0.0.0"
   uid ""
 
-stream-chat@8.46.0:
-  version "8.46.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.46.0.tgz#416b325e05b144d0937a3527d1e622463113d605"
-  integrity sha512-HQVCRVldrfQFAvsBOHiHR0TKYf+wpsg/cAzRojeZY+buy1vG6eoqk09h6Fl4k2eG3zFLoA0G9W6o7o45jyFE1g==
+stream-chat@^8.50.0:
+  version "8.52.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.52.0.tgz#7cb477433d0eb3d7351852f76b3838f5ce0af000"
+  integrity sha512-u5M9z4m8O0tB82XTQMkOvLp5+OJg6al8k8/sXQaDx1tMCTMnRWzCIXtRXKjBCWIftwB/4SuPV72+Zy9r/zJMng==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"
@@ -6848,10 +6849,10 @@ stream-chat@8.46.0:
     jsonwebtoken "~9.0.0"
     ws "^7.5.10"
 
-stream-chat@^8.50.0:
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.52.0.tgz#7cb477433d0eb3d7351852f76b3838f5ce0af000"
-  integrity sha512-u5M9z4m8O0tB82XTQMkOvLp5+OJg6al8k8/sXQaDx1tMCTMnRWzCIXtRXKjBCWIftwB/4SuPV72+Zy9r/zJMng==
+stream-chat@^8.54.1:
+  version "8.54.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.54.1.tgz#61a7330c9b7401f3e176e55445b29317bca2b108"
+  integrity sha512-BmeN1nq/zbItJXayHz/kBDc36Xvs4rW5pol/ngPXs0Vl8tw7vCuYBI4aFvpthvFU9EhCIJzBn8ISqDlnfWyDkw==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"

--- a/package/expo-package/yarn.lock
+++ b/package/expo-package/yarn.lock
@@ -5113,10 +5113,10 @@ stream-buffers@2.2.x, stream-buffers@~2.2.0:
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
   integrity sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==
 
-stream-chat-react-native-core@6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.3.1.tgz#fa173c92bc11538e729978e223fd14db39c7ae75"
-  integrity sha512-ec1ySYZS7m0ncQ0zw+B2fw2+eMf4+8xpf9ynrmOoeLh54EmHYyhH3BK6roEXnMDGwI4U60iI2yolotY3E/xtNA==
+stream-chat-react-native-core@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.4.0.tgz#ea39a152328af5f38904c9aa66d849a2c4ffca9e"
+  integrity sha512-dKK3y7vvygEzd7XUKE2QFx2a+jVfd7kZGQL3LmyXNCulKAdGNBMEfk0lh/mXFoxx9c9cBYAY7iydPmmdEwWtQQ==
   dependencies:
     "@gorhom/bottom-sheet" "^5.0.6"
     dayjs "1.10.5"
@@ -5129,12 +5129,13 @@ stream-chat-react-native-core@6.3.1:
     path "0.12.7"
     react-native-markdown-package "1.8.2"
     react-native-url-polyfill "^1.3.0"
-    stream-chat "8.46.0"
+    stream-chat "^8.50.0"
+    use-sync-external-store "^1.4.0"
 
-stream-chat@8.46.0:
-  version "8.46.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.46.0.tgz#416b325e05b144d0937a3527d1e622463113d605"
-  integrity sha512-HQVCRVldrfQFAvsBOHiHR0TKYf+wpsg/cAzRojeZY+buy1vG6eoqk09h6Fl4k2eG3zFLoA0G9W6o7o45jyFE1g==
+stream-chat@^8.50.0:
+  version "8.54.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.54.1.tgz#61a7330c9b7401f3e176e55445b29317bca2b108"
+  integrity sha512-BmeN1nq/zbItJXayHz/kBDc36Xvs4rW5pol/ngPXs0Vl8tw7vCuYBI4aFvpthvFU9EhCIJzBn8ISqDlnfWyDkw==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"
@@ -5615,6 +5616,11 @@ url-join@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.0.tgz#4d3340e807d3773bda9991f8305acdcc2a665d2a"
   integrity sha512-EGXjXJZhIHiQMK2pQukuFcL303nskqIRzWvPvV5O8miOfwoUb9G+a/Cld60kUyeaybEI94wvVClT10DtfeAExA==
+
+use-sync-external-store@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
+  integrity sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==
 
 util@^0.10.3:
   version "0.10.4"

--- a/package/native-package/yarn.lock
+++ b/package/native-package/yarn.lock
@@ -4242,10 +4242,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stream-chat-react-native-core@6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.3.1.tgz#fa173c92bc11538e729978e223fd14db39c7ae75"
-  integrity sha512-ec1ySYZS7m0ncQ0zw+B2fw2+eMf4+8xpf9ynrmOoeLh54EmHYyhH3BK6roEXnMDGwI4U60iI2yolotY3E/xtNA==
+stream-chat-react-native-core@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.4.0.tgz#ea39a152328af5f38904c9aa66d849a2c4ffca9e"
+  integrity sha512-dKK3y7vvygEzd7XUKE2QFx2a+jVfd7kZGQL3LmyXNCulKAdGNBMEfk0lh/mXFoxx9c9cBYAY7iydPmmdEwWtQQ==
   dependencies:
     "@gorhom/bottom-sheet" "^5.0.6"
     dayjs "1.10.5"
@@ -4258,12 +4258,13 @@ stream-chat-react-native-core@6.3.1:
     path "0.12.7"
     react-native-markdown-package "1.8.2"
     react-native-url-polyfill "^1.3.0"
-    stream-chat "8.46.0"
+    stream-chat "^8.50.0"
+    use-sync-external-store "^1.4.0"
 
-stream-chat@8.46.0:
-  version "8.46.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.46.0.tgz#416b325e05b144d0937a3527d1e622463113d605"
-  integrity sha512-HQVCRVldrfQFAvsBOHiHR0TKYf+wpsg/cAzRojeZY+buy1vG6eoqk09h6Fl4k2eG3zFLoA0G9W6o7o45jyFE1g==
+stream-chat@^8.50.0:
+  version "8.54.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.54.1.tgz#61a7330c9b7401f3e176e55445b29317bca2b108"
+  integrity sha512-BmeN1nq/zbItJXayHz/kBDc36Xvs4rW5pol/ngPXs0Vl8tw7vCuYBI4aFvpthvFU9EhCIJzBn8ISqDlnfWyDkw==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"
@@ -4483,6 +4484,11 @@ update-browserslist-db@^1.1.0:
   dependencies:
     escalade "^3.1.2"
     picocolors "^1.0.1"
+
+use-sync-external-store@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
+  integrity sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"

--- a/package/package.json
+++ b/package/package.json
@@ -77,7 +77,7 @@
     "path": "0.12.7",
     "react-native-markdown-package": "1.8.2",
     "react-native-url-polyfill": "^1.3.0",
-    "stream-chat": "^8.50.0",
+    "stream-chat": "^8.54.1",
     "use-sync-external-store": "^1.4.0"
   },
   "peerDependencies": {

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -9316,10 +9316,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stream-chat@^8.50.0:
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.52.0.tgz#7cb477433d0eb3d7351852f76b3838f5ce0af000"
-  integrity sha512-u5M9z4m8O0tB82XTQMkOvLp5+OJg6al8k8/sXQaDx1tMCTMnRWzCIXtRXKjBCWIftwB/4SuPV72+Zy9r/zJMng==
+stream-chat@^8.54.1:
+  version "8.54.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.54.1.tgz#61a7330c9b7401f3e176e55445b29317bca2b108"
+  integrity sha512-BmeN1nq/zbItJXayHz/kBDc36Xvs4rW5pol/ngPXs0Vl8tw7vCuYBI4aFvpthvFU9EhCIJzBn8ISqDlnfWyDkw==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"


### PR DESCRIPTION
## 🎯 Goal

The issue is explained in [this PR](https://github.com/GetStream/stream-chat-js/pull/1456).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


