### PR TITLE
fix: android push notification permission issues

### DIFF
--- a/examples/SampleApp/src/components/SecretMenu.tsx
+++ b/examples/SampleApp/src/components/SecretMenu.tsx
@@ -81,14 +81,14 @@ export const SecretMenu = ({ close, visible, chatClient }: { close: () => void, 
           >
             Notification Provider
           </Text>
-          <View style={{ marginLeft: 16 }}>
+          {isAndroid ? null : <View style={{ marginLeft: 16 }}>
             {notificationConfigItems.map((item) => (
               <TouchableOpacity key={item.id} style={{ paddingTop: 8, flexDirection: 'row' }} onPress={() => storeProvider(item)}>
                 <Text style={styles.notificationItem}>{item.label}</Text>
                 {item.id === selectedProvider ? <Check height={16} pathFill={'green'} width={16} style={{ marginLeft: 12 }} /> : null}
               </TouchableOpacity>
             ))}
-          </View>
+          </View>}
         </View>
       </View>
       <TouchableOpacity onPress={removeAllDevices} style={menuDrawerStyles.menuItem}>


### PR DESCRIPTION
## 🎯 Goal

I missed resolving this issue in the [previous PR](https://github.com/GetStream/stream-chat-react-native/commit/7ea43d4c389aa81213e419c03c6460dbf0b40abc).

We essentially need to ask for permissions manually as of the newer Android versions.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


