### PR TITLE
fix: audio component recursive loading for expo

### DIFF
--- a/package/src/components/Attachment/AudioAttachment.tsx
+++ b/package/src/components/Attachment/AudioAttachment.tsx
@@ -208,10 +208,14 @@ export const AudioAttachment = (props: AudioAttachmentProps) => {
       if (!isExpoCLI) {
         return;
       }
-      if (item.paused) {
-        await pauseAudio();
-      } else {
-        await playAudio();
+      try {
+        if (item.paused) {
+          await pauseAudio();
+        } else {
+          await playAudio();
+        }
+      } catch (e) {
+        console.log('An error has occurred while trying to interact with the audio. ', e);
       }
     };
     // For expo CLI

--- a/package/src/hooks/useAudioPlayer.ts
+++ b/package/src/hooks/useAudioPlayer.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { NativeHandlers, SoundReturnType } from '../native';
 
@@ -15,7 +15,7 @@ export const useAudioPlayer = (props: UseSoundPlayerProps) => {
 
   const isExpoCLI = NativeHandlers.SDK === 'stream-chat-expo';
 
-  const playAudio = async () => {
+  const playAudio = useCallback(async () => {
     if (isExpoCLI) {
       if (soundRef.current?.playAsync) {
         await soundRef.current.playAsync();
@@ -25,9 +25,9 @@ export const useAudioPlayer = (props: UseSoundPlayerProps) => {
         soundRef.current.resume();
       }
     }
-  };
+  }, [isExpoCLI, soundRef]);
 
-  const pauseAudio = async () => {
+  const pauseAudio = useCallback(async () => {
     if (isExpoCLI) {
       if (soundRef.current?.pauseAsync) {
         await soundRef.current.pauseAsync();
@@ -37,39 +37,45 @@ export const useAudioPlayer = (props: UseSoundPlayerProps) => {
         soundRef.current.pause();
       }
     }
-  };
+  }, [isExpoCLI, soundRef]);
 
-  const seekAudio = async (currentTime: number) => {
-    if (isExpoCLI) {
-      if (currentTime === 0) {
-        // If currentTime is 0, we should replay the video from 0th position.
-        if (soundRef.current?.replayAsync) {
-          await soundRef.current.replayAsync({
-            positionMillis: 0,
-            shouldPlay: false,
-          });
+  const seekAudio = useCallback(
+    async (currentTime: number) => {
+      if (isExpoCLI) {
+        if (currentTime === 0) {
+          // If currentTime is 0, we should replay the video from 0th position.
+          if (soundRef.current?.replayAsync) {
+            await soundRef.current.replayAsync({
+              positionMillis: 0,
+              shouldPlay: false,
+            });
+          }
+        } else {
+          if (soundRef.current?.setPositionAsync) {
+            await soundRef.current.setPositionAsync(currentTime * 1000);
+          }
         }
       } else {
-        if (soundRef.current?.setPositionAsync) {
-          await soundRef.current.setPositionAsync(currentTime * 1000);
+        if (soundRef.current?.seek) {
+          soundRef.current.seek(currentTime);
         }
       }
-    } else {
-      if (soundRef.current?.seek) {
-        soundRef.current.seek(currentTime);
-      }
-    }
-  };
+    },
+    [isExpoCLI, soundRef],
+  );
 
-  const changeAudioSpeed = async (speed: number) => {
-    // Handled through prop `rate` in `Sound.Player`
-    if (!isExpoCLI) {
-      return;
-    }
-    if (soundRef.current?.setRateAsync) {
-      await soundRef.current.setRateAsync(speed);
-    }
-  };
+  const changeAudioSpeed = useCallback(
+    async (speed: number) => {
+      // Handled through prop `rate` in `Sound.Player`
+      if (!isExpoCLI) {
+        return;
+      }
+      if (soundRef.current?.setRateAsync) {
+        await soundRef.current.setRateAsync(speed);
+      }
+    },
+    [isExpoCLI, soundRef],
+  );
 
   return { changeAudioSpeed, pauseAudio, playAudio, seekAudio };
 };


### PR DESCRIPTION
## 🎯 Goal

Fixes [this Github issue](https://github.com/GetStream/stream-chat-react-native/issues/3036).

Tons of credit to @thib92 for the [initial fix](https://github.com/GetStream/stream-chat-react-native/pull/3037) !

Linear issue: https://linear.app/stream/issue/RN-173/[]-voice-message-playback-runs-an-infinite-useeffect-loop-in-v6

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


