### PR TITLE
docs: update README.md to make expo-package path clear

### DIFF
--- a/examples/ExpoMessaging/README.md
+++ b/examples/ExpoMessaging/README.md
@@ -26,7 +26,7 @@ yarn install
 cd package && yarn install
 ```
 
-3. Move to the `expo-package` directory and install the dependencies:
+3. Move to the `package/expo-package` directory and install the dependencies:
 
 ```bash
 cd expo-package && yarn install


### PR DESCRIPTION
The readme was a bit confusing - it should mention that expo-package is under the package directory.  I looked for it at the root and didn't see it.

## 🎯 Goal

Make readme clear

## 🛠 Implementation details

Update readme
## 🧪 Testing

Not applicable

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


