### PR TITLE
fix: change flatlist inside the bottom sheet modal and fix gesture in bottom sheet

### DIFF
--- a/package/src/components/MessageMenu/MessageActionList.tsx
+++ b/package/src/components/MessageMenu/MessageActionList.tsx
@@ -25,7 +25,7 @@ export const MessageActionList = (props: MessageActionListProps) => {
   const {
     theme: {
       messageMenu: {
-        actionList: { container },
+        actionList: { container, contentContainer },
       },
     },
   } = useTheme();
@@ -33,7 +33,11 @@ export const MessageActionList = (props: MessageActionListProps) => {
   if (messageActions?.length === 0) return null;
 
   return (
-    <ScrollView accessibilityLabel='Message action list' style={[styles.container, container]}>
+    <ScrollView
+      accessibilityLabel='Message action list'
+      contentContainerStyle={[styles.contentContainer, contentContainer]}
+      style={[styles.container, container]}
+    >
       {messageActions?.map((messageAction, index) => (
         <MessageActionListItem
           key={messageAction.title}
@@ -45,7 +49,8 @@ export const MessageActionList = (props: MessageActionListProps) => {
 };
 
 const styles = StyleSheet.create({
-  container: {
+  container: {},
+  contentContainer: {
     paddingHorizontal: 16,
   },
 });

--- a/package/src/components/MessageMenu/MessageActionList.tsx
+++ b/package/src/components/MessageMenu/MessageActionList.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet } from 'react-native';
+
+import { ScrollView } from 'react-native-gesture-handler';
 
 import { MessageActionType } from './MessageActionListItem';
 
@@ -31,14 +33,14 @@ export const MessageActionList = (props: MessageActionListProps) => {
   if (messageActions?.length === 0) return null;
 
   return (
-    <View accessibilityLabel='Message action list' style={[styles.container, container]}>
+    <ScrollView accessibilityLabel='Message action list' style={[styles.container, container]}>
       {messageActions?.map((messageAction, index) => (
         <MessageActionListItem
           key={messageAction.title}
           {...{ ...messageAction, index, length: messageActions.length }}
         />
       ))}
-    </View>
+    </ScrollView>
   );
 };
 

--- a/package/src/components/MessageMenu/MessageUserReactions.tsx
+++ b/package/src/components/MessageMenu/MessageUserReactions.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
-import { FlatList, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { FlatList } from 'react-native-gesture-handler';
 
 import { ReactionSortBase } from 'stream-chat';
 
@@ -179,7 +180,9 @@ export const MessageUserReactions = (props: MessageUserReactionsProps) => {
 };
 
 const styles = StyleSheet.create({
-  container: {},
+  container: {
+    flex: 1,
+  },
   contentContainer: {
     flexGrow: 1,
     justifyContent: 'space-around',

--- a/package/src/components/UIComponents/BottomSheetModal.tsx
+++ b/package/src/components/UIComponents/BottomSheetModal.tsx
@@ -119,36 +119,33 @@ export const BottomSheetModal = (props: PropsWithChildren<BottomSheetModalProps>
     });
 
   return (
-    <View style={{ alignItems: 'center', flex: 1, justifyContent: 'center' }}>
+    <View style={styles.wrapper}>
       <Modal onRequestClose={onClose} transparent visible={visible}>
-        <TouchableWithoutFeedback onPress={onClose} style={{ flex: 1 }}>
-          <GestureHandlerRootView style={{ flex: 1 }}>
-            <GestureDetector gesture={gesture}>
-              <View style={[styles.overlay, { backgroundColor: overlay }, overlayTheme]}>
-                <Animated.View
-                  style={[
-                    styles.container,
-                    {
-                      backgroundColor: white_snow,
-                      height,
-                      transform: [{ translateY }],
-                    },
-                    container,
-                  ]}
-                >
-                  <View
-                    style={[
-                      styles.handle,
-                      { backgroundColor: grey, width: windowWidth / 4 },
-                      handle,
-                    ]}
-                  />
-                  <View style={[styles.contentContainer, contentContainer]}>{children}</View>
-                </Animated.View>
-              </View>
-            </GestureDetector>
-          </GestureHandlerRootView>
-        </TouchableWithoutFeedback>
+        <GestureHandlerRootView style={{ flex: 1 }}>
+          <GestureDetector gesture={gesture}>
+            <View style={[styles.overlay, { backgroundColor: overlay }, overlayTheme]}>
+              <TouchableWithoutFeedback onPress={onClose} style={{ flex: 1 }}>
+                <View style={{ flex: 1 }} />
+              </TouchableWithoutFeedback>
+              <Animated.View
+                style={[
+                  styles.container,
+                  {
+                    backgroundColor: white_snow,
+                    height,
+                    transform: [{ translateY }],
+                  },
+                  container,
+                ]}
+              >
+                <View
+                  style={[styles.handle, { backgroundColor: grey, width: windowWidth / 4 }, handle]}
+                />
+                <View style={[styles.contentContainer, contentContainer]}>{children}</View>
+              </Animated.View>
+            </View>
+          </GestureDetector>
+        </GestureHandlerRootView>
       </Modal>
     </View>
   );
@@ -176,5 +173,10 @@ const styles = StyleSheet.create({
   overlay: {
     flex: 1,
     justifyContent: 'flex-end',
+  },
+  wrapper: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
   },
 });

--- a/package/src/components/UIComponents/BottomSheetModal.tsx
+++ b/package/src/components/UIComponents/BottomSheetModal.tsx
@@ -1,14 +1,13 @@
 import React, { PropsWithChildren, useEffect } from 'react';
 import {
   Animated,
-  Dimensions,
-  Modal,
-  StyleSheet,
-  useWindowDimensions,
-  TouchableWithoutFeedback,
-  View,
   Keyboard,
   KeyboardEvent,
+  Modal,
+  StyleSheet,
+  TouchableWithoutFeedback,
+  useWindowDimensions,
+  View,
 } from 'react-native';
 import {
   Gesture,

--- a/package/src/components/UIComponents/BottomSheetModal.tsx
+++ b/package/src/components/UIComponents/BottomSheetModal.tsx
@@ -45,7 +45,7 @@ export const BottomSheetModal = (props: PropsWithChildren<BottomSheetModalProps>
   const { children, height = windowHeight / 2, onClose, visible } = props;
   const {
     theme: {
-      bottomSheetModal: { container, contentContainer, handle, overlay: overlayTheme },
+      bottomSheetModal: { container, contentContainer, handle, overlay: overlayTheme, wrapper },
       colors: { grey, overlay, white_snow },
     },
   } = useTheme();
@@ -119,7 +119,7 @@ export const BottomSheetModal = (props: PropsWithChildren<BottomSheetModalProps>
     });
 
   return (
-    <View style={styles.wrapper}>
+    <View style={[styles.wrapper, wrapper]}>
       <Modal onRequestClose={onClose} transparent visible={visible}>
         <GestureHandlerRootView style={{ flex: 1 }}>
           <GestureDetector gesture={gesture}>

--- a/package/src/components/UIComponents/BottomSheetModal.tsx
+++ b/package/src/components/UIComponents/BottomSheetModal.tsx
@@ -1,13 +1,14 @@
 import React, { PropsWithChildren, useEffect } from 'react';
 import {
   Animated,
-  Keyboard,
-  KeyboardEvent,
+  Dimensions,
   Modal,
   StyleSheet,
-  TouchableWithoutFeedback,
   useWindowDimensions,
+  TouchableWithoutFeedback,
   View,
+  Keyboard,
+  KeyboardEvent,
 } from 'react-native';
 import {
   Gesture,
@@ -119,32 +120,38 @@ export const BottomSheetModal = (props: PropsWithChildren<BottomSheetModalProps>
     });
 
   return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-      <Modal animationType='fade' onRequestClose={handleDismiss} transparent visible={visible}>
-        <TouchableWithoutFeedback onPress={handleDismiss}>
-          <View style={[styles.overlay, { backgroundColor: overlay }, overlayTheme]}>
+    <View style={{ alignItems: 'center', flex: 1, justifyContent: 'center' }}>
+      <Modal onRequestClose={onClose} transparent visible={visible}>
+        <TouchableWithoutFeedback onPress={onClose} style={{ flex: 1 }}>
+          <GestureHandlerRootView style={{ flex: 1 }}>
             <GestureDetector gesture={gesture}>
-              <Animated.View
-                style={[
-                  styles.container,
-                  {
-                    backgroundColor: white_snow,
-                    height,
-                    transform: [{ translateY }],
-                  },
-                  container,
-                ]}
-              >
-                <View
-                  style={[styles.handle, { backgroundColor: grey, width: windowWidth / 4 }, handle]}
-                />
-                <View style={[styles.contentContainer, contentContainer]}>{children}</View>
-              </Animated.View>
+              <View style={[styles.overlay, { backgroundColor: overlay }, overlayTheme]}>
+                <Animated.View
+                  style={[
+                    styles.container,
+                    {
+                      backgroundColor: white_snow,
+                      height,
+                      transform: [{ translateY }],
+                    },
+                    container,
+                  ]}
+                >
+                  <View
+                    style={[
+                      styles.handle,
+                      { backgroundColor: grey, width: windowWidth / 4 },
+                      handle,
+                    ]}
+                  />
+                  <View style={[styles.contentContainer, contentContainer]}>{children}</View>
+                </Animated.View>
+              </View>
             </GestureDetector>
-          </View>
+          </GestureHandlerRootView>
         </TouchableWithoutFeedback>
       </Modal>
-    </GestureHandlerRootView>
+    </View>
   );
 };
 

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -132,6 +132,7 @@ export type Theme = {
     contentContainer: ViewStyle;
     handle: ViewStyle;
     overlay: ViewStyle;
+    wrapper: ViewStyle;
   };
   channel: {
     selectChannel: TextStyle;
@@ -892,6 +893,7 @@ export const defaultTheme: Theme = {
     contentContainer: {},
     handle: {},
     overlay: {},
+    wrapper: {},
   },
   channel: {
     selectChannel: {},

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -442,6 +442,7 @@ export type Theme = {
   messageMenu: {
     actionList: {
       container: ViewStyle;
+      contentContainer: ViewStyle;
     };
     actionListItem: {
       container: ViewStyle;
@@ -1196,6 +1197,7 @@ export const defaultTheme: Theme = {
   messageMenu: {
     actionList: {
       container: {},
+      contentContainer: {},
     },
     actionListItem: {
       container: {},


### PR DESCRIPTION
The goal of the PR is to make the FlatList/ScrollView responsive inside the BottomSheetModal. We were using the one from React native, which was not working with the gesture handler, so we migrated it to the one from `react-native-gesture-handler`.

As a part of the PR, the bottom sheet is also improved, and the pan gesture reacts to the gesture we put in the UI.


https://github.com/user-attachments/assets/e1ab6ae2-faf3-41ad-b4ee-2262f8ca14e6

