### PR TITLE
perf: do not rerender Channel on poll events

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -679,8 +679,6 @@ const ChannelWithContext = <
     VideoThumbnail = VideoThumbnailDefault,
   } = props;
 
-  console.log('am i really rerendering');
-
   const { thread: threadProps, threadInstance } = threadFromProps;
   const StopMessageStreamingButton =
     StopMessageStreamingButtonOverride === undefined

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -679,6 +679,8 @@ const ChannelWithContext = <
     VideoThumbnail = VideoThumbnailDefault,
   } = props;
 
+  console.log('am i really rerendering');
+
   const { thread: threadProps, threadInstance } = threadFromProps;
   const StopMessageStreamingButton =
     StopMessageStreamingButtonOverride === undefined
@@ -766,7 +768,7 @@ const ChannelWithContext = <
     if (shouldSyncChannel) {
       // Ignore user.watching.start and user.watching.stop events
       const ignorableEvents = ['user.watching.start', 'user.watching.stop'];
-      if (ignorableEvents.includes(event.type)) return;
+      if (ignorableEvents.includes(event.type) || event.type.startsWith('poll.')) return;
 
       // If the event is typing.start or typing.stop, set the typing state
       const isTypingEvent = event.type === 'typing.start' || event.type === 'typing.stop';
@@ -869,7 +871,7 @@ const ChannelWithContext = <
       listener?.unsubscribe();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [channel.cid, messageId, shouldSyncChannel]);
+  }, [channelId, messageId, shouldSyncChannel]);
 
   // subscribe to channel.deleted event
   useEffect(() => {


### PR DESCRIPTION
## 🎯 Goal

Since the `channel` class instance is not reactive, we've traditionally relied on copying over the `ChannelState` from the LLC every time a relevant WS event arrives. 

We do not need this for polls, as they themselves are reactive and don't rely on this behaviour.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


