### PR TITLE
fix: return properly sorted messages from offline DB

### DIFF
--- a/package/src/store/apis/queries/selectMessagesForChannels.ts
+++ b/package/src/store/apis/queries/selectMessagesForChannels.ts
@@ -30,7 +30,7 @@ export const selectMessagesForChannels = async (
         *,
         ROW_NUMBER() OVER (
           PARTITION BY cid
-          ORDER BY datetime(createdAt) DESC
+          ORDER BY cast(strftime('%s', createdAt) AS INTEGER) ASC
         ) RowNum
       FROM messages
       WHERE cid in (${questionMarks})


### PR DESCRIPTION
## 🎯 Goal

This PR fixes a regression that we introduced about a month ago which causes a specific chain of events to break pagination in the `MessageList` whenever offline support is enabled. 

Steps to reproduce:

- Open a freshly installed app
- Load the `ChannelList` component
- Close the app or log out (this is important, so that we don't receive any WS events)
- Receive some messages in a channel (anything >= 1 message)
- Open the app again
- Open the channel which received messages
- You are now unable to paginate to previous messages

With a recent bugfix to pagination, we pessimistically set the pagination cursors to `false` as an initial value. The bugfix relies on the fact that whenever we query for new messages, we should heuristically be able to figure out whether we have earlier (or later) messages to load through the sorting of the messages. However, when offline support is enabled we do not in fact do a query first as we optimistically fetch whatever's in the DB and only then query. This causes the pagination state to be irreparably broken and unable to recover (even with closing and reopening the app).

The culprit was the fact that we were not properly sorting messages from our local `SQLite` instance and they arrived in reverse order, breaking the heuristics. After the messages are consumed, sorting is still applied so it was not noticeable at all. This "issue" has been dormant for a very long time, however due to the fact that we always had the pagination cursors set to `true` initially the issue has not surfaced until now.

The reason why the sorting is wrong is because `SQLite` has a hard time parsing `ISOString` instances of a date. This means that it will lose precision and sometimes even fallback to alternative sorting if it cannot figure the input out. In our case, it caused the order of the messages to be reversed as it falls back to sorting lexicographically (and `ISOString`s can be sorted like so) causing the bug. 

To fix this, we resort to converting the date into a UNIX timestamp and sorting that way, as it's:

- Much more precise
- Much quicker

Linear ticket: https://linear.app/stream/issue/REACT-306/pagination-sometimes-breaks-when-offline-support-is-enabled

Possibly also fixes this GH issue: https://github.com/GetStream/stream-chat-react-native/issues/2994

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


