### PR TITLE
fix: visibility of unread notification and underlay in certain scenarios

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -1064,6 +1064,7 @@ const ChannelWithContext = (props: PropsWithChildren<ChannelPropsWithContext>) =
         if (failedMessages?.length) {
           channel.state.addMessagesSorted(failedMessages);
         }
+        await markRead();
         channel.state.setIsUpToDate(true);
       } else {
         await reloadThread();

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -425,7 +425,6 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
     // the unread notification to appear (for example if the old last read messages
     // go out of the viewport).
     if (processedMessageList.length !== messagesLength.current) {
-      setIsUnreadNotificationOpen(false);
       return;
     }
     messagesLength.current = processedMessageList.length;


### PR DESCRIPTION
## 🎯 Goal

This PR should fix 2 things:

- Unreliable visibility of the unread message notification (especially when sending longer messages that would take the last read message out of the viewport)
- Display of the unread message overlay when message sending is delayed (for example, if we send 5-6 consecutive videos which would take time to upload in the offline case)

The general idea is that if the length of the message list changes after the initial time the notification was rendered, we can safely assume that we're present in the channel and do not need to see the notification. Marking a message as unread should still work as intended.

Should also fix [this Zendesk ticket](https://getstream.zendesk.com/agent/tickets/65229).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


