### PR TITLE
fix: use useSyncExternalStore in the useStateStore hook

### DIFF
--- a/package/src/hooks/useStateStore.ts
+++ b/package/src/hooks/useStateStore.ts
@@ -1,6 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import type { StateStore } from 'stream-chat';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
+
+const noop = () => {};
 
 export function useStateStore<
   T extends Record<string, unknown>,
@@ -14,22 +17,48 @@ export function useStateStore<
   T extends Record<string, unknown>,
   O extends Readonly<Record<string, unknown> | Readonly<unknown[]>>,
 >(store: StateStore<T> | undefined, selector: (v: T) => O) {
-  const [state, setState] = useState<O | undefined>(() => {
-    if (!store) {
-      return undefined;
-    }
-    return selector(store.getLatestValue());
-  });
+  const wrappedSubscription = useCallback(
+    (onStoreChange: () => void) => {
+      const unsubscribe = store?.subscribeWithSelector(selector, onStoreChange);
+      return unsubscribe ?? noop;
+    },
+    [store, selector],
+  );
 
-  useEffect(() => {
-    if (!store) {
-      return;
-    }
+  const wrappedSnapshot = useMemo(() => {
+    let cachedTuple: [T, O];
 
-    const unsubscribe = store.subscribeWithSelector(selector, setState);
+    return () => {
+      const currentValue = store?.getLatestValue();
 
-    return unsubscribe;
+      if (!currentValue) return undefined;
+
+      // store value hasn't changed, no need to compare individual values
+      if (cachedTuple && cachedTuple[0] === currentValue) {
+        return cachedTuple[1];
+      }
+
+      const newlySelected = selector(currentValue);
+
+      // store value changed but selected values wouldn't have to, double-check selected
+      if (cachedTuple) {
+        let selectededAreEqualToCached = true;
+
+        for (const key in cachedTuple[1]) {
+          if (cachedTuple[1][key] === newlySelected[key]) continue;
+          selectededAreEqualToCached = false;
+          break;
+        }
+
+        if (selectededAreEqualToCached) return cachedTuple[1];
+      }
+
+      cachedTuple = [currentValue, newlySelected];
+      return cachedTuple[1];
+    };
   }, [store, selector]);
+
+  const state = useSyncExternalStore(wrappedSubscription, wrappedSnapshot);
 
   return state;
 }


### PR DESCRIPTION
The goal of the PR is inspired by https://github.com/GetStream/stream-chat-react/pull/2573. I was trying to reply to a message where I noticed that when replying to a poll message, and then if you reply to some other message, the poll message doesn't go away from the UI, and that is because of https://github.com/GetStream/stream-chat-react-native/blob/develop/package/src/components/Reply/Reply.tsx#L180 not resetting as it should. React added this change in the past to the `useStateStore` hook they have, which we never added to fix a similar bug. This is a possible fix to the issue, as previously changing the store in the hook would keep the previously calculated state and return it. 

**Prev**

https://github.com/user-attachments/assets/050b5709-21f9-4950-9bf5-14e550494278



**Now**



https://github.com/user-attachments/assets/0ba54f02-049d-459c-a80b-51d72a0e3ed2


