### PR TITLE
chore: remove support for react-native-document-picker

### DIFF
--- a/package/native-package/package.json
+++ b/package/native-package/package.json
@@ -29,7 +29,6 @@
     "react-native": ">=0.67.0",
     "react-native-audio-recorder-player": ">=3.6.4",
     "react-native-blob-util": ">=0.19.9",
-    "react-native-document-picker": ">=9.3.0",
     "@react-native-documents/picker": ">=10.1.1",
     "react-native-haptic-feedback": ">=2.2.0",
     "react-native-image-picker": ">=7.1.2",
@@ -47,9 +46,6 @@
       "optional": true
     },
     "react-native-share": {
-      "optional": true
-    },
-    "react-native-document-picker": {
       "optional": true
     },
     "@react-native-documents/picker": {

--- a/package/native-package/src/optionalDependencies/pickDocument.ts
+++ b/package/native-package/src/optionalDependencies/pickDocument.ts
@@ -1,7 +1,7 @@
 /**
  * Types are approximated from what we need from the DocumentPicker API.
  *
- * For its full API, see https://github.com/rnmods/react-native-document-picker/blob/master/src/index.tsx
+ * For its full API, see https://github.com/react-native-documents/document-picker/blob/main/packages/document-picker/src/index.ts
  * */
 type ResponseValue = {
   name: string;
@@ -19,31 +19,12 @@ type DocumentPickerType =
 
 let DocumentPicker: DocumentPickerType;
 
-let OldDocumentPicker: DocumentPickerType;
-let NewDocumentPicker: DocumentPickerType;
-
 try {
-  NewDocumentPicker = require('@react-native-documents/picker');
+  DocumentPicker = require('@react-native-documents/picker');
 } catch (err) {
-  // we log below
-}
-
-try {
-  OldDocumentPicker = require('react-native-document-picker').default;
-} catch (err) {
-  // we log below
-}
-
-if (NewDocumentPicker) {
-  DocumentPicker = NewDocumentPicker;
-} else if (OldDocumentPicker) {
-  DocumentPicker = OldDocumentPicker;
+  // do nothing
   console.log(
-    "You're using the react-native-document-picker library, which is no longer supported and has moved to @react-native-documents/picker. Things might not work as intended. Please migrate to the new library as soon as possible !",
-  );
-} else {
-  console.log(
-    'Neither react-native-document-picker nor @react-native-documents/picker are installed.',
+    'The @react-native-documents/picker is not installed. Installing it will enable you to pick and upload files from within your app.',
   );
 }
 


### PR DESCRIPTION
## 🎯 Goal

Since we had to keep support for both `react-native-document-picker` and `@react-native-documents/picker` in V6, in V7 we remove support for the stale `react-native-document-picker`. 

This change is done as part of this Linear ticket: https://linear.app/stream/issue/RN-148/v7-of-the-stream-chat-react-native-sdk

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


