### PR TITLE
fix Infinite `useEffect` loop in audio playback

### DIFF
--- a/package/src/hooks/useAudioPlayer.ts
+++ b/package/src/hooks/useAudioPlayer.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { NativeHandlers, SoundReturnType } from '../native';
 
@@ -15,7 +15,7 @@ export const useAudioPlayer = (props: UseSoundPlayerProps) => {
 
   const isExpoCLI = NativeHandlers.SDK === 'stream-chat-expo';
 
-  const playAudio = async () => {
+  const playAudio = useCallback(async () => {
     if (isExpoCLI) {
       if (soundRef.current?.playAsync) {
         await soundRef.current.playAsync();
@@ -25,9 +25,9 @@ export const useAudioPlayer = (props: UseSoundPlayerProps) => {
         soundRef.current.resume();
       }
     }
-  };
+  }, [soundRef.current, isExpoCLI]);
 
-  const pauseAudio = async () => {
+  const pauseAudio = useCallback(async () => {
     if (isExpoCLI) {
       if (soundRef.current?.pauseAsync) {
         await soundRef.current.pauseAsync();
@@ -37,7 +37,7 @@ export const useAudioPlayer = (props: UseSoundPlayerProps) => {
         soundRef.current.pause();
       }
     }
-  };
+  }, [soundRef.current, isExpoCLI]);
 
   const seekAudio = async (currentTime: number) => {
     if (isExpoCLI) {


### PR DESCRIPTION
## 🎯 Goal

Fix the bug described in #3036, where playing a voice note triggers an infinite `useEffect` loop, causing a massive performance impact, and even crashing the React Native bridge when using the old architecture

## 🛠 Implementation details

Wraps `pauseAudio` and `playAudio` in `useCallback` to avoid having the refs of these functions being redefined on each re-render of the `AudioAttachment` component. This avoids the `useEffect` being re-triggered on each render, causing another render indefinitely.

## 🎨 UI Changes

None

## 🧪 Testing

The reproduction steps for the issue have been described in #3036 . Applying this fix on the reproduction repo fixes the issue.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated (irrelevant)
- [ ] New code is tested in main example apps, including all possible scenarios (tested in the reproduction repo instead)
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


