### PR TITLE
fix: channel.visible not taking sort and pinned channels into account

### DIFF
--- a/package/src/__tests__/offline-support/offline-feature.js
+++ b/package/src/__tests__/offline-support/offline-feature.js
@@ -254,7 +254,6 @@ export const Generic = () => {
         const reactionsRows = await BetterSqlite.selectFromTable('reactions');
         const readsRows = await BetterSqlite.selectFromTable('reads');
 
-        console.log('ON UI', channelIdsOnUI);
         expect(channelIdsOnUI.length).toBe(channels.length);
         expect(channelsRows.length).toBe(channels.length);
         expect(messagesRows.length).toBe(allMessages.length);

--- a/package/src/__tests__/offline-support/offline-feature.js
+++ b/package/src/__tests__/offline-support/offline-feature.js
@@ -254,6 +254,7 @@ export const Generic = () => {
         const reactionsRows = await BetterSqlite.selectFromTable('reactions');
         const readsRows = await BetterSqlite.selectFromTable('reads');
 
+        console.log('ON UI', channelIdsOnUI);
         expect(channelIdsOnUI.length).toBe(channels.length);
         expect(channelsRows.length).toBe(channels.length);
         expect(messagesRows.length).toBe(allMessages.length);
@@ -381,9 +382,8 @@ export const Generic = () => {
       channels.push(newChannel);
       useMockedApis(chatClient, [getOrCreateChannelApi(newChannel)]);
 
+      await act(() => dispatchNotificationMessageNewEvent(chatClient, newChannel.channel));
       await waitFor(() => {
-        act(() => dispatchNotificationMessageNewEvent(chatClient, newChannel.channel));
-
         const channelIdsOnUI = screen
           .queryAllByLabelText('list-item')
           .map((node) => node._fiber.pendingProps.testID);

--- a/package/src/components/ChannelList/ChannelList.tsx
+++ b/package/src/components/ChannelList/ChannelList.tsx
@@ -349,6 +349,7 @@ export const ChannelList = <
 
   useChannelVisible({
     onChannelVisible,
+    options: { sort },
     setChannels,
   });
 

--- a/package/src/components/ChannelList/hooks/listeners/useChannelVisible.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useChannelVisible.ts
@@ -48,7 +48,6 @@ export const useChannelVisible = <
               ? moveChannelUp({
                   channels,
                   channelToMove: channel,
-                  channelToMoveIndexWithinChannels: -1,
                   sort,
                 })
               : channels,

--- a/package/src/components/ChannelList/hooks/listeners/useNewMessageNotification.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useNewMessageNotification.ts
@@ -56,7 +56,6 @@ export const useNewMessageNotification = <
               ? moveChannelUp({
                   channels,
                   channelToMove: channel,
-                  channelToMoveIndexWithinChannels: -1,
                   sort,
                 })
               : channels,

--- a/package/src/components/ChannelList/hooks/listeners/useNewMessageNotification.ts
+++ b/package/src/components/ChannelList/hooks/listeners/useNewMessageNotification.ts
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
 
-import uniqBy from 'lodash/uniqBy';
-
 import type { Channel, Event } from 'stream-chat';
 
 import { useChatContext } from '../../../../contexts/chatContext/ChatContext';
@@ -10,7 +8,7 @@ import type {
   ChannelListEventListenerOptions,
   DefaultStreamChatGenerics,
 } from '../../../../types/types';
-import { getChannel } from '../../utils';
+import { getChannel, moveChannelUp } from '../../utils';
 import { isChannelArchived } from '../utils';
 
 type Parameters<StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics> =
@@ -39,7 +37,7 @@ export const useNewMessageNotification = <
         onNewMessageNotification(setChannels, event, options);
       } else {
         if (!options) return;
-        const { filters } = options;
+        const { filters, sort } = options;
         if (event.channel?.id && event.channel?.type) {
           const channel = await getChannel({
             client,
@@ -53,7 +51,16 @@ export const useNewMessageNotification = <
             return;
           }
 
-          setChannels((channels) => (channels ? uniqBy([channel, ...channels], 'cid') : channels));
+          setChannels((channels) =>
+            channels
+              ? moveChannelUp({
+                  channels,
+                  channelToMove: channel,
+                  channelToMoveIndexWithinChannels: -1,
+                  sort,
+                })
+              : channels,
+          );
         }
       }
     };


### PR DESCRIPTION
## 🎯 Goal

This PR fixes an issue with channel pinning where pinned channels aren't respected if a channel goes from hidden to visible.

Steps to reproduce:

- Pin 1 or more channels within `ChannelList`
- Take another `channel` (not a pinned one) and `channel.hide()` it
- After that, run `channel.show()` without reloading the app (so that no HTTP requests are done in the meantime)
- The recently shown `channel` will not respect pinned ones

~~Also, pretty sure that `notification.message_new` handler is also incorrect since it doesn't take archiving into account, but will look into that on Monday.~~

Update: This was indeed an issue with `notification.message_new` as well and is fixed in this PR.

This is already fixed in the [recent reactive channel list state PR in the LLC](https://github.com/GetStream/stream-chat-js/pull/1460), but porting it here too so that we don't leave the SDK with a bug until that one gets merged.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


