### PR TITLE
fix: keybaord taking full screen issue when the prefer cross-fade transition setting is enabled on iOS

### DIFF
--- a/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
+++ b/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
@@ -58,7 +58,12 @@ export class KeyboardCompatibleView extends React.Component<
 
   _relativeKeyboardHeight(keyboardFrame: KeyboardMetrics) {
     const frame = this._frame;
-    if (!frame || !keyboardFrame) {
+    /**
+     * With iOS 14 & Reduce Motion > Prefer Cross-Fade Transitions enabled, the keyboard position
+     * height is reported differently (0 instead of Y position value) which caused the view to take full height
+     * of the screen.
+     */
+    if (!frame || !keyboardFrame || keyboardFrame.screenY === 0) {
       return 0;
     }
 


### PR DESCRIPTION
The fix is as per the patch provided here - https://github.com/facebook/react-native/issues/29974#issuecomment-700804626