### PR TITLE
feat: add blockquote support for preview in message

### DIFF
--- a/package/src/components/Message/MessageSimple/utils/generateMarkdownText.test.ts
+++ b/package/src/components/Message/MessageSimple/utils/generateMarkdownText.test.ts
@@ -15,7 +15,7 @@ describe('generateMarkdownText', () => {
       'Hi [test@gmail.com](mailto:test@gmail.com) @test@gmail.com',
     ],
     ['Hi @getstream.io getstream.io', 'Hi @getstream.io [getstream.io](http://getstream.io)'],
-    ['Hi <Stream>', 'Hi \\<Stream\\>'],
+    ['Hi <Stream>', 'Hi \\<Stream>'],
   ])('Returns the generated markdown text for %p and %p', (text, expected) => {
     const result = generateMarkdownText(text);
     expect(result).toBe(expected);

--- a/package/src/components/Message/MessageSimple/utils/generateMarkdownText.ts
+++ b/package/src/components/Message/MessageSimple/utils/generateMarkdownText.ts
@@ -34,7 +34,7 @@ export const generateMarkdownText = (text?: string) => {
   }
 
   // Escape the " and ' characters, except in code blocks where we deem this allowed.
-  resultText = resultText.replace(/(```[\s\S]*?```|`.*?`)|[<"'>]/g, (match, code) => {
+  resultText = resultText.replace(/(```[\s\S]*?```|`.*?`)|[<"']/g, (match, code) => {
     if (code) return code;
     return `\\${match}`;
   });

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -200,6 +200,23 @@ export const renderText = <
       color: colors.accent_blue,
       ...markdownStyles?.autolink,
     },
+    blockQuoteText: {
+      ...defaultMarkdownStyles.blockQuoteText,
+      ...markdownStyles?.blockQuoteText,
+    },
+    blockQuoteSection: {
+      ...defaultMarkdownStyles.blockQuoteSection,
+      flexDirection: 'row',
+      padding: 8,
+      ...markdownStyles?.blockQuoteSection,
+    },
+    blockQuoteSectionBar: {
+      ...defaultMarkdownStyles.blockQuoteSectionBar,
+      width: 2,
+      backgroundColor: colors.grey_gainsboro,
+      marginRight: 8,
+      ...markdownStyles?.blockQuoteSectionBar,
+    },
     codeBlock: {
       ...defaultMarkdownStyles.codeBlock,
       backgroundColor: colors.code_block,
@@ -398,6 +415,13 @@ export const renderText = <
     </MarkdownReactiveScrollView>
   );
 
+  const blockQuoteReact: ReactNodeOutput = (node, output, state) => (
+    <View key={state.key} style={styles.blockQuoteSection}>
+      <View style={styles.blockQuoteSectionBar} />
+      <View style={styles.blockQuoteText}>{output(node.content, state)}</View>
+    </View>
+  );
+
   const customRules = {
     // do not render images, we will scrape them out of the message and show on attachment card component
     image: { match: () => null },
@@ -420,6 +444,9 @@ export const renderText = <
       : {}),
     codeBlock: { react: codeBlockReact },
     table: { react: tableReact },
+    blockQuote: {
+      react: blockQuoteReact,
+    },
   };
 
   return (

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -423,6 +423,10 @@ export const renderText = <
   );
 
   const customRules = {
+    blockQuote: {
+      react: blockQuoteReact,
+    },
+    codeBlock: { react: codeBlockReact },
     // do not render images, we will scrape them out of the message and show on attachment card component
     image: { match: () => null },
     link: { react: linkReact },
@@ -442,11 +446,7 @@ export const renderText = <
           },
         }
       : {}),
-    codeBlock: { react: codeBlockReact },
     table: { react: tableReact },
-    blockQuote: {
-      react: blockQuoteReact,
-    },
   };
 
   return (

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -200,10 +200,6 @@ export const renderText = <
       color: colors.accent_blue,
       ...markdownStyles?.autolink,
     },
-    blockQuoteText: {
-      ...defaultMarkdownStyles.blockQuoteText,
-      ...markdownStyles?.blockQuoteText,
-    },
     blockQuoteSection: {
       ...defaultMarkdownStyles.blockQuoteSection,
       flexDirection: 'row',
@@ -212,10 +208,14 @@ export const renderText = <
     },
     blockQuoteSectionBar: {
       ...defaultMarkdownStyles.blockQuoteSectionBar,
-      width: 2,
       backgroundColor: colors.grey_gainsboro,
       marginRight: 8,
+      width: 2,
       ...markdownStyles?.blockQuoteSectionBar,
+    },
+    blockQuoteText: {
+      ...defaultMarkdownStyles.blockQuoteText,
+      ...markdownStyles?.blockQuoteText,
     },
     codeBlock: {
       ...defaultMarkdownStyles.codeBlock,


### PR DESCRIPTION
The PR is responsible for the preview of the blockquote in the message text.

![simulator_screenshot_D29B3DDC-C935-4E74-A0EF-64C4BF1E2DAE](https://github.com/user-attachments/assets/e192d65e-03ca-49cd-982d-cc0b530a77e4)
