### PR TITLE
fix: bottom sheet animations on new reactions

### DIFF
--- a/package/expo-package/yarn.lock
+++ b/package/expo-package/yarn.lock
@@ -4733,10 +4733,10 @@ stream-buffers@2.2.x, stream-buffers@~2.2.0:
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
   integrity sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==
 
-stream-chat-react-native-core@6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.7.0.tgz#d9e8c8ca57db93f148ef8acab93d3552f425eb36"
-  integrity sha512-Ue/euBMJ2h/H33hp58znfOMFzocgyW+dqvS8qiCooO5RZ26zQYGSDvmp8TeYyiBpqwM927vqfrPmPqOeXb12IQ==
+stream-chat-react-native-core@6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.7.1.tgz#37cdfbc5c7f8a5bac5634b954da4bbdcd2fb95f2"
+  integrity sha512-4ePEMt1W+iw3zUulSDRFO9Nt4HPa8kW6wJ3Qv+ZN+y886rvcUuTuH18MFrdrJtHYb+UxCU+X3oz++3qzq7Jzxw==
   dependencies:
     "@gorhom/bottom-sheet" "^5.1.1"
     dayjs "1.10.5"

--- a/package/native-package/yarn.lock
+++ b/package/native-package/yarn.lock
@@ -3409,10 +3409,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stream-chat-react-native-core@6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.7.0.tgz#d9e8c8ca57db93f148ef8acab93d3552f425eb36"
-  integrity sha512-Ue/euBMJ2h/H33hp58znfOMFzocgyW+dqvS8qiCooO5RZ26zQYGSDvmp8TeYyiBpqwM927vqfrPmPqOeXb12IQ==
+stream-chat-react-native-core@6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-6.7.1.tgz#37cdfbc5c7f8a5bac5634b954da4bbdcd2fb95f2"
+  integrity sha512-4ePEMt1W+iw3zUulSDRFO9Nt4HPa8kW6wJ3Qv+ZN+y886rvcUuTuH18MFrdrJtHYb+UxCU+X3oz++3qzq7Jzxw==
   dependencies:
     "@gorhom/bottom-sheet" "^5.1.1"
     dayjs "1.10.5"

--- a/package/src/components/UIComponents/BottomSheetModal.tsx
+++ b/package/src/components/UIComponents/BottomSheetModal.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useEffect } from 'react';
+import React, { PropsWithChildren, useEffect, useMemo } from 'react';
 import {
   Animated,
   Keyboard,
@@ -50,13 +50,17 @@ export const BottomSheetModal = (props: PropsWithChildren<BottomSheetModalProps>
     },
   } = useTheme();
 
-  const translateY = new Animated.Value(height);
+  const translateY = useMemo(() => new Animated.Value(height), [height]);
 
-  const openAnimation = Animated.timing(translateY, {
-    duration: 200,
-    toValue: 0,
-    useNativeDriver: true,
-  });
+  const openAnimation = useMemo(
+    () =>
+      Animated.timing(translateY, {
+        duration: 200,
+        toValue: 0,
+        useNativeDriver: true,
+      }),
+    [translateY],
+  );
 
   const closeAnimation = Animated.timing(translateY, {
     duration: 50,


### PR DESCRIPTION
## 🎯 Goal

This PR fixes a nasty bug where if the reaction list is open, receiving new reactions would trigger a run of an effect that handles the animation. 

Linear ticket: https://linear.app/stream/issue/RN-185/receiving-new-reaction-while-reaction-list-is-open-causes-unwanted

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


