### PR TITLE
fix: pin preferredAssetRepresentationMode to current

### DIFF
--- a/package/expo-package/src/optionalDependencies/pickImage.ts
+++ b/package/expo-package/src/optionalDependencies/pickImage.ts
@@ -34,6 +34,7 @@ export const pickImage = ImagePicker
           const result = await ImagePicker.launchImageLibraryAsync({
             allowsMultipleSelection: true,
             mediaTypes: ['images', 'videos'],
+            preferredAssetRepresentationMode: 'current',
           });
 
           const canceled = result.canceled;


### PR DESCRIPTION
## 🎯 Goal

Zendesk ticket: https://getstream.zendesk.com/agent/tickets/61817

Whenever we set access to the native image picker as `Limit Access` and try to upload a very large video (above the 100mb threshold), the `Alert` telling us that we cannot upload the file comes in after a very long time (above 10 seconds). 

This is due to the fact that `iOS` has a compression mechanism in place that unfortunately `expo-image-picker` waits for. On `Android`, it's a similar issue (albeit not reproducible on every device), but related to copying the file elsewhere in the system. Unfortunately there is no workaround for `Android` provided by the library.

 This also means that for `iOS` we will not have implicit compression in place. As an alternative, integrators can implement `pickImage` on their own if none of these fixes resolve their issues.   

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


