### PR TITLE
fix: properly set minIndexForVisible

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -345,10 +345,6 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
     [autoscrollToRecent, minIndexForVisible],
   );
 
-  useEffect(() => {
-    console.log('CHANGED: ', maintainVisibleContentPosition);
-  }, [maintainVisibleContentPosition]);
-
   /**
    * We want to call onEndReached and onStartReached only once, per content length.
    * We keep track of calls to these functions per content length, with following trackers.

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -335,13 +335,19 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
 
   const [autoscrollToRecent, setAutoscrollToRecent] = useState(false);
 
+  const minIndexForVisible = Math.min(1, processedMessageList.length);
+
   const maintainVisibleContentPosition = useMemo(
     () => ({
       autoscrollToTopThreshold: autoscrollToRecent ? 10 : undefined,
-      minIndexForVisible: 1,
+      minIndexForVisible,
     }),
-    [autoscrollToRecent],
+    [autoscrollToRecent, minIndexForVisible],
   );
+
+  useEffect(() => {
+    console.log('CHANGED: ', maintainVisibleContentPosition);
+  }, [maintainVisibleContentPosition]);
 
   /**
    * We want to call onEndReached and onStartReached only once, per content length.
@@ -620,7 +626,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
   }, [threadList, messageListLengthAfterUpdate, topMessageAfterUpdate?.id]);
 
   useEffect(() => {
-    if (!rawMessageList.length) {
+    if (!processedMessageList.length) {
       return;
     }
     if (threadList) {
@@ -637,7 +643,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
     }
     const latestNonCurrentMessageBeforeUpdate = latestNonCurrentMessageBeforeUpdateRef.current;
     latestNonCurrentMessageBeforeUpdateRef.current = undefined;
-    const latestCurrentMessageAfterUpdate = rawMessageList[rawMessageList.length - 1];
+    const latestCurrentMessageAfterUpdate = processedMessageList[0];
     if (!latestCurrentMessageAfterUpdate) {
       setAutoscrollToRecent(true);
       return;
@@ -662,7 +668,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [channel, rawMessageList, threadList]);
+  }, [channel, processedMessageList, threadList]);
 
   const goToMessage = useStableCallback(async (messageId: string) => {
     const indexOfParentInMessageList = processedMessageList.findIndex(


### PR DESCRIPTION
## 🎯 Goal

This PR addresses an issue where the `MessageList`'s underlying `FlatList` would get caught in a weird infinite scrolling (into nothing) state whenever we removed the last `item` inside of it. 

This was particularly obvious on `threads`, with the following reproduction steps:

- Set `deletedMessagesVisibilityType={'never'}` on the `Channel` component encapsulating a `Thread`
- Create a `thread` from a message
- Write a single `message` into the `thread`
- Delete the message (no `Deleted Message` default as we set the visibility to `never`)
- The `FlatList` would now spin endlessly

The actual issue is that the `FlatList` completely bugs out whenever we pass it an `index` it can clearly not find (since the message got deleted, the index no longer exists. Instead, we keep the `minIndexForVisible` set to `1` for anything other than an empty list. 

Should also close [this Github issue](https://github.com/GetStream/stream-chat-react-native/issues/3101).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


