### PR TITLE
feat: add the ability to override pn provider names

### DIFF
--- a/examples/SampleApp/src/components/SecretMenu.tsx
+++ b/examples/SampleApp/src/components/SecretMenu.tsx
@@ -1,12 +1,31 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming } from 'react-native-reanimated';
-import { LayoutChangeEvent, Text, TouchableOpacity, View, Platform, StyleSheet } from 'react-native';
-import { Close, Notification, Check, Delete, useTheme } from 'stream-chat-react-native';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  LayoutChangeEvent,
+  Text,
+  TouchableOpacity,
+  View,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+import { Close, Notification, Delete, useTheme } from 'stream-chat-react-native';
 import { styles as menuDrawerStyles } from './MenuDrawer.tsx';
 import AsyncStore from '../utils/AsyncStore.ts';
 import { StreamChat } from 'stream-chat';
+import { LabeledTextInput } from '../screens/AdvancedUserSelectorScreen.tsx';
 
-export const SlideInView = ({ visible, children }: { visible: boolean; children: React.ReactNode }) => {
+export const SlideInView = ({
+  visible,
+  children,
+}: {
+  visible: boolean;
+  children: React.ReactNode;
+}) => {
   const animatedHeight = useSharedValue(0);
 
   const onLayout = (event: LayoutChangeEvent) => {
@@ -14,23 +33,102 @@ export const SlideInView = ({ visible, children }: { visible: boolean; children:
     animatedHeight.value = height;
   };
 
-  const animatedStyle = useAnimatedStyle(() => ({
-    height: withSpring(visible ? animatedHeight.value : 0, { damping: 10 }),
-    opacity: withTiming(visible ? 1 : 0, { duration: 500 }),
-  }), [visible]);
+  const animatedStyle = useAnimatedStyle(
+    () => ({
+      height: withSpring(visible ? animatedHeight.value : 0, { damping: 10 }),
+      opacity: withTiming(visible ? 1 : 0, { duration: 500 }),
+    }),
+    [visible],
+  );
 
   return (
     <Animated.View style={animatedStyle}>
-      {visible ? <View onLayout={onLayout} style={{ position: 'absolute', width: '100%' }}>
-        {children}
-      </View> : null}
+      {visible ? (
+        <View onLayout={onLayout} style={{ position: 'absolute', width: '100%' }}>
+          {children}
+        </View>
+      ) : null}
     </Animated.View>
   );
 };
 
 const isAndroid = Platform.OS === 'android';
 
-export const SecretMenu = ({ close, visible, chatClient }: { close: () => void, visible: boolean, chatClient: StreamChat }) => {
+type NotificationConfigItem = { label: string; name: string; id: string };
+
+const SecretMenuNotificationConfigItem = ({
+  notificationConfigItem,
+  storeProvider,
+  isSelected,
+}: {
+  notificationConfigItem: NotificationConfigItem;
+  storeProvider: (item: NotificationConfigItem) => void;
+  isSelected: boolean;
+}) => {
+  const [providerNameOverride, setProviderNameOverride] = useState<string>('');
+  const [lastSubmittedOverride, setLastSubmittedOverride] = useState<string | null>(null);
+
+  const asyncStorageKey = useMemo(
+    () => `@stream-rn-sampleapp-push-provider-${notificationConfigItem.id}-override`,
+    [notificationConfigItem],
+  );
+
+  useEffect(() => {
+    const getProviderNameOverride = async () => {
+      const nameOverride = await AsyncStore.getItem(asyncStorageKey, '');
+      setLastSubmittedOverride(nameOverride ?? '');
+    };
+    getProviderNameOverride();
+  }, [asyncStorageKey]);
+
+  const storeProviderNameOverride = useCallback(async () => {
+    await AsyncStore.setItem(asyncStorageKey, providerNameOverride);
+    setLastSubmittedOverride(providerNameOverride);
+  }, [asyncStorageKey, providerNameOverride]);
+
+  return (
+    <View
+      style={[styles.notificationItemContainer, { borderColor: isSelected ? 'green' : 'gray' }]}
+    >
+      <TouchableOpacity
+        style={{ flexDirection: 'row' }}
+        onPress={() => storeProvider(notificationConfigItem)}
+      >
+        <Text style={styles.notificationItem}>{notificationConfigItem.label}</Text>
+        <Text
+          numberOfLines={1}
+          style={{ opacity: 0.7, fontSize: 14, marginLeft: 4, maxWidth: 145 }}
+        >
+          {lastSubmittedOverride && lastSubmittedOverride.length > 0
+            ? lastSubmittedOverride
+            : notificationConfigItem.name}
+        </Text>
+      </TouchableOpacity>
+      {isSelected ? (
+        <>
+          <LabeledTextInput
+            onChangeText={setProviderNameOverride}
+            label={'PN Provider name override'}
+            value={providerNameOverride}
+          />
+          <TouchableOpacity style={styles.submitButton} onPress={storeProviderNameOverride}>
+            <Text style={{ color: 'white', fontSize: 12 }}>Submit</Text>
+          </TouchableOpacity>
+        </>
+      ) : null}
+    </View>
+  );
+};
+
+export const SecretMenu = ({
+  close,
+  visible,
+  chatClient,
+}: {
+  close: () => void;
+  visible: boolean;
+  chatClient: StreamChat;
+}) => {
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const {
     theme: {
@@ -38,19 +136,28 @@ export const SecretMenu = ({ close, visible, chatClient }: { close: () => void, 
     },
   } = useTheme();
 
-  const notificationConfigItems = useMemo(() => [{ label: 'Firebase', name: 'rn-fcm', id: 'firebase' }, { label: 'APNs', name: 'APN', id: 'apn' }], []);
+  const notificationConfigItems = useMemo(
+    () => [
+      { label: 'Firebase', name: 'rn-fcm', id: 'firebase' },
+      { label: 'APNs', name: 'APN', id: 'apn' },
+    ],
+    [],
+  );
 
   useEffect(() => {
     const getSelectedProvider = async () => {
-      const provider = await AsyncStore.getItem('@stream-rn-sampleapp-push-provider', notificationConfigItems[0]);
+      const provider = await AsyncStore.getItem(
+        '@stream-rn-sampleapp-push-provider',
+        notificationConfigItems[0],
+      );
       setSelectedProvider(provider?.id ?? 'firebase');
     };
     getSelectedProvider();
   }, [notificationConfigItems]);
 
-  const storeProvider = useCallback(async (item: { label: string, name: string, id: string }) => {
-      await AsyncStore.setItem('@stream-rn-sampleapp-push-provider', item);
-      setSelectedProvider(item.id);
+  const storeProvider = useCallback(async (item: NotificationConfigItem) => {
+    await AsyncStore.setItem('@stream-rn-sampleapp-push-provider', item);
+    setSelectedProvider(item.id);
   }, []);
 
   const removeAllDevices = useCallback(async () => {
@@ -81,14 +188,18 @@ export const SecretMenu = ({ close, visible, chatClient }: { close: () => void, 
           >
             Notification Provider
           </Text>
-          {isAndroid ? null : <View style={{ marginLeft: 16 }}>
-            {notificationConfigItems.map((item) => (
-              <TouchableOpacity key={item.id} style={{ paddingTop: 8, flexDirection: 'row' }} onPress={() => storeProvider(item)}>
-                <Text style={styles.notificationItem}>{item.label}</Text>
-                {item.id === selectedProvider ? <Check height={16} pathFill={'green'} width={16} style={{ marginLeft: 12 }} /> : null}
-              </TouchableOpacity>
-            ))}
-          </View>}
+          {isAndroid ? null : (
+            <View style={{ marginLeft: 16 }}>
+              {notificationConfigItems.map((item) => (
+                <SecretMenuNotificationConfigItem
+                  key={item.id}
+                  notificationConfigItem={item}
+                  storeProvider={storeProvider}
+                  isSelected={item.id === selectedProvider}
+                />
+              ))}
+            </View>
+          )}
         </View>
       </View>
       <TouchableOpacity onPress={removeAllDevices} style={menuDrawerStyles.menuItem}>
@@ -126,9 +237,24 @@ export const SecretMenu = ({ close, visible, chatClient }: { close: () => void, 
 
 export const styles = StyleSheet.create({
   separator: { height: 1, width: '100%', opacity: 0.2 },
-  notificationContainer: {},
+  notificationItemContainer: {
+    paddingTop: 8,
+    marginTop: 12,
+    borderRadius: 15,
+    borderWidth: 2,
+    padding: 8,
+    width: 225,
+  },
   notificationItem: {
-    fontSize: 13,
+    fontSize: 15,
     fontWeight: '500',
+  },
+  submitButton: {
+    flex: 1,
+    marginTop: 8,
+    borderRadius: 5,
+    backgroundColor: 'lightskyblue',
+    padding: 8,
+    alignItems: 'center',
   },
 });

--- a/examples/SampleApp/src/screens/AdvancedUserSelectorScreen.tsx
+++ b/examples/SampleApp/src/screens/AdvancedUserSelectorScreen.tsx
@@ -121,6 +121,7 @@ export const LabeledTextInput: React.FC<LabeledTextInputProps> = ({
         placeholder={label}
         placeholderTextColor={grey}
         returnKeyType='next'
+        numberOfLines={1}
         style={[
           styles.input,
           {
@@ -234,7 +235,7 @@ export const AdvancedUserSelectorScreen: React.FC = () => {
                   });
                 } catch (e) {
                   Alert.alert(
-                    'Login resulted in error. Please make sure you have entered valid credentials',
+                    `Login resulted in error. Please make sure you have entered valid credentials. Error: ${(e as Error).message}`,
                   );
                   console.warn(e);
                 }


### PR DESCRIPTION
## 🎯 Goal

A new entry is added to the secret menu, which allows the provider name to be overridden of the currently selected provider. The name persists through reloads and such. Needed for debugging the new PN architecture.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


