### PR TITLE
fix: state break on channel prop update

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
+import React, { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { KeyboardAvoidingViewProps, StyleSheet, Text, View } from 'react-native';
 
 import debounce from 'lodash/debounce';
@@ -749,18 +749,21 @@ const ChannelWithContext = <
       ? newMessageStateUpdateThrottleInterval
       : stateUpdateThrottleInterval;
 
-  const copyChannelState = useRef(
-    throttle(
-      () => {
-        if (channel) {
-          copyStateFromChannel(channel);
-          copyMessagesStateFromChannel(channel);
-        }
-      },
-      copyChannelStateThrottlingTime,
-      throttleOptions,
-    ),
-  ).current;
+  const copyChannelState = useMemo(
+    () =>
+      throttle(
+        () => {
+          if (channel) {
+            copyStateFromChannel(channel);
+            console.log('COPYING ENTIRE STATE FOR BUG', channel.cid);
+            copyMessagesStateFromChannel(channel);
+          }
+        },
+        copyChannelStateThrottlingTime,
+        throttleOptions,
+      ),
+    [channel, copyChannelStateThrottlingTime, copyMessagesStateFromChannel, copyStateFromChannel],
+  );
 
   const handleEvent: EventHandler<StreamChatGenerics> = (event) => {
     if (shouldSyncChannel) {

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -755,7 +755,6 @@ const ChannelWithContext = <
         () => {
           if (channel) {
             copyStateFromChannel(channel);
-            console.log('COPYING ENTIRE STATE FOR BUG', channel.cid);
             copyMessagesStateFromChannel(channel);
           }
         },

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -579,7 +579,7 @@ const MessageListWithContext = <
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rawMessageList, threadList]);
+  }, [channel, rawMessageList, threadList]);
 
   const goToMessage = async (messageId: string) => {
     const indexOfParentInMessageList = processedMessageList.findIndex(
@@ -1097,12 +1097,13 @@ const MessageListWithContext = <
           keyboardShouldPersistTaps='handled'
           keyExtractor={keyExtractor}
           ListFooterComponent={ListFooterComponent}
-          /**
-            if autoscrollToTopThreshold is 10, we scroll to recent if before new list update it was already at the bottom (10 offset or below)
-            minIndexForVisible = 1 means that beyond item at index 1 will not change position on list updates
-            minIndexForVisible is not used when autoscrollToTopThreshold = 10
-          */
           ListHeaderComponent={ListHeaderComponent}
+          /**
+            If autoscrollToTopThreshold is 10, we scroll to recent only if before the update, the list was already at the
+            bottom (10 offset or below).
+            minIndexForVisible = 1 means that beyond the item at index 1 we will not change the position on list updates,
+            however it is not used when autoscrollToTopThreshold = 10.
+          */
           maintainVisibleContentPosition={{
             autoscrollToTopThreshold: autoscrollToRecent ? 10 : undefined,
             minIndexForVisible: 1,

--- a/package/src/components/MessageList/hooks/useShouldScrollToRecentOnNewOwnMessage.ts
+++ b/package/src/components/MessageList/hooks/useShouldScrollToRecentOnNewOwnMessage.ts
@@ -38,8 +38,7 @@ export function useShouldScrollToRecentOnNewOwnMessage<
         }
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rawMessageList]);
+  }, [currentUserId, rawMessageList]);
 
   return isMyOwnNewMessageRef;
 }


### PR DESCRIPTION
## 🎯 Goal

This PR addresses [this GH issue](https://github.com/GetStream/stream-chat-react-native/issues/2954).

Essentially, we were wrapping the copying of the `channel` state from our LLC in a `ref` which was never updated, thus resulting in an issue whenever we don't explicitly unmount and then remount the `Channel` component.

Although it is not very common behaviour to have this working like explained on mobile devices, it is very common on tablets for example where we're aiming for more of a web-like behaviour. 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


