### PR TITLE
fix: thread messages setting broken

### DIFF
--- a/package/src/contexts/channelsStateContext/useChannelState.ts
+++ b/package/src/contexts/channelsStateContext/useChannelState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import type { Channel as ChannelType } from 'stream-chat';
+import type { Channel as ChannelType, LocalMessage } from 'stream-chat';
 
 import { useChannelsStateContext } from './ChannelsStateContext';
 
@@ -45,7 +45,7 @@ export function useChannelState(
   const cid = channel?.id || 'id'; // in case channel is not initialized, use generic id string for indexing
   const { setState, state } = useChannelsStateContext();
 
-  const [threadMessages, setThreadMessages] = useStateManager(
+  const [threadMessages, setThreadMessagesInternal] = useStateManager(
     {
       cid,
       key: 'threadMessages',
@@ -53,6 +53,10 @@ export function useChannelState(
       state,
     },
     (threadId && channel?.state?.threads?.[threadId]) || [],
+  );
+  const setThreadMessages = useCallback(
+    (value: LocalMessage[]) => setThreadMessagesInternal([...value]),
+    [setThreadMessagesInternal],
   );
 
   return {

--- a/package/src/contexts/channelsStateContext/useChannelState.ts
+++ b/package/src/contexts/channelsStateContext/useChannelState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import type { Channel as ChannelType, LocalMessage } from 'stream-chat';
+import type { Channel as ChannelType } from 'stream-chat';
 
 import { useChannelsStateContext } from './ChannelsStateContext';
 
@@ -55,7 +55,7 @@ export function useChannelState(
     (threadId && channel?.state?.threads?.[threadId]) || [],
   );
   const setThreadMessages = useCallback(
-    (value: LocalMessage[]) => setThreadMessagesInternal([...value]),
+    (value: ChannelState['threadMessages']) => setThreadMessagesInternal([...value]),
     [setThreadMessagesInternal],
   );
 


### PR DESCRIPTION
## 🎯 Goal

This is an interesting bug that we caught within smoke testing of V7.

Essentially, this has been a dormant issue in the SDK for ages; pretty much relying on the fact that our `MessageList` would rerender literally every time one of its parents rerendered (and completely rereference its `data` in the process). In that regard, this would work because of cascading state updates that happened on the `Channel` HoC level.

Since this was fixed in one of the recent performance improvement PRs, the faulty behaviour was no longer in place and the dormant bug came to the horizon.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


