### PR TITLE
chore: secret menu for dev config

### DIFF
--- a/examples/SampleApp/src/components/MenuDrawer.tsx
+++ b/examples/SampleApp/src/components/MenuDrawer.tsx
@@ -102,7 +102,7 @@ export const MenuDrawer = ({ navigation }: DrawerContentComponentProps) => {
         </Pressable>
         <View style={styles.menuContainer}>
           <View>
-            <SecretMenu visible={secretMenuVisible} close={closeSecretMenu} />
+            <SecretMenu visible={secretMenuVisible} close={closeSecretMenu} chatClient={chatClient} />
             <TouchableOpacity
               onPress={() => navigation.navigate('NewDirectMessagingScreen')}
               style={styles.menuItem}

--- a/examples/SampleApp/src/components/MenuDrawer.tsx
+++ b/examples/SampleApp/src/components/MenuDrawer.tsx
@@ -1,12 +1,21 @@
-import React from 'react';
-import { Image, SafeAreaView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Image,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  Pressable,
+  View,
+} from 'react-native';
 import { Edit, Group, User, useTheme } from 'stream-chat-react-native';
 
 import { useAppContext } from '../context/AppContext';
+import { SecretMenu } from './SecretMenu.tsx';
 
 import type { DrawerContentComponentProps } from '@react-navigation/drawer';
 
-const styles = StyleSheet.create({
+export const styles = StyleSheet.create({
   avatar: {
     borderRadius: 20,
     height: 40,
@@ -44,11 +53,25 @@ const styles = StyleSheet.create({
 });
 
 export const MenuDrawer = ({ navigation }: DrawerContentComponentProps) => {
+  const [secretMenuPressCounter, setSecretMenuPressCounter] = useState(0);
+  const [secretMenuVisible, setSecretMenuVisible] = useState(false);
+
   const {
     theme: {
       colors: { black, grey, white },
     },
   } = useTheme();
+
+  useEffect(() => {
+    if (!secretMenuVisible && secretMenuPressCounter >= 7) {
+      setSecretMenuVisible(true);
+    }
+  }, [secretMenuVisible, secretMenuPressCounter]);
+
+  const closeSecretMenu = useCallback(() => {
+    setSecretMenuPressCounter(0);
+    setSecretMenuVisible(false);
+  }, []);
 
   const { chatClient, logout } = useAppContext();
 
@@ -59,7 +82,7 @@ export const MenuDrawer = ({ navigation }: DrawerContentComponentProps) => {
   return (
     <View style={[styles.container, { backgroundColor: white }]}>
       <SafeAreaView style={{ flex: 1 }}>
-        <View style={[styles.userRow]}>
+        <Pressable onPress={() => setSecretMenuPressCounter(c => c + 1)} style={[styles.userRow]}>
           <Image
             source={{
               uri: chatClient.user?.image,
@@ -76,9 +99,10 @@ export const MenuDrawer = ({ navigation }: DrawerContentComponentProps) => {
           >
             {chatClient.user?.name}
           </Text>
-        </View>
+        </Pressable>
         <View style={styles.menuContainer}>
           <View>
+            <SecretMenu visible={secretMenuVisible} close={closeSecretMenu} />
             <TouchableOpacity
               onPress={() => navigation.navigate('NewDirectMessagingScreen')}
               style={styles.menuItem}

--- a/examples/SampleApp/src/components/SecretMenu.tsx
+++ b/examples/SampleApp/src/components/SecretMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming } from 'react-native-reanimated';
 import { LayoutChangeEvent, Text, TouchableOpacity, View, Platform, StyleSheet } from 'react-native';
-import { Close, Notification, Check, useTheme } from 'stream-chat-react-native';
+import { Close, Notification, Check, Delete, useTheme } from 'stream-chat-react-native';
 import { styles as menuDrawerStyles } from './MenuDrawer.tsx';
 import AsyncStore from '../utils/AsyncStore.ts';
 import { StreamChat } from 'stream-chat';
@@ -92,7 +92,7 @@ export const SecretMenu = ({ close, visible, chatClient }: { close: () => void, 
         </View>
       </View>
       <TouchableOpacity onPress={removeAllDevices} style={menuDrawerStyles.menuItem}>
-        <Close height={24} pathFill={grey} width={24} />
+        <Delete height={24} size={24} pathFill={grey} width={24} />
         <Text
           style={[
             menuDrawerStyles.menuTitle,

--- a/examples/SampleApp/src/components/SecretMenu.tsx
+++ b/examples/SampleApp/src/components/SecretMenu.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming } from 'react-native-reanimated';
+import { LayoutChangeEvent, Text, TouchableOpacity, View } from 'react-native';
+import { Close, Notification, useTheme } from 'stream-chat-react-native';
+import { styles as menuDrawerStyles } from './MenuDrawer.tsx';
+
+export const SlideInView = ({ visible, children }: { visible: boolean; children: React.ReactNode }) => {
+  const animatedHeight = useSharedValue(0);
+
+  const onLayout = (event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout;
+    animatedHeight.value = height;
+  };
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    height: withSpring(visible ? animatedHeight.value : 0, { damping: 10 }),
+    opacity: withTiming(visible ? 1 : 0, { duration: 500 }),
+  }), [visible]);
+
+  return (
+    <Animated.View style={animatedStyle}>
+      {visible ? <View onLayout={onLayout} style={{ position: 'absolute', width: '100%' }}>
+        {children}
+      </View> : null}
+    </Animated.View>
+  );
+};
+
+export const SecretMenu = ({ close, visible }: { close: () => void, visible: boolean }) => {
+  const {
+    theme: {
+      colors: { black, grey },
+    },
+  } = useTheme();
+
+  return <SlideInView visible={visible} >
+    <TouchableOpacity style={menuDrawerStyles.menuItem}>
+      <Notification height={24} pathFill={grey} width={24} />
+      <Text
+        style={[
+          menuDrawerStyles.menuTitle,
+          {
+            color: black,
+          },
+        ]}
+      >
+        BRUH
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity onPress={close} style={menuDrawerStyles.menuItem}>
+      <Close height={24} pathFill={grey} width={24} />
+      <Text
+        style={[
+          menuDrawerStyles.menuTitle,
+          {
+            color: black,
+          },
+        ]}
+      >
+        Close
+      </Text>
+    </TouchableOpacity>
+    <View style={menuDrawerStyles.menuItem}>
+      <View style={{ backgroundColor: grey, height: 1, width: '100%', opacity: 0.2 }}/>
+    </View>
+  </SlideInView>;
+};

--- a/examples/SampleApp/src/components/SecretMenu.tsx
+++ b/examples/SampleApp/src/components/SecretMenu.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming } from 'react-native-reanimated';
-import { LayoutChangeEvent, Text, TouchableOpacity, View } from 'react-native';
-import { Close, Notification, useTheme } from 'stream-chat-react-native';
+import { LayoutChangeEvent, Text, TouchableOpacity, View, Platform, StyleSheet } from 'react-native';
+import { Close, Notification, Check, useTheme } from 'stream-chat-react-native';
 import { styles as menuDrawerStyles } from './MenuDrawer.tsx';
+import AsyncStore from '../utils/AsyncStore.ts';
+import { StreamChat } from 'stream-chat';
 
 export const SlideInView = ({ visible, children }: { visible: boolean; children: React.ReactNode }) => {
   const animatedHeight = useSharedValue(0);
@@ -26,42 +28,107 @@ export const SlideInView = ({ visible, children }: { visible: boolean; children:
   );
 };
 
-export const SecretMenu = ({ close, visible }: { close: () => void, visible: boolean }) => {
+const isAndroid = Platform.OS === 'android';
+
+export const SecretMenu = ({ close, visible, chatClient }: { close: () => void, visible: boolean, chatClient: StreamChat }) => {
+  const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const {
     theme: {
       colors: { black, grey },
     },
   } = useTheme();
 
-  return <SlideInView visible={visible} >
-    <TouchableOpacity style={menuDrawerStyles.menuItem}>
-      <Notification height={24} pathFill={grey} width={24} />
-      <Text
+  const notificationConfigItems = useMemo(() => [{ label: 'Firebase', name: 'rn-fcm', id: 'firebase' }, { label: 'APNs', name: 'APN', id: 'apn' }], []);
+
+  useEffect(() => {
+    const getSelectedProvider = async () => {
+      const provider = await AsyncStore.getItem('@stream-rn-sampleapp-push-provider', notificationConfigItems[0]);
+      setSelectedProvider(provider?.id ?? 'firebase');
+    };
+    getSelectedProvider();
+  }, [notificationConfigItems]);
+
+  const storeProvider = useCallback(async (item: { label: string, name: string, id: string }) => {
+      await AsyncStore.setItem('@stream-rn-sampleapp-push-provider', item);
+      setSelectedProvider(item.id);
+  }, []);
+
+  const removeAllDevices = useCallback(async () => {
+    const { devices } = await chatClient.getDevices(chatClient.userID);
+    for (const device of devices ?? []) {
+      await chatClient.removeDevice(device.id, chatClient.userID);
+    }
+  }, [chatClient]);
+
+  return (
+    <SlideInView visible={visible}>
+      <View
         style={[
-          menuDrawerStyles.menuTitle,
-          {
-            color: black,
-          },
+          menuDrawerStyles.menuItem,
+          { opacity: isAndroid ? 0.3 : 1, alignItems: 'flex-start' },
         ]}
       >
-        BRUH
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity onPress={close} style={menuDrawerStyles.menuItem}>
-      <Close height={24} pathFill={grey} width={24} />
-      <Text
-        style={[
-          menuDrawerStyles.menuTitle,
-          {
-            color: black,
-          },
-        ]}
-      >
-        Close
-      </Text>
-    </TouchableOpacity>
-    <View style={menuDrawerStyles.menuItem}>
-      <View style={{ backgroundColor: grey, height: 1, width: '100%', opacity: 0.2 }}/>
-    </View>
-  </SlideInView>;
+        <Notification height={24} pathFill={grey} width={24} />
+        <View>
+          <Text
+            style={[
+              menuDrawerStyles.menuTitle,
+              {
+                color: black,
+                marginTop: 4,
+              },
+            ]}
+          >
+            Notification Provider
+          </Text>
+          <View style={{ marginLeft: 16 }}>
+            {notificationConfigItems.map((item) => (
+              <TouchableOpacity key={item.id} style={{ paddingTop: 8, flexDirection: 'row' }} onPress={() => storeProvider(item)}>
+                <Text style={styles.notificationItem}>{item.label}</Text>
+                {item.id === selectedProvider ? <Check height={16} pathFill={'green'} width={16} style={{ marginLeft: 12 }} /> : null}
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+      </View>
+      <TouchableOpacity onPress={removeAllDevices} style={menuDrawerStyles.menuItem}>
+        <Close height={24} pathFill={grey} width={24} />
+        <Text
+          style={[
+            menuDrawerStyles.menuTitle,
+            {
+              color: black,
+            },
+          ]}
+        >
+          Remove all devices
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={close} style={menuDrawerStyles.menuItem}>
+        <Close height={24} pathFill={grey} width={24} />
+        <Text
+          style={[
+            menuDrawerStyles.menuTitle,
+            {
+              color: black,
+            },
+          ]}
+        >
+          Close
+        </Text>
+      </TouchableOpacity>
+      <View style={menuDrawerStyles.menuItem}>
+        <View style={[styles.separator, { backgroundColor: grey }]} />
+      </View>
+    </SlideInView>
+  );
 };
+
+export const styles = StyleSheet.create({
+  separator: { height: 1, width: '100%', opacity: 0.2 },
+  notificationContainer: {},
+  notificationItem: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+});


### PR DESCRIPTION
## 🎯 Goal

This PR creates a way for us to switch push providers on the fly. It's meant to be used for testing purposes while the BE team works on the new PN infrastructure.

How-to:

- In the user menu (top left corner), you can press on the currently logged in user's name/image 7 times and another menu will appear
- In this menu you can:
  - Choose between preset push providers (currently only `Firebase` and `APNs`)
  - Remove all devices for the given user

Whenever switching between push providers please make sure to also close and reopen the app.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


