### PR TITLE
fix: prefer error screen over loading screen

### DIFF
--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -282,7 +282,7 @@ export const usePaginatedChannels = ({
           // ready. I do not like providing a way to set the ready state, as it should be managed
           // in the LLC entirely. Once we move offline support to the LLC, we can remove this check
           // too as it'll be redundant.
-          pagination?.isLoading || (!channelListInitialized && channels.length === 0),
+          pagination?.isLoading || (!channelListInitialized && channels.length === 0 && !error),
     loadingNextPage: pagination?.isLoadingNext,
     loadNextPage: channelManager.loadNext,
     refreshing: activeQueryType === 'refresh',


### PR DESCRIPTION
## 🎯 Goal

Fixes [this Zendesk ticket](https://getstream.zendesk.com/agent/tickets/64773).

In the event of an error occurring while the `ChannelList` is loading, the `error` state is not preferred over the loading one and in due to how offline support works on the current version, we need to have an extra check for loading because of it which was causing as stuck loading state. 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


