### PR TITLE
fix: initial scroll to first unread v5

### DIFF
--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install && Build - SDK and Sample App
         uses: ./.github/actions/install-and-build-sdk
       - name: Cache iOS pods
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: examples/SampleApp/ios/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('examples/SampleApp/ios/Podfile.lock') }}

--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build_and_deploy_ios_testflight_qa:
     name: Build SampleApp iOS and Deploy-${{ github.ref == 'refs/heads/V5' }}
-    runs-on: [macos-14]
+    runs-on: [macos-15]
     steps:
       - name: Connect Bot
         uses: webfactory/ssh-agent@v0.7.0
@@ -33,7 +33,9 @@ jobs:
             ${{ runner.os }}-pods-
       - name: iOS Pods setup
         working-directory: examples/SampleApp/ios
-        run: bundle exec pod install
+        run: |
+          pod update hermes-engine --no-repo-update
+          bundle exec pod install
       - name: Build and release Testflight QA
         working-directory: examples/SampleApp
         run: bundle exec fastlane deploy_to_testflight_qa deploy:${{ github.ref == 'refs/heads/V5' }};

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -203,7 +203,7 @@ export const reactionData: ReactionData[] = [
  * If count of unread messages is less than 4, then no need to scroll to first unread message,
  * since first unread message will be in visible frame anyways.
  */
-const scrollToFirstUnreadThreshold = 4;
+const scrollToFirstUnreadThreshold = 0;
 
 const defaultThrottleInterval = 500;
 const defaultDebounceInterval = 500;
@@ -1042,6 +1042,7 @@ const ChannelWithContext = <
       },
       () => {
         if (unreadMessageIdToScrollTo) {
+          setTargetedMessage(unreadMessageIdToScrollTo);
           restartSetsMergeFuncRef.current();
         }
       },


### PR DESCRIPTION
## 🎯 Goal

This PR fixes a bug in V5 where scrolling to the first unread message was behaving in a weird way. It either sometimes would not happen or when it did it would not respect message sets properly. 

This PR should fix these issues.

Closes [this Zendesk ticket](https://getstream.zendesk.com/agent/tickets/62480) and [this Linear issue](https://linear.app/stream/issue/RN-157/issue-with-initialscrolltofirstunreadmessage-functionality-in-channel).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


