### PR TITLE
fix: onViewableItemsChanged invariant violation

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -443,7 +443,7 @@ const MessageListWithContext = <
    * FlatList doesn't accept changeable function for onViewableItemsChanged prop.
    * Thus useRef.
    */
-  const onViewableItemsChanged = ({
+  const unstableOnViewableItemsChanged = ({
     viewableItems,
   }: {
     viewableItems: ViewToken[] | undefined;
@@ -456,6 +456,16 @@ const MessageListWithContext = <
     }
     updateStickyUnreadIndicator(viewableItems);
   };
+
+  const onViewableItemsChanged = useRef(unstableOnViewableItemsChanged);
+  onViewableItemsChanged.current = unstableOnViewableItemsChanged;
+
+  const stableOnViwableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: ViewToken[] | undefined }) => {
+      onViewableItemsChanged.current({ viewableItems });
+    },
+    [],
+  );
 
   /**
    * Resets the pagination trackers, doing so cancels currently scheduled loading more calls
@@ -1136,7 +1146,7 @@ const MessageListWithContext = <
           onScrollEndDrag={onScrollEndDrag}
           onScrollToIndexFailed={onScrollToIndexFailedRef.current}
           onTouchEnd={dismissImagePicker}
-          onViewableItemsChanged={onViewableItemsChanged}
+          onViewableItemsChanged={stableOnViwableItemsChanged}
           ref={refCallback}
           renderItem={renderItem}
           scrollEnabled={overlay === 'none'}


### PR DESCRIPTION
## 🎯 Goal

It appears that for some RN versions we still have the issue of `onViewableItemsChanged` throwing an invariant violation whenever it changes dynamically, causing a regression here. We can keep this workaround for now and get rid of it on the next major release.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


