### PR TITLE
Provide additionalInfo to onLongPressProp

### DIFF
--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -656,6 +656,7 @@ const MessageWithContext = <
         emitter: payload?.emitter || 'message',
         event: payload?.event,
         message,
+        additionalInfo: payload && 'additionalInfo' in payload ? payload.additionalInfo : undefined,
       };
 
       const handleOnLongPress = () => {


### PR DESCRIPTION
## 🎯 Goal

I noticed my custom onLongPressProp wasn't receiving `additionalnfo` about the press (e.g. specific thumbnail that was long pressed).  I want to be able to take action based off the specific thumbnail that was long pressed in my custom `onLongPress` function. To do this I need access to the additional info objet.
## 🛠 Implementation details

This change passes the `additionalInfo` object to prop `onLongPress` functions.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


