### PR TITLE
feat: add reminders implementation

### DIFF
--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -10,8 +10,10 @@ import {
   OverlayProvider,
   setupCommandUIMiddlewares,
   SqliteClient,
+  Streami18n,
   ThemeProvider,
   useOverlayContext,
+  enTranslations,
 } from 'stream-chat-react-native';
 import { getMessaging } from '@react-native-firebase/messaging';
 import notifee, { EventType } from '@notifee/react-native';
@@ -201,16 +203,28 @@ const DrawerNavigatorWrapper: React.FC<{
   chatClient: StreamChat;
 }> = ({ chatClient }) => {
   const streamChatTheme = useStreamChatTheme();
+  const streami18n = new Streami18n();
+
+  streami18n.registerTranslation('en', {
+    ...enTranslations,
+    'Due since {{ dueSince }}': 'Due since {{ dueSince }}',
+    'Due {{ timeLeft }}': 'Due {{ timeLeft }}',
+    'duration/Message reminder': '{{ milliseconds | durationFormatter(withSuffix: true) }}',
+    'duration/Remind Me': '{{ milliseconds | durationFormatter(withSuffix: true) }}',
+    'timestamp/Remind me': '{{ milliseconds | durationFormatter(withSuffix: true) }}',
+    'timestamp/ReminderNotification': '{{ timestamp | timestampFormatter(calendar: true) }}',
+  });
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <OverlayProvider value={{ style: streamChatTheme }}>
+      <OverlayProvider value={{ style: streamChatTheme }} i18nInstance={streami18n}>
         <Chat
           client={chatClient}
           enableOfflineSupport
           // @ts-expect-error - the `ImageComponent` prop is generic, meaning we can expect an error
           ImageComponent={FastImage}
           isMessageAIGenerated={isMessageAIGenerated}
+          i18nInstance={streami18n}
         >
           <AppOverlayProvider>
             <UserSearchProvider>

--- a/examples/SampleApp/ios/Podfile.lock
+++ b/examples/SampleApp/ios/Podfile.lock
@@ -2425,7 +2425,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.7.1)
-  - stream-chat-react-native (7.2.0):
+  - stream-chat-react-native (8.0.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2872,7 +2872,7 @@ SPEC CHECKSUMS:
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  stream-chat-react-native: 2de2866392bfecadf005ec5f0b1f882b613b89ba
+  stream-chat-react-native: 14526230f326d59b638dd1e2bd36f105045c7065
   Yoga: b2eaabf17044cd4273a661b14eb83f9fd2c90491
 
 PODFILE CHECKSUM: 4f662370295f8f9cee909f1a4c59a614999a209d

--- a/examples/SampleApp/ios/Podfile.lock
+++ b/examples/SampleApp/ios/Podfile.lock
@@ -2784,7 +2784,7 @@ SPEC CHECKSUMS:
   hermes-engine: 94ed01537bdeccaab1adbf94b040d115d6fa1a7f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  op-sqlite: 6a5255f36253697406618ceba5212d6572012a9d
+  op-sqlite: d7e3053a9518cfb8f763f09a899df7403a9d4eb9
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
@@ -2794,87 +2794,87 @@ SPEC CHECKSUMS:
   React: 114ee161feb204412580928b743e6716aebac987
   React-callinvoker: d175cf3640a993f6cd960044a7657543157f0ba9
   React-Codegen: 4b8b4817cea7a54b83851d4c1f91f79aa73de30a
-  React-Core: e84d47ce3df8dde567f5b9668f6103f8e562d72a
-  React-CoreModules: ce8e588dca54cd790e2d424d0e678924e62b41b1
-  React-cxxreact: 2c10954abacc35e876adf46e25ebfd74a0106521
+  React-Core: cd487c9eeb125c902242bcc76ced12e14adf4ea4
+  React-CoreModules: 202df4f342e5c2893d5d1899b2856879a90d4bf1
+  React-cxxreact: 72be57cebb9976199e6130ec6f9d511c6ae3b310
   React-debug: d2042a489905b47cb1a987bb9eacc81a68e89587
-  React-defaultsnativemodule: caeee1aa6a9bc60c27c3678e96055ada96c37e22
-  React-domnativemodule: 0b7d770c5d3da2bc194091bf9fc68416e9b88670
-  React-Fabric: b8118ef9817c9ccadd7a878d66ae2faf02e59e8a
-  React-FabricComponents: 7da55420b42b55e06b3b9b6a1aad3c7e300885f2
-  React-FabricImage: 2515fa043a9e652b97947231c0a79bfa778cdd37
+  React-defaultsnativemodule: db406c1b44ed9fd30ef9c86a2d0529c4ba8ed8c9
+  React-domnativemodule: f71e27c03fbdeaa5a318576beb99b997267dfa31
+  React-Fabric: 84377d3efd7f7fb832eb48674c64a4f1b75bc68f
+  React-FabricComponents: e99187e0dcd333cba72d7ac931c06dea66c60849
+  React-FabricImage: 0cd0b4b1ad571648c9aa74060075f425bb1a0baf
   React-featureflags: 8d2d86c7d0812ab474cb326b854c987f44633c72
-  React-featureflagsnativemodule: 8a11970c8713104bf7327ca8aa314be250e6d73f
-  React-graphics: 6581de50c43af3a613ae197df886c86a014ed165
-  React-hermes: 2a9fb8df8a1be5e5b065c91d7b0fad072554055e
-  React-idlecallbacksnativemodule: 66d6d2e3c85d19067763d6764cd3159a39b89e60
-  React-ImageManager: 9ab8bc29c0a743ec51f109925f6d961a57a8293e
-  React-jserrorhandler: f51e203fc68469a86d49fc4dbc99254aca68d122
-  React-jsi: 606a42a46f9a7299c1757686c6856eca8346754b
-  React-jsiexecutor: 762ee9c7962597d2f168afee00a0cac7573e6e48
-  React-jsinspector: 8f3969250c71e78f6a1ef9c6109f12cf723bf69c
-  React-jsinspectortracing: 1c7188a624cb28de6b13d69492161ad2265327b6
-  React-jsitooling: 92450f21d15de625ae6f35cd1540164e7ed61e91
-  React-jsitracing: 4185f91ab619c7005a28edcb8b35b5e741460a16
-  React-logger: 44e070aefe084568c02b544b9d7d436703be1a47
-  React-Mapbuffer: ed1f528261013e46790379cc6727b8005e169a67
-  React-microtasksnativemodule: da563fd4cb7ecc23f67b5f15b92dfe94a9791e2d
-  react-native-blob-util: 68f288ed8fd64a191a4d83ffa5a1dd375dc786d2
-  react-native-cameraroll: 71f93f6a1676f322b7913462d3613e70bd2dc675
-  react-native-document-picker: 06ad77eb1650e628def114ff74f9f767f1888edd
-  react-native-image-picker: 6ccf4bb98d38facc22db35fc2ee59a574fca4d16
-  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
-  react-native-safe-area-context: f2e97b088ae5f3078f1ad03f51a44bd84f479053
-  react-native-video: 1e0df051b1d5c4bfc8532d8c8bd68428de4a4081
-  React-NativeModulesApple: c761e39d8bb17a074530cb637ec6fe4460fac3af
+  React-featureflagsnativemodule: bd54ca89ed64d31a61a17fa103a991fcfee70821
+  React-graphics: bad51b93c457bb7517540bc9d112e8218773dfe1
+  React-hermes: a40e47b18c31efe4baa7942357e2327ddab63918
+  React-idlecallbacksnativemodule: 75f7e8b32e74c78124297ba73c1b3e6ac08fd39b
+  React-ImageManager: 529243f1b6094af8a8dd58aef885f9afb1c73d8c
+  React-jserrorhandler: bbd5fd904735fac723afc84d295fb17558956698
+  React-jsi: ae02c9d6d68dbed80a9fde8f6d6198035ca154ce
+  React-jsiexecutor: 8c266057f23430685a2d928703e77eda80e1742e
+  React-jsinspector: 1971f190bf2f1ee72f9e1e0e6f56f2f42024fdb2
+  React-jsinspectortracing: 56c50684abc51cbf959a6bbba4ec20fe02f20259
+  React-jsitooling: 0a516b47b6b1c427751ae2a5537c07dd5af60470
+  React-jsitracing: 6aa49f8c5a07eb1c042a924419ecd5d39c2e2098
+  React-logger: 514fac028fee60c84591f951c7c04ba1c5023334
+  React-Mapbuffer: 02f95b72f631228befdfb7e71ad8e2e12b6dae0d
+  React-microtasksnativemodule: 953b922f9473c100dd153cc51739e0d210bfd617
+  react-native-blob-util: e032f2a9d5779aa94934139a60fe5ed6c5071328
+  react-native-cameraroll: 23d28040c32ca8b20661e0c41b56ab041779244b
+  react-native-document-picker: 1f8a568fcd43ed5ad9e53307d487d1de21c340a4
+  react-native-image-picker: f6ece66f251f4a17aab08f5add7be6eb9e7f5356
+  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
+  react-native-safe-area-context: 8cf8caf5fc0f5a5d3581b650579af9c85c16be04
+  react-native-video: 6a236aa5c7619d4ba9b07ddf965a0b62b1702da3
+  React-NativeModulesApple: 579cac2962d42ffee0d8aae48752f30c4e498bb9
   React-oscompat: f26aa2a4adc84c34212ab12c07988fe19e9cf16a
-  React-perflogger: fb196ad3fa3263afc55f773a10c2741517a27f7c
-  React-performancetimeline: 0d549cebbe759dcbe8efde0fd9cf8922e5788bb8
+  React-perflogger: e15a0d43d1928e1c82f4f0b7fc05f7e9bccfede8
+  React-performancetimeline: 117ad5127882ec6a459435d1397d713e35760be7
   React-RCTActionSheet: c89c8b9b7c3ef87cb6a67e20f5eaea271f4b5f67
-  React-RCTAnimation: 8cff4eda84c7e70c674c50763c724c660ae7e56c
-  React-RCTAppDelegate: 12b784fb29e25a606aaf869d11efb4ae97bb81b3
-  React-RCTBlob: 105ead00cc3cb7ed4180481cec7cb68829c0c16b
-  React-RCTFabric: 5584605ac217c7e66d69bf5b72260e1e64ed8a9a
-  React-RCTFBReactNativeSpec: c3bfd143e072358d0d8b7efc97fb6a09e77f8f46
-  React-RCTImage: ef3831114706dbb9ccab839abe804edef1e1faab
-  React-RCTLinking: eadceef820a11dd2bc7b4b569406eacc637c7f82
-  React-RCTNetwork: 9e1323f0cdfaf0f561d8a6667363cc8deadf41e8
-  React-RCTRuntime: b531dd9beffda4bf014edcbb416eda1411392ac5
-  React-RCTSettings: 482bb7da0e94823cd1a36edd408c85abb2d2e42a
-  React-RCTText: d103fac423b92be0ed295767ea4c2ecc1f4389fd
-  React-RCTVibration: 816504f335105f0682467823400436e18ec98b7b
+  React-RCTAnimation: e00af558ccb5fedd380ae32329be4c38e92e9b90
+  React-RCTAppDelegate: 10d98d4867643322fa4fcd04548359ac88c74656
+  React-RCTBlob: ef645bccf9c33d3b4391794983744da897474dfb
+  React-RCTFabric: bb4d7c817e3228d6e55052a420e6ec2892a6a702
+  React-RCTFBReactNativeSpec: e0942c2c7efa10303c63e287c1c1788aeb6d99ef
+  React-RCTImage: 0e3669a0bda8995874736d0f8f12c21d522df3c4
+  React-RCTLinking: bd81ec3d1b6686a7c58bc8ed8b7a1f05ff2b3f8b
+  React-RCTNetwork: 20b8044841a043b80e7027e1bc4049ffa552d1fa
+  React-RCTRuntime: 13b115119851e0bb55cc7e3f347d763b7c6d9e40
+  React-RCTSettings: fa1d3e6c302e9980b5670315e2ccc998255ce32a
+  React-RCTText: 71f01a9261c015b76702e9d7a4153c9ca45f2341
+  React-RCTVibration: 0e05fa4647ec1391c409fcc1cbd7cdb4894d80ef
   React-rendererconsistency: fd094e5d05a8969e556334496610e66886ab10cb
-  React-renderercss: 7d0c1b296a1712ee17a776eb60589e95d4d6ee2a
-  React-rendererdebug: 6ede134de6beebd53b4917d666142c362b7b6632
+  React-renderercss: f40da71385a7950b778c185e77a3979853f9827c
+  React-rendererdebug: c189ec79cb8a585c973c404f3341c4a8627e3a98
   React-rncore: 9f8b4d93dba987f5209346404ef740c6b6105d73
-  React-RuntimeApple: 53437a180d53b77b14817f41efbdc547a071886d
-  React-RuntimeCore: ab6eab30b91c75b5f07c980dae9cf7951600a33f
+  React-RuntimeApple: 4f2fd7353b517ec268f7fb076976354c1de5d086
+  React-RuntimeCore: 134e3e2982f4afceb751c0b3fdf6c5f3e1768def
   React-runtimeexecutor: 4e7bc0119ff38f80df43d109ef9508497cac1eee
-  React-RuntimeHermes: 16fa50d6afea4bfc8bcc8905b7146b28f838fd80
-  React-runtimescheduler: e44b4ba76d439272d58bd95c0e0750e428b2a6fc
+  React-RuntimeHermes: 0608c43ea0a6e746e964678b343dc439c3e198f8
+  React-runtimescheduler: b9d753b1d34c274261ed14fa35151b38232a7f13
   React-timing: 220bf771493c44a15fdbdedad2cf0a2e3c41edcd
-  React-utils: d6819ad2da189ca066301cf4e41aaad51cef4d16
-  ReactAppDependencyProvider: 552391af67c115d8ee20f9359711e7821145cd96
-  ReactCodegen: 5a3b071aec923e67260550b3f65329f844d691fa
-  ReactCommon: 1dce2374d9dc2cdf634244f1584513b606512750
-  RNAudioRecorderPlayer: 8a1c6ee5080aa83c3f2ccc75d1a43b2ce82b366d
-  RNCAsyncStorage: faf86846c58994b6b8aab074a4914eb1796c2a9f
-  RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
-  RNFBApp: df5caad9f64b6bc87f8a0b110e6bc411fb00a12b
-  RNFBMessaging: 6586f18ab3411aeb3349088c19fe54283d39e529
-  RNGestureHandler: 2fa49aef8b58d35bcc61abe06ffecc4bcc5268a4
-  RNNotifee: 4a6ee5c7deaf00e005050052d73ee6315dff7ec9
-  RNReactNativeHapticFeedback: 85c0a6ff490d52f5e8073040296fefe5945ebbfa
-  RNReanimated: 2b314b18e28adf1b300f606eb0f205a1a6a643e1
-  RNScreens: d9d5d8a2a484bb4446968bfa00db991f1117db44
-  RNShare: 082dae96ef6cabef31d3e6b016d388e71ff0e0d7
-  RNSVG: 1fa61293cb54a97d8ee3b182d2fb60443edcdf69
+  React-utils: a439ca94e40a809a832ad8329698df0146eaccc8
+  ReactAppDependencyProvider: e6d0c3c3cc9862a3ccef0c252835cd7ccb96313d
+  ReactCodegen: 338cfa0d67a821a9caec4888f6f83458dcc69771
+  ReactCommon: 4dbe3f8218c0b6589e982081f503725057457d2b
+  RNAudioRecorderPlayer: 5d5aac7a0e0f159861736ef2b433770342da7197
+  RNCAsyncStorage: c1dca434eda758348a549efb46822b4091d76804
+  RNFastImage: 462a183c4b0b6b26fdfd639e1ed6ba37536c3b87
+  RNFBApp: db9c2e6d36fe579ab19b82c0a4a417ff7569db7e
+  RNFBMessaging: de62448d205095171915d622ed5fb45c2be5e075
+  RNGestureHandler: 9aefee4dffdfa4a32d401a771b8a513ecb507d08
+  RNNotifee: 5e3b271e8ea7456a36eec994085543c9adca9168
+  RNReactNativeHapticFeedback: 1597ab4e15cabb38f0f0c62faa17a5e295430170
+  RNReanimated: 0df48dab58b5ee37fd1d1341caba79f59a1187ec
+  RNScreens: 90b905d545a5ebbe976985702b8a39e3475727b2
+  RNShare: 6300b941668273d502ecee9122cade0d5ea966bd
+  RNSVG: 45e3c3210465e75ab6374c9f746179e75d76ce48
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  stream-chat-react-native: 14526230f326d59b638dd1e2bd36f105045c7065
+  stream-chat-react-native: ab733c7105d4e46deccbf6e1c0267b8c230a25ca
   Yoga: b2eaabf17044cd4273a661b14eb83f9fd2c90491
 
 PODFILE CHECKSUM: 4f662370295f8f9cee909f1a4c59a614999a209d
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.16.2

--- a/examples/SampleApp/src/components/BottomTabs.tsx
+++ b/examples/SampleApp/src/components/BottomTabs.tsx
@@ -12,6 +12,7 @@ import { MentionsTab } from '../icons/MentionsTab';
 import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import type { Route } from '@react-navigation/native';
 import { DraftsTab } from '../icons/DraftsTab';
+import { RemindersTab } from '../icons/ReminderTab';
 
 const styles = StyleSheet.create({
   notification: {
@@ -50,7 +51,6 @@ const getTab = (key: string) => {
         icon: <DraftsTab />,
         iconActive: <DraftsTab active />,
         title: 'Drafts',
-        notification: <ChannelsUnreadCountBadge />,
       };
     case 'ThreadsScreen':
       return {
@@ -65,6 +65,13 @@ const getTab = (key: string) => {
         iconActive: <MentionsTab active />,
         title: 'Mentions',
       };
+    case 'RemindersScreen':
+      return {
+        icon: <RemindersTab />,
+        iconActive: <RemindersTab active />,
+        title: 'Reminders',
+      };
+    // Add more cases for other tabs as needed
     default:
       return null;
   }

--- a/examples/SampleApp/src/components/DraftsList.tsx
+++ b/examples/SampleApp/src/components/DraftsList.tsx
@@ -187,7 +187,7 @@ export const DraftsList = () => {
   }, [draftsManager]);
 
   const onEndReached = useCallback(() => {
-      draftsManager.loadNextPage();
+    draftsManager.loadNextPage();
   }, [draftsManager]);
 
   return (

--- a/examples/SampleApp/src/components/DraftsList.tsx
+++ b/examples/SampleApp/src/components/DraftsList.tsx
@@ -1,9 +1,7 @@
 import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
 import { DraftsIcon } from '../icons/DraftIcon';
 import {
-  FileTypes,
   MessagePreview,
-  TranslationContextValue,
   useChatContext,
   useStateStore,
   useTheme,
@@ -14,6 +12,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import dayjs from 'dayjs';
 import { useIsFocused, useNavigation } from '@react-navigation/native';
 import { ChannelResponse, DraftMessage, DraftResponse, MessageResponseBase } from 'stream-chat';
+import { getPreviewFromMessage } from '../utils/getPreviewOfMessage';
 
 export type DraftItemProps = {
   type?: 'channel' | 'thread';
@@ -22,67 +21,6 @@ export type DraftItemProps = {
   message: DraftMessage;
   // TODO: Fix the type for thread
   thread?: MessageResponseBase;
-};
-
-export const attachmentTypeIconMap = {
-  audio: '🔈',
-  file: '📄',
-  image: '📷',
-  video: '🎥',
-  voiceRecording: '🎙️',
-} as const;
-
-const getPreviewFromMessage = ({
-  t,
-  draftMessage,
-}: {
-  t: TranslationContextValue['t'];
-  draftMessage: DraftMessage;
-}) => {
-  if (draftMessage.attachments?.length) {
-    const attachment = draftMessage?.attachments?.at(0);
-
-    const attachmentIcon = attachment
-      ? `${
-          attachmentTypeIconMap[
-            (attachment.type as keyof typeof attachmentTypeIconMap) ?? 'file'
-          ] ?? attachmentTypeIconMap.file
-        } `
-      : '';
-
-    if (attachment?.type === FileTypes.VoiceRecording) {
-      return [
-        { bold: false, text: attachmentIcon },
-        {
-          bold: false,
-          text: t('Voice message'),
-        },
-      ];
-    }
-    return [
-      { bold: false, text: attachmentIcon },
-      {
-        bold: false,
-        text:
-          attachment?.type === FileTypes.Image
-            ? attachment?.fallback
-              ? attachment?.fallback
-              : 'N/A'
-            : attachment?.title
-              ? attachment?.title
-              : 'N/A',
-      },
-    ];
-  }
-
-  if (draftMessage.text) {
-    return [
-      {
-        bold: false,
-        text: draftMessage.text,
-      },
-    ];
-  }
 };
 
 export const DraftItem = ({ type, channel, date, message, thread }: DraftItemProps) => {
@@ -113,7 +51,7 @@ export const DraftItem = ({ type, channel, date, message, thread }: DraftItemPro
   };
 
   const previews = useMemo(() => {
-    return getPreviewFromMessage({ draftMessage: message, t });
+    return getPreviewFromMessage({ message, t });
   }, [message, t]);
 
   return (

--- a/examples/SampleApp/src/components/Reminders/MessageReminderHeader.tsx
+++ b/examples/SampleApp/src/components/Reminders/MessageReminderHeader.tsx
@@ -1,10 +1,10 @@
 import {
   MessageFooterProps,
   Time,
+  useMessageReminder,
   useStateStore,
   useTranslationContext,
 } from 'stream-chat-react-native';
-import { useMessageReminder } from '../../hooks/useMessageReminder';
 import { ReminderState } from 'stream-chat';
 import { StyleSheet, Text, View } from 'react-native';
 

--- a/examples/SampleApp/src/components/Reminders/MessageReminderHeader.tsx
+++ b/examples/SampleApp/src/components/Reminders/MessageReminderHeader.tsx
@@ -1,0 +1,75 @@
+import {
+  MessageFooterProps,
+  Time,
+  useStateStore,
+  useTranslationContext,
+} from 'stream-chat-react-native';
+import { useMessageReminder } from '../../hooks/useMessageReminder';
+import { ReminderState } from 'stream-chat';
+import { StyleSheet, Text, View } from 'react-native';
+
+const reminderStateSelector = (state: ReminderState) => ({
+  timeLeftMs: state.timeLeftMs,
+});
+
+export const MessageReminderHeader = ({ message }: MessageFooterProps) => {
+  const messageId = message?.id ?? '';
+  const reminder = useMessageReminder(messageId);
+  const { timeLeftMs } = useStateStore(reminder?.state, reminderStateSelector) ?? {};
+  const { t } = useTranslationContext();
+
+  const stopRefreshBoundaryMs = reminder?.timer.stopRefreshBoundaryMs;
+  const stopRefreshTimeStamp =
+    reminder?.remindAt && stopRefreshBoundaryMs
+      ? reminder?.remindAt.getTime() + stopRefreshBoundaryMs
+      : undefined;
+
+  const isBehindRefreshBoundary =
+    !!stopRefreshTimeStamp && new Date().getTime() > stopRefreshTimeStamp;
+
+  if (!reminder) {
+    return null;
+  }
+
+  // This is for "Saved for Later"
+  if (!reminder.remindAt) {
+    return (
+      <View>
+        <Text style={styles.headerTitle}>🔖 Saved for Later</Text>
+      </View>
+    );
+  }
+
+  if (reminder.remindAt && timeLeftMs !== null) {
+    return (
+      <View style={styles.headerContainer}>
+        <Time height={16} width={16} />
+        <Text style={styles.headerTitle}>
+          {isBehindRefreshBoundary
+            ? t('Due since {{ dueSince }}', {
+                dueSince: t('timestamp/ReminderNotification', {
+                  timestamp: reminder.remindAt,
+                }),
+              })
+            : t('Due {{ timeLeft }}', {
+                timeLeft: t('duration/Message reminder', {
+                  milliseconds: timeLeftMs,
+                }),
+              })}
+        </Text>
+      </View>
+    );
+  }
+};
+
+const styles = StyleSheet.create({
+  headerContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  headerTitle: {
+    fontSize: 14,
+    fontWeight: '500',
+    marginLeft: 4,
+  },
+});

--- a/examples/SampleApp/src/components/Reminders/ReminderBanner.tsx
+++ b/examples/SampleApp/src/components/Reminders/ReminderBanner.tsx
@@ -18,8 +18,8 @@ export const ReminderBanner = (item: ReminderResponse) => {
     },
   } = useTheme();
   const { t } = useTranslationContext();
-  const { message } = item;
-  const reminder = useMessageReminder(message.id);
+  const { message_id } = item;
+  const reminder = useMessageReminder(message_id);
   const { timeLeftMs } = useStateStore(reminder?.state, reminderStateSelector) ?? {};
   const stopRefreshBoundaryMs = reminder?.timer.stopRefreshBoundaryMs;
   const stopRefreshTimeStamp =

--- a/examples/SampleApp/src/components/Reminders/ReminderBanner.tsx
+++ b/examples/SampleApp/src/components/Reminders/ReminderBanner.tsx
@@ -1,0 +1,68 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { ReminderResponse, ReminderState } from 'stream-chat';
+import { useTheme, useTranslationContext, useStateStore } from 'stream-chat-react-native';
+import { useMessageReminder } from '../../hooks/useMessageReminder';
+
+const reminderStateSelector = (state: ReminderState) => ({
+  timeLeftMs: state.timeLeftMs,
+});
+
+export const ReminderBanner = (item: ReminderResponse) => {
+  const {
+    theme: {
+      colors: { accent_blue, accent_red },
+    },
+  } = useTheme();
+  const { t } = useTranslationContext();
+  const { message } = item;
+  const reminder = useMessageReminder(message.id);
+  const { timeLeftMs } = useStateStore(reminder?.state, reminderStateSelector) ?? {};
+  const stopRefreshBoundaryMs = reminder?.timer.stopRefreshBoundaryMs;
+  const stopRefreshTimeStamp =
+    reminder?.remindAt && stopRefreshBoundaryMs
+      ? reminder?.remindAt.getTime() + stopRefreshBoundaryMs
+      : undefined;
+
+  const isBehindRefreshBoundary =
+    !!stopRefreshTimeStamp && new Date().getTime() > stopRefreshTimeStamp;
+
+  if (!reminder?.remindAt) {
+    return <Text style={styles.date}>🔖</Text>;
+  } else if (reminder.remindAt && timeLeftMs) {
+    return (
+      <View
+        style={[
+          styles.bannerContainer,
+          { backgroundColor: timeLeftMs > 0 ? accent_blue : accent_red },
+        ]}
+      >
+        <Text style={styles.date}>
+          {isBehindRefreshBoundary
+            ? t('Due since {{ dueSince }}', {
+                dueSince: t('timestamp/ReminderNotification', {
+                  timestamp: reminder.remindAt,
+                }),
+              })
+            : t('Due {{ timeLeft }}', {
+                timeLeft: t('duration/Message reminder', {
+                  milliseconds: timeLeftMs,
+                }),
+              })}
+        </Text>
+      </View>
+    );
+  }
+};
+
+const styles = StyleSheet.create({
+  bannerContainer: {
+    paddingHorizontal: 8,
+    borderRadius: 16,
+    paddingVertical: 4,
+  },
+  date: {
+    color: 'white',
+    fontWeight: '500',
+    fontSize: 12,
+  },
+});

--- a/examples/SampleApp/src/components/Reminders/ReminderBanner.tsx
+++ b/examples/SampleApp/src/components/Reminders/ReminderBanner.tsx
@@ -1,7 +1,11 @@
 import { StyleSheet, Text, View } from 'react-native';
 import { ReminderResponse, ReminderState } from 'stream-chat';
-import { useTheme, useTranslationContext, useStateStore } from 'stream-chat-react-native';
-import { useMessageReminder } from '../../hooks/useMessageReminder';
+import {
+  useMessageReminder,
+  useTheme,
+  useTranslationContext,
+  useStateStore,
+} from 'stream-chat-react-native';
 
 const reminderStateSelector = (state: ReminderState) => ({
   timeLeftMs: state.timeLeftMs,

--- a/examples/SampleApp/src/components/Reminders/ReminderItem.tsx
+++ b/examples/SampleApp/src/components/Reminders/ReminderItem.tsx
@@ -1,0 +1,250 @@
+import { useNavigation } from '@react-navigation/native';
+import { useCallback, useMemo } from 'react';
+import { Alert, AlertButton, Pressable, StyleSheet, Text, View } from 'react-native';
+import { MessageResponse, ReminderResponse } from 'stream-chat';
+import {
+  Delete,
+  FileTypes,
+  MessagePreview,
+  TranslationContextValue,
+  useChatContext,
+  useTheme,
+  useTranslationContext,
+} from 'stream-chat-react-native';
+import { ReminderBanner } from './ReminderBanner';
+import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
+
+export const attachmentTypeIconMap = {
+  audio: '🔈',
+  file: '📄',
+  image: '📷',
+  video: '🎥',
+  voiceRecording: '🎙️',
+} as const;
+
+const getPreviewFromMessage = ({
+  t,
+  message,
+}: {
+  t: TranslationContextValue['t'];
+  message: MessageResponse;
+}) => {
+  if (message.attachments?.length) {
+    const attachment = message?.attachments?.at(0);
+
+    const attachmentIcon = attachment
+      ? `${
+          attachmentTypeIconMap[
+            (attachment.type as keyof typeof attachmentTypeIconMap) ?? 'file'
+          ] ?? attachmentTypeIconMap.file
+        } `
+      : '';
+
+    if (attachment?.type === FileTypes.VoiceRecording) {
+      return [
+        { bold: false, text: attachmentIcon },
+        {
+          bold: false,
+          text: t('Voice message'),
+        },
+      ];
+    }
+    return [
+      { bold: false, text: attachmentIcon },
+      {
+        bold: false,
+        text:
+          attachment?.type === FileTypes.Image
+            ? attachment?.fallback
+              ? attachment?.fallback
+              : 'N/A'
+            : attachment?.title
+              ? attachment?.title
+              : 'N/A',
+      },
+    ];
+  }
+
+  if (message.poll_id) {
+    return [
+      {
+        bold: false,
+        text: '📊',
+      },
+      {
+        bold: false,
+        text: 'Poll',
+      },
+    ];
+  }
+
+  return [
+    {
+      bold: false,
+      text: message.text ?? '',
+    },
+  ];
+};
+
+export const ReminderItem = (
+  item: ReminderResponse & { onDeleteHandler?: (id: string) => void },
+) => {
+  const { channel, message, onDeleteHandler } = item;
+  const navigation = useNavigation();
+  const { client } = useChatContext();
+  const { t } = useTranslationContext();
+  const channelName = channel?.name ? channel.name : 'Channel';
+  const {
+    theme: {
+      colors: { accent_red, white_smoke, grey_gainsboro },
+    },
+  } = useTheme();
+
+  const onNavigationHandler = async () => {
+    if (channel?.type && channel.id) {
+      const resultChannel = client.channel(channel?.type, channel?.id);
+      await resultChannel?.watch();
+
+      // TODO: Handle thread navigation if needed
+      navigation.navigate('ChannelScreen', { channel: resultChannel });
+    }
+  };
+
+  const previews = useMemo(() => {
+    return getPreviewFromMessage({ message: message, t });
+  }, [message, t]);
+
+  const onDeleteReminder = useCallback(() => {
+    Alert.alert('Remove Reminder', 'Are you sure you want to remove this reminder?', [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+      },
+      {
+        text: 'Remove',
+        onPress: async () => {
+          await client.reminders.deleteReminder(item.message.id);
+          onDeleteHandler?.(item.message.id);
+        },
+        style: 'destructive',
+      },
+    ]);
+  }, [client.reminders, item.message.id, onDeleteHandler]);
+
+  const updateButtons = useMemo(() => {
+    const buttons: AlertButton[] = client.reminders.scheduledOffsetsMs.map((offsetMs) => ({
+      text: t('timestamp/Remind me', { milliseconds: offsetMs }),
+      onPress: async () => {
+        await client.reminders.upsertReminder({
+          messageId: item.message.id,
+          remind_at: new Date(new Date().getTime() + offsetMs).toISOString(),
+        });
+      },
+      style: 'default',
+    }));
+
+    buttons.push({
+      text: 'Clear Due Date',
+      onPress: async () => {
+        await client.reminders.upsertReminder({
+          messageId: item.message.id,
+          remind_at: null,
+        });
+      },
+      style: 'default',
+    });
+
+    buttons.push({
+      text: 'Cancel',
+      style: 'destructive',
+    });
+
+    return buttons;
+  }, [client.reminders, item.message.id, t]);
+
+  const updateReminder = useCallback(() => {
+    Alert.alert('Edit Reminder Time', 'When would you like to be reminded?', updateButtons);
+  }, [updateButtons]);
+
+  const renderRightActions = useCallback(() => {
+    return (
+      <View style={[styles.swipeableContainer, { backgroundColor: white_smoke }]}>
+        <Pressable onPress={updateReminder} style={[styles.leftSwipeableButton]}>
+          <Text style={styles.text}>Edit</Text>
+        </Pressable>
+        <Pressable onPress={onDeleteReminder} style={[styles.rightSwipeableButton]}>
+          <Delete size={32} fill={accent_red} />
+        </Pressable>
+      </View>
+    );
+  }, [accent_red, onDeleteReminder, updateReminder, white_smoke]);
+
+  return (
+    <Swipeable
+      containerStyle={[
+        styles.itemContainer,
+        {
+          borderColor: grey_gainsboro,
+        },
+      ]}
+      overshootLeft={false}
+      overshootRight={false}
+      renderRightActions={renderRightActions}
+    >
+      <Pressable
+        style={({ pressed }) => [{ opacity: pressed ? 0.8 : 1 }]}
+        onPress={onNavigationHandler}
+      >
+        <View style={styles.header}>
+          <Text style={styles.name}>
+            {message.type !== 'reply' ? `# ${channelName}` : `Thread in # ${channelName}`}
+          </Text>
+          <ReminderBanner {...item} />
+        </View>
+        <View style={styles.content}>
+          <MessagePreview previews={previews} />
+        </View>
+      </Pressable>
+    </Swipeable>
+  );
+};
+
+const styles = StyleSheet.create({
+  itemContainer: {
+    paddingVertical: 8,
+    marginHorizontal: 8,
+    borderBottomWidth: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  name: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  text: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  leftSwipeableButton: {
+    paddingLeft: 16,
+    paddingRight: 8,
+    paddingVertical: 20,
+  },
+  rightSwipeableButton: {
+    paddingLeft: 8,
+    paddingRight: 16,
+    paddingVertical: 20,
+  },
+  swipeableContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
+});

--- a/examples/SampleApp/src/components/Reminders/ReminderItem.tsx
+++ b/examples/SampleApp/src/components/Reminders/ReminderItem.tsx
@@ -105,8 +105,11 @@ export const ReminderItem = (
       const resultChannel = client.channel(channel?.type, channel?.id);
       await resultChannel?.watch();
 
-      // TODO: Handle thread navigation if needed
-      navigation.navigate('ChannelScreen', { channel: resultChannel });
+      if (message.parent_id) {
+        // TODO: Handle thread navigation
+      } else {
+        navigation.navigate('ChannelScreen', { channel: resultChannel });
+      }
     }
   };
 

--- a/examples/SampleApp/src/components/Reminders/ReminderItem.tsx
+++ b/examples/SampleApp/src/components/Reminders/ReminderItem.tsx
@@ -1,90 +1,17 @@
 import { useNavigation } from '@react-navigation/native';
 import { useCallback, useMemo } from 'react';
 import { Alert, AlertButton, Pressable, StyleSheet, Text, View } from 'react-native';
-import { MessageResponse, ReminderResponse } from 'stream-chat';
+import { ReminderResponse } from 'stream-chat';
 import {
   Delete,
-  FileTypes,
   MessagePreview,
-  TranslationContextValue,
   useChatContext,
   useTheme,
   useTranslationContext,
 } from 'stream-chat-react-native';
 import { ReminderBanner } from './ReminderBanner';
 import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
-
-export const attachmentTypeIconMap = {
-  audio: '🔈',
-  file: '📄',
-  image: '📷',
-  video: '🎥',
-  voiceRecording: '🎙️',
-} as const;
-
-const getPreviewFromMessage = ({
-  t,
-  message,
-}: {
-  t: TranslationContextValue['t'];
-  message: MessageResponse;
-}) => {
-  if (message.attachments?.length) {
-    const attachment = message?.attachments?.at(0);
-
-    const attachmentIcon = attachment
-      ? `${
-          attachmentTypeIconMap[
-            (attachment.type as keyof typeof attachmentTypeIconMap) ?? 'file'
-          ] ?? attachmentTypeIconMap.file
-        } `
-      : '';
-
-    if (attachment?.type === FileTypes.VoiceRecording) {
-      return [
-        { bold: false, text: attachmentIcon },
-        {
-          bold: false,
-          text: t('Voice message'),
-        },
-      ];
-    }
-    return [
-      { bold: false, text: attachmentIcon },
-      {
-        bold: false,
-        text:
-          attachment?.type === FileTypes.Image
-            ? attachment?.fallback
-              ? attachment?.fallback
-              : 'N/A'
-            : attachment?.title
-              ? attachment?.title
-              : 'N/A',
-      },
-    ];
-  }
-
-  if (message.poll_id) {
-    return [
-      {
-        bold: false,
-        text: '📊',
-      },
-      {
-        bold: false,
-        text: 'Poll',
-      },
-    ];
-  }
-
-  return [
-    {
-      bold: false,
-      text: message.text ?? '',
-    },
-  ];
-};
+import { getPreviewFromMessage } from '../../utils/getPreviewOfMessage';
 
 export const ReminderItem = (
   item: ReminderResponse & { onDeleteHandler?: (id: string) => void },

--- a/examples/SampleApp/src/components/Reminders/ReminderItem.tsx
+++ b/examples/SampleApp/src/components/Reminders/ReminderItem.tsx
@@ -53,20 +53,20 @@ export const ReminderItem = (
       {
         text: 'Remove',
         onPress: async () => {
-          await client.reminders.deleteReminder(item.message.id);
-          onDeleteHandler?.(item.message.id);
+          await client.reminders.deleteReminder(item.message_id);
+          onDeleteHandler?.(item.message_id);
         },
         style: 'destructive',
       },
     ]);
-  }, [client.reminders, item.message.id, onDeleteHandler]);
+  }, [client.reminders, item.message_id, onDeleteHandler]);
 
   const updateButtons = useMemo(() => {
     const buttons: AlertButton[] = client.reminders.scheduledOffsetsMs.map((offsetMs) => ({
       text: t('timestamp/Remind me', { milliseconds: offsetMs }),
       onPress: async () => {
         await client.reminders.upsertReminder({
-          messageId: item.message.id,
+          messageId: item.message_id,
           remind_at: new Date(new Date().getTime() + offsetMs).toISOString(),
         });
       },
@@ -77,7 +77,7 @@ export const ReminderItem = (
       text: 'Clear Due Date',
       onPress: async () => {
         await client.reminders.upsertReminder({
-          messageId: item.message.id,
+          messageId: item.message_id,
           remind_at: null,
         });
       },
@@ -90,7 +90,7 @@ export const ReminderItem = (
     });
 
     return buttons;
-  }, [client.reminders, item.message.id, t]);
+  }, [client.reminders, item.message_id, t]);
 
   const updateReminder = useCallback(() => {
     Alert.alert('Edit Reminder Time', 'When would you like to be reminded?', updateButtons);
@@ -127,7 +127,7 @@ export const ReminderItem = (
       >
         <View style={styles.header}>
           <Text style={styles.name}>
-            {message.type !== 'reply' ? `# ${channelName}` : `Thread in # ${channelName}`}
+            {message?.type !== 'reply' ? `# ${channelName}` : `Thread in # ${channelName}`}
           </Text>
           <ReminderBanner {...item} />
         </View>

--- a/examples/SampleApp/src/components/Reminders/RemindersList.tsx
+++ b/examples/SampleApp/src/components/Reminders/RemindersList.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useState } from 'react';
+import { FlatList, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useChatContext, useStateStore, useTheme } from 'stream-chat-react-native';
+import { PaginatorState, ReminderResponse } from 'stream-chat';
+import { ReminderItem } from './ReminderItem';
+import { useIsFocused } from '@react-navigation/native';
+
+const selector = (nextValue: PaginatorState<ReminderResponse>) =>
+  ({
+    isLoading: nextValue.isLoading,
+    items: nextValue.items,
+  }) as const;
+
+const tabs = [
+  { key: 'all', title: 'All' },
+  { key: 'overdue', title: 'Overdue' },
+  { key: 'upcoming', title: 'Upcoming' },
+  { key: 'scheduled', title: 'Scheduled' },
+  { key: 'saved-for-later', title: 'Saved for Later' },
+];
+
+type TabItemType = {
+  key: string;
+  title: string;
+};
+
+export const RemindersList = () => {
+  const [selectedTab, setSelectedTab] = useState<TabItemType>(tabs[0]);
+  const {
+    theme: {
+      colors: { accent_blue, grey_gainsboro },
+    },
+  } = useTheme();
+  const isFocused = useIsFocused();
+  const { client } = useChatContext();
+  const { isLoading, items } = useStateStore(client.reminders.paginator.state, selector);
+  const [reminders, setReminders] = useState<ReminderResponse[] | undefined>([]);
+
+  useEffect(() => {
+    setReminders(items);
+  }, [items]);
+
+  useEffect(() => {
+    if (!isFocused) {
+      return;
+    }
+    client.reminders.paginator.sort = { remind_at: 1 };
+  }, [client.reminders.paginator, isFocused]);
+
+  const onEndReached = useCallback(() => {
+    client.reminders.paginator.next();
+  }, [client.reminders]);
+
+  const onChangeTab = useCallback(
+    async (tab: TabItemType) => {
+      setSelectedTab(tab);
+      if (tab.key === 'all') {
+        client.reminders.paginator.filters = {};
+      } else if (tab.key === 'overdue') {
+        client.reminders.paginator.filters = {
+          remind_at: { $lte: new Date().toISOString() },
+        };
+      } else if (tab.key === 'upcoming') {
+        client.reminders.paginator.filters = {
+          remind_at: { $gt: new Date().toISOString() },
+        };
+      } else if (tab.key === 'scheduled') {
+        client.reminders.paginator.filters = {
+          remind_at: { $exists: true },
+        };
+      } else if (tab.key === 'saved-for-later') {
+        client.reminders.paginator.filters = {
+          remind_at: { $eq: null },
+        };
+      }
+      await client.reminders.queryNextReminders();
+    },
+    [client.reminders],
+  );
+
+  const onRefresh = useCallback(async () => {
+    await client.reminders.queryNextReminders();
+  }, [client.reminders]);
+
+  const onDeleteItemHandler = useCallback((id: string) => {
+    setReminders((prevReminders) =>
+      prevReminders?.filter((reminder) => reminder.message_id !== id),
+    );
+  }, []);
+
+  const renderItem = useCallback(
+    ({ item }: { item: ReminderResponse }) => (
+      <ReminderItem {...item} onDeleteHandler={onDeleteItemHandler} />
+    ),
+    [onDeleteItemHandler],
+  );
+
+  const renderEmptyComponent = useCallback(
+    () => (
+      <Text style={styles.emptyContainer}>
+        {selectedTab.key === 'all' ? 'No reminders available' : `No ${selectedTab.title} reminders`}
+      </Text>
+    ),
+    [selectedTab],
+  );
+
+  return (
+    <View style={{ flex: 1 }}>
+      <View style={styles.tabBar}>
+        <ScrollView
+          horizontal
+          contentContainerStyle={styles.container}
+          showsHorizontalScrollIndicator={false}
+        >
+          {tabs.map((tab) => (
+            <Pressable
+              key={tab.key}
+              onPress={() => onChangeTab(tab)}
+              style={[
+                styles.tab,
+                { backgroundColor: selectedTab === tab ? accent_blue : grey_gainsboro },
+              ]}
+            >
+              <Text style={styles.tabText}>{tab.title}</Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+      </View>
+
+      <FlatList
+        contentContainerStyle={{ flexGrow: 1 }}
+        data={reminders}
+        refreshing={isLoading}
+        onRefresh={onRefresh}
+        keyExtractor={(item) => item.message.id}
+        renderItem={renderItem}
+        ListEmptyComponent={renderEmptyComponent}
+        onEndReached={onEndReached}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+  },
+  tabBar: {
+    marginVertical: 8,
+  },
+  tab: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    margin: 4,
+    justifyContent: 'center',
+    borderRadius: 16,
+  },
+  tabText: {
+    fontWeight: '500',
+    fontSize: 14,
+    color: 'white',
+  },
+  emptyContainer: {
+    textAlign: 'center',
+  },
+});

--- a/examples/SampleApp/src/components/Reminders/RemindersList.tsx
+++ b/examples/SampleApp/src/components/Reminders/RemindersList.tsx
@@ -28,7 +28,7 @@ export const RemindersList = () => {
   } = useTheme();
   const { client } = useChatContext();
 
-  const { data, isLoading, onEndReached, onRefresh } = useQueryReminders();
+  const { data, isLoading, loadNext } = useQueryReminders();
 
   useEffect(() => {
     client.reminders.paginator.filters = {};
@@ -61,6 +61,10 @@ export const RemindersList = () => {
     },
     [client.reminders],
   );
+
+  const onRefresh = useCallback(async () => {
+    await client.reminders.queryNextReminders();
+  }, [client.reminders]);
 
   const renderEmptyComponent = useCallback(
     () => (
@@ -102,7 +106,7 @@ export const RemindersList = () => {
         keyExtractor={(item) => item.message_id}
         renderItem={renderItem}
         ListEmptyComponent={renderEmptyComponent}
-        onEndReached={onEndReached}
+        onEndReached={loadNext}
       />
     </View>
   );

--- a/examples/SampleApp/src/components/Reminders/RemindersList.tsx
+++ b/examples/SampleApp/src/components/Reminders/RemindersList.tsx
@@ -41,11 +41,11 @@ export const RemindersList = () => {
   }, [items]);
 
   useEffect(() => {
-    if (!isFocused) {
-      return;
+    if (isFocused) {
+      client.reminders.paginator.sort = { remind_at: 1 };
+      client.reminders.queryNextReminders();
     }
-    client.reminders.paginator.sort = { remind_at: 1 };
-  }, [client.reminders.paginator, isFocused]);
+  }, [client.reminders, isFocused]);
 
   const onEndReached = useCallback(() => {
     client.reminders.paginator.next();

--- a/examples/SampleApp/src/components/Reminders/RemindersList.tsx
+++ b/examples/SampleApp/src/components/Reminders/RemindersList.tsx
@@ -1,5 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
-import { FlatList, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { useChatContext, useTheme, useQueryReminders } from 'stream-chat-react-native';
 import { ReminderResponse } from 'stream-chat';
 import { ReminderItem } from './ReminderItem';
@@ -62,10 +70,6 @@ export const RemindersList = () => {
     [client.reminders],
   );
 
-  const onRefresh = useCallback(async () => {
-    await client.reminders.queryNextReminders();
-  }, [client.reminders]);
-
   const renderEmptyComponent = useCallback(
     () => (
       <Text style={styles.emptyContainer}>
@@ -74,6 +78,14 @@ export const RemindersList = () => {
     ),
     [selectedTab],
   );
+
+  const renderFooter = useCallback(() => {
+    if (isLoading) {
+      return (
+        <ActivityIndicator size={'small'} color={accent_blue} style={{ marginVertical: 16 }} />
+      );
+    }
+  }, [accent_blue, isLoading]);
 
   return (
     <View style={{ flex: 1 }}>
@@ -101,12 +113,11 @@ export const RemindersList = () => {
       <FlatList
         style={{ flexGrow: 1 }}
         data={data}
-        refreshing={isLoading}
-        onRefresh={onRefresh}
         keyExtractor={(item) => item.message_id}
         renderItem={renderItem}
         ListEmptyComponent={renderEmptyComponent}
         onEndReached={loadNext}
+        ListFooterComponent={renderFooter}
       />
     </View>
   );

--- a/examples/SampleApp/src/components/Reminders/RemindersList.tsx
+++ b/examples/SampleApp/src/components/Reminders/RemindersList.tsx
@@ -90,7 +90,7 @@ export const RemindersList = () => {
 
   const renderItem = useCallback(
     ({ item }: { item: ReminderResponse }) => (
-      <ReminderItem {...item} onDeleteHandler={onDeleteItemHandler} />
+      <ReminderItem {...item} key={item.message_id} onDeleteHandler={onDeleteItemHandler} />
     ),
     [onDeleteItemHandler],
   );

--- a/examples/SampleApp/src/components/Reminders/RemindersList.tsx
+++ b/examples/SampleApp/src/components/Reminders/RemindersList.tsx
@@ -64,15 +64,12 @@ export const RemindersList = () => {
   }, [client.reminders.paginator]);
 
   useEffect(() => {
-    if (selectedTab.key === 'all') {
-      return;
-    }
     const handleReminderDeleted = (event: Event) => {
       if (!event.reminder?.message_id) {
         return;
       }
       setData((prevData) => {
-        return prevData.filter((item) => item.message.id !== event.reminder?.message_id);
+        return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
       });
     };
 
@@ -87,27 +84,30 @@ export const RemindersList = () => {
     };
 
     const handleReminderUpdated = (event: Event) => {
+      if (selectedTab.key === 'all') {
+        return;
+      }
       const { reminder } = event;
       setData((prevData) => {
         if (!reminder) {
           return prevData; // No update needed if reminder is undefined
         }
-        const existingReminder = prevData.find((item) => item.message.id === reminder?.message_id);
+        const existingReminder = prevData.find((item) => item.message_id === reminder?.message_id);
         if (!existingReminder) {
           return prevData; // No update needed if reminder not found
         }
 
         if (existingReminder.remind_at && !event.reminder?.remind_at) {
-          return prevData.filter((item) => item.message.id !== event.reminder?.message_id);
+          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
         }
         if (!existingReminder.remind_at && event.reminder?.remind_at) {
-          return prevData.filter((item) => item.message.id !== event.reminder?.message_id);
+          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
         }
         if (isReminderOverdue(existingReminder) && !isReminderOverdue(event.reminder)) {
-          return prevData.filter((item) => item.message.id !== event.reminder?.message_id);
+          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
         }
         if (isReminderUpcoming(existingReminder) && !isReminderUpcoming(event.reminder)) {
-          return prevData.filter((item) => item.message.id !== event.reminder?.message_id);
+          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
         }
 
         return prevData;
@@ -151,6 +151,7 @@ export const RemindersList = () => {
           remind_at: { $eq: null },
         };
       }
+      await client.reminders.queryNextReminders();
     },
     [client.reminders],
   );
@@ -201,7 +202,7 @@ export const RemindersList = () => {
         data={data}
         refreshing={isLoading}
         onRefresh={onRefresh}
-        keyExtractor={(item) => item.message.id}
+        keyExtractor={(item) => item.message_id}
         renderItem={renderItem}
         ListEmptyComponent={renderEmptyComponent}
         onEndReached={onEndReached}

--- a/examples/SampleApp/src/components/Reminders/RemindersList.tsx
+++ b/examples/SampleApp/src/components/Reminders/RemindersList.tsx
@@ -1,14 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { FlatList, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
-import { useChatContext, useStateStore, useTheme } from 'stream-chat-react-native';
-import { Event, PaginatorState, ReminderResponse } from 'stream-chat';
+import { useChatContext, useTheme, useQueryReminders } from 'stream-chat-react-native';
+import { ReminderResponse } from 'stream-chat';
 import { ReminderItem } from './ReminderItem';
-
-const selector = (nextValue: PaginatorState<ReminderResponse>) =>
-  ({
-    isLoading: nextValue.isLoading,
-    reminders: nextValue.items,
-  }) as const;
 
 const tabs = [
   { key: 'all', title: 'All' },
@@ -23,24 +17,7 @@ type TabItemType = {
   title: string;
 };
 
-// Utility to sort reminders by remind_at date in ascending order
-const sortRemindersByDate = (reminders: ReminderResponse[]) => {
-  return reminders.sort((a, b) => {
-    if (!a.remind_at || !b.remind_at) {
-      return 0; // If either remind_at is missing, keep original order
-    }
-    // Sort by remind_at date
-    return new Date(a.remind_at).getTime() - new Date(b.remind_at).getTime();
-  });
-};
-
-const isReminderOverdue = (reminder?: ReminderResponse) => {
-  return reminder?.remind_at && new Date(reminder.remind_at) < new Date();
-};
-
-const isReminderUpcoming = (reminder?: ReminderResponse) => {
-  return reminder?.remind_at && new Date(reminder.remind_at) > new Date();
-};
+const renderItem = ({ item }: { item: ReminderResponse }) => <ReminderItem {...item} />;
 
 export const RemindersList = () => {
   const [selectedTab, setSelectedTab] = useState<TabItemType>(tabs[0]);
@@ -50,84 +27,13 @@ export const RemindersList = () => {
     },
   } = useTheme();
   const { client } = useChatContext();
-  const { isLoading, reminders } = useStateStore(client.reminders.paginator.state, selector);
-  const [data, setData] = useState<ReminderResponse[]>(reminders ?? []);
+
+  const { data, isLoading, onEndReached, onRefresh } = useQueryReminders();
 
   useEffect(() => {
+    client.reminders.paginator.filters = {};
     client.reminders.paginator.sort = { remind_at: 1 };
-    client.reminders.paginator.state.subscribeWithSelector(
-      ({ items }) => [items],
-      ([items]) => {
-        setData(items ?? []);
-      },
-    );
   }, [client.reminders.paginator]);
-
-  useEffect(() => {
-    const handleReminderDeleted = (event: Event) => {
-      if (!event.reminder?.message_id) {
-        return;
-      }
-      setData((prevData) => {
-        return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
-      });
-    };
-
-    const handleReminderCreated = (event: Event) => {
-      setData((prevData) => {
-        if (!event.reminder) {
-          return prevData;
-        }
-        const updatedData = [...prevData, event.reminder];
-        return sortRemindersByDate(updatedData);
-      });
-    };
-
-    const handleReminderUpdated = (event: Event) => {
-      if (selectedTab.key === 'all') {
-        return;
-      }
-      const { reminder } = event;
-      setData((prevData) => {
-        if (!reminder) {
-          return prevData; // No update needed if reminder is undefined
-        }
-        const existingReminder = prevData.find((item) => item.message_id === reminder?.message_id);
-        if (!existingReminder) {
-          return prevData; // No update needed if reminder not found
-        }
-
-        if (existingReminder.remind_at && !event.reminder?.remind_at) {
-          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
-        }
-        if (!existingReminder.remind_at && event.reminder?.remind_at) {
-          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
-        }
-        if (isReminderOverdue(existingReminder) && !isReminderOverdue(event.reminder)) {
-          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
-        }
-        if (isReminderUpcoming(existingReminder) && !isReminderUpcoming(event.reminder)) {
-          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
-        }
-
-        return prevData;
-      });
-    };
-
-    const listeners = [
-      client.on('reminder.created', handleReminderCreated),
-      client.on('reminder.deleted', handleReminderDeleted),
-      client.on('reminder.updated', handleReminderUpdated),
-    ];
-
-    return () => {
-      listeners.forEach((l) => l.unsubscribe());
-    };
-  }, [client, selectedTab]);
-
-  const onEndReached = useCallback(() => {
-    client.reminders.queryNextReminders();
-  }, [client.reminders]);
 
   const onChangeTab = useCallback(
     async (tab: TabItemType) => {
@@ -154,15 +60,6 @@ export const RemindersList = () => {
       await client.reminders.queryNextReminders();
     },
     [client.reminders],
-  );
-
-  const onRefresh = useCallback(async () => {
-    await client.reminders.queryNextReminders();
-  }, [client.reminders]);
-
-  const renderItem = useCallback(
-    ({ item }: { item: ReminderResponse }) => <ReminderItem {...item} />,
-    [],
   );
 
   const renderEmptyComponent = useCallback(

--- a/examples/SampleApp/src/hooks/useMessageReminder.ts
+++ b/examples/SampleApp/src/hooks/useMessageReminder.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+
+import type { ReminderManagerState } from 'stream-chat';
+import { useChatContext, useStateStore } from 'stream-chat-react-native';
+
+export const useMessageReminder = (messageId: string) => {
+  const { client } = useChatContext();
+  const reminderSelector = useCallback(
+    (state: ReminderManagerState) => ({
+      reminder: state.reminders.get(messageId),
+    }),
+    [messageId],
+  );
+  const { reminder } = useStateStore(client.reminders.state, reminderSelector);
+  return reminder;
+};

--- a/examples/SampleApp/src/icons/Bell.tsx
+++ b/examples/SampleApp/src/icons/Bell.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+import { useTheme } from 'stream-chat-react-native';
+
+import { IconProps } from '../utils/base';
+
+export const Bell: React.FC<IconProps> = ({ height = 512, width = 512 }) => {
+  const {
+    theme: {
+      colors: { grey },
+    },
+  } = useTheme();
+
+  return (
+    <Svg height={height} viewBox={'0 0 24 24'} width={width}>
+      <Path
+        d='M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.9,2 2,2zM18,16v-5c0,-3.07 -1.63,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.64,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2zM16,17L8,17v-6c0,-2.48 1.51,-4.5 4,-4.5s4,2.02 4,4.5v6z'
+        fill={grey}
+      />
+    </Svg>
+  );
+};

--- a/examples/SampleApp/src/icons/ReminderTab.tsx
+++ b/examples/SampleApp/src/icons/ReminderTab.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+import { useTheme } from 'stream-chat-react-native';
+
+import { IconProps } from '../utils/base';
+
+export const RemindersTab: React.FC<IconProps> = ({ active, height = 24, width = 24 }) => {
+  const {
+    theme: {
+      colors: { black, grey },
+    },
+  } = useTheme();
+
+  return (
+    <Svg fill='none' height={height} viewBox={`0 0 ${height} ${width}`} width={width}>
+      <Path d='M12 9a1 1 0 112 0v4a1 1 0 01-1 1H9a1 1 0 110-2h3V9z' fill={active ? black : grey} />
+      <Path
+        clipRule='evenodd'
+        d='M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10zm-2 0a8 8 0 11-16 0 8 8 0 0116 0z'
+        fill={active ? black : grey}
+        fillRule='evenodd'
+      />
+    </Svg>
+  );
+};

--- a/examples/SampleApp/src/screens/ChannelScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelScreen.tsx
@@ -118,9 +118,7 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
   const navigation = useNavigation();
   const { bottom } = useSafeAreaInsets();
   const {
-    theme: {
-      colors: { white },
-    },
+    theme: { colors },
   } = useTheme();
   const { t } = useTranslationContext();
 
@@ -168,7 +166,7 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
   }
 
   return (
-    <View style={[styles.flex, { backgroundColor: white, paddingBottom: bottom }]}>
+    <View style={[styles.flex, { backgroundColor: colors.white, paddingBottom: bottom }]}>
       <Channel
         audioRecordingEnabled={true}
         channel={channel}
@@ -181,6 +179,7 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
             params,
             chatClient,
             t,
+            colors,
           });
         }}
         MessageHeader={MessageReminderHeader}

--- a/examples/SampleApp/src/screens/ChannelScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelScreen.tsx
@@ -14,6 +14,7 @@ import {
   useTypingString,
   AITypingIndicatorView,
   useTranslationContext,
+  MessageActionsParams,
 } from 'stream-chat-react-native';
 import { Platform, Pressable, StyleSheet, View } from 'react-native';
 import type { StackNavigationProp } from '@react-navigation/stack';
@@ -161,6 +162,21 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
     [channel, navigation],
   );
 
+  const messageActions = useCallback(
+    (params: MessageActionsParams) => {
+      if (!chatClient) {
+        return [];
+      }
+      return channelMessageActions({
+        params,
+        chatClient,
+        t,
+        colors,
+      });
+    },
+    [chatClient, colors, t],
+  );
+
   if (!channel || !chatClient) {
     return null;
   }
@@ -174,14 +190,7 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
         enforceUniqueReaction
         initialScrollToFirstUnreadMessage
         keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : -300}
-        messageActions={(params) => {
-          return channelMessageActions({
-            params,
-            chatClient,
-            t,
-            colors,
-          });
-        }}
+        messageActions={messageActions}
         MessageHeader={MessageReminderHeader}
         messageId={messageId}
         NetworkDownIndicator={() => null}

--- a/examples/SampleApp/src/screens/ChannelScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelScreen.tsx
@@ -13,6 +13,7 @@ import {
   useTheme,
   useTypingString,
   AITypingIndicatorView,
+  useTranslationContext,
 } from 'stream-chat-react-native';
 import { Platform, Pressable, StyleSheet, View } from 'react-native';
 import type { StackNavigationProp } from '@react-navigation/stack';
@@ -25,6 +26,8 @@ import { useChannelMembersStatus } from '../hooks/useChannelMembersStatus';
 import type { StackNavigatorParamList } from '../types';
 import { NetworkDownIndicator } from '../components/NetworkDownIndicator';
 import { useCreateDraftFocusEffect } from '../utils/useCreateDraftFocusEffect.tsx';
+import { MessageReminderHeader } from '../components/Reminders/MessageReminderHeader.tsx';
+import { channelMessageActions } from '../utils/messageActions.tsx';
 
 export type ChannelScreenNavigationProp = StackNavigationProp<
   StackNavigatorParamList,
@@ -119,6 +122,7 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
       colors: { white },
     },
   } = useTheme();
+  const { t } = useTranslationContext();
 
   const [channel, setChannel] = useState<StreamChatChannel | undefined>(channelFromProp);
 
@@ -172,6 +176,14 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
         enforceUniqueReaction
         initialScrollToFirstUnreadMessage
         keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : -300}
+        messageActions={(params) => {
+          return channelMessageActions({
+            params,
+            chatClient,
+            t,
+          });
+        }}
+        MessageHeader={MessageReminderHeader}
         messageId={messageId}
         NetworkDownIndicator={() => null}
         thread={selectedThread}

--- a/examples/SampleApp/src/screens/ChatScreen.tsx
+++ b/examples/SampleApp/src/screens/ChatScreen.tsx
@@ -12,6 +12,7 @@ import type { StackNavigationProp } from '@react-navigation/stack';
 
 import type { BottomTabNavigatorParamList, StackNavigatorParamList } from '../types';
 import { DraftsScreen } from './DraftScreen';
+import { RemindersScreen } from './RemindersScreen';
 
 const Tab = createBottomTabNavigator<BottomTabNavigatorParamList>();
 
@@ -34,5 +35,10 @@ export const ChatScreen: React.FC<Props> = () => (
       options={{ headerShown: false }}
     />
     <Tab.Screen component={DraftsScreen} name='DraftsScreen' options={{ headerShown: false }} />
+    <Tab.Screen
+      component={RemindersScreen}
+      name='RemindersScreen'
+      options={{ headerShown: false }}
+    />
   </Tab.Navigator>
 );

--- a/examples/SampleApp/src/screens/RemindersScreen.tsx
+++ b/examples/SampleApp/src/screens/RemindersScreen.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { StackNavigationProp } from '@react-navigation/stack';
+import { BottomTabNavigatorParamList } from '../types';
+import { StyleSheet, View } from 'react-native';
+import { ChatScreenHeader } from '../components/ChatScreenHeader';
+import { useTheme } from 'stream-chat-react-native';
+import { RemindersList } from '../components/Reminders/RemindersList';
+
+export type RemindersScreenProps = {
+  navigation: StackNavigationProp<BottomTabNavigatorParamList, 'RemindersScreen'>;
+};
+
+export const RemindersScreen: React.FC<RemindersScreenProps> = () => {
+  const {
+    theme: {
+      colors: { white_snow },
+    },
+  } = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: white_snow,
+        },
+      ]}
+    >
+      <ChatScreenHeader />
+      <RemindersList />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  tab: {
+    paddingHorizontal: 12,
+    margin: 4,
+    justifyContent: 'center',
+    borderRadius: 16,
+    height: 32,
+  },
+  tabText: {
+    fontWeight: 'bold',
+    fontSize: 16,
+    color: 'white',
+  },
+});

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   Channel,
+  MessageActionsParams,
   Thread,
   ThreadType,
   useChatContext,
@@ -74,6 +75,20 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
   const { client: chatClient } = useChatContext();
   const { t } = useTranslationContext();
 
+  const messageActions = useCallback(
+    (params: MessageActionsParams) => {
+      if (!chatClient) {
+        return [];
+      }
+      return channelMessageActions({
+        params,
+        chatClient,
+        t,
+      });
+    },
+    [chatClient, t],
+  );
+
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: white }]}>
       <Channel
@@ -81,13 +96,7 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
         channel={channel}
         enforceUniqueReaction
         keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : -300}
-        messageActions={(params) => {
-          return channelMessageActions({
-            params,
-            chatClient,
-            t,
-          });
-        }}
+        messageActions={messageActions}
         MessageHeader={MessageReminderHeader}
         thread={thread}
         threadList

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Channel, Thread, ThreadType, useTheme, useTypingString } from 'stream-chat-react-native';
+import {
+  Channel,
+  Thread,
+  ThreadType,
+  useChatContext,
+  useTheme,
+  useTranslationContext,
+  useTypingString,
+} from 'stream-chat-react-native';
 import { useStateStore } from 'stream-chat-react-native';
 
 import { ScreenHeader } from '../components/ScreenHeader';
@@ -11,6 +19,8 @@ import type { RouteProp } from '@react-navigation/native';
 import type { StackNavigatorParamList } from '../types';
 import { LocalMessage, ThreadState, UserResponse } from 'stream-chat';
 import { useCreateDraftFocusEffect } from '../utils/useCreateDraftFocusEffect.tsx';
+import { MessageReminderHeader } from '../components/Reminders/MessageReminderHeader.tsx';
+import { channelMessageActions } from '../utils/messageActions.tsx';
 
 const selector = (nextValue: ThreadState) => ({ parentMessage: nextValue.parentMessage }) as const;
 
@@ -61,6 +71,8 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
       colors: { white },
     },
   } = useTheme();
+  const { client: chatClient } = useChatContext();
+  const { t } = useTranslationContext();
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: white }]}>
@@ -69,6 +81,14 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
         channel={channel}
         enforceUniqueReaction
         keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : -300}
+        messageActions={(params) => {
+          return channelMessageActions({
+            params,
+            chatClient,
+            t,
+          });
+        }}
+        MessageHeader={MessageReminderHeader}
         thread={thread}
         threadList
       >

--- a/examples/SampleApp/src/types.ts
+++ b/examples/SampleApp/src/types.ts
@@ -50,6 +50,7 @@ export type UserSelectorParamList = {
 export type BottomTabNavigatorParamList = {
   ChatScreen: undefined;
   DraftsScreen: undefined;
+  RemindersScreen: undefined;
   MentionsScreen: undefined;
   ThreadsScreen: undefined;
 };

--- a/examples/SampleApp/src/utils/getPreviewOfMessage.ts
+++ b/examples/SampleApp/src/utils/getPreviewOfMessage.ts
@@ -1,0 +1,74 @@
+import { DraftMessage, LocalMessage, MessageResponse } from 'stream-chat';
+import { FileTypes, TranslationContextValue } from 'stream-chat-react-native';
+
+export const attachmentTypeIconMap = {
+  audio: '🔈',
+  file: '📄',
+  image: '📷',
+  video: '🎥',
+  voiceRecording: '🎙️',
+} as const;
+
+export const getPreviewFromMessage = ({
+  t,
+  message,
+}: {
+  t: TranslationContextValue['t'];
+  message: MessageResponse | LocalMessage | DraftMessage;
+}) => {
+  if (message.attachments?.length) {
+    const attachment = message?.attachments?.at(0);
+
+    const attachmentIcon = attachment
+      ? `${
+          attachmentTypeIconMap[
+            (attachment.type as keyof typeof attachmentTypeIconMap) ?? 'file'
+          ] ?? attachmentTypeIconMap.file
+        } `
+      : '';
+
+    if (attachment?.type === FileTypes.VoiceRecording) {
+      return [
+        { bold: false, text: attachmentIcon },
+        {
+          bold: false,
+          text: t('Voice message'),
+        },
+      ];
+    }
+    return [
+      { bold: false, text: attachmentIcon },
+      {
+        bold: false,
+        text:
+          attachment?.type === FileTypes.Image
+            ? attachment?.fallback
+              ? attachment?.fallback
+              : 'N/A'
+            : attachment?.title
+              ? attachment?.title
+              : 'N/A',
+      },
+    ];
+  }
+
+  if (message.poll_id) {
+    return [
+      {
+        bold: false,
+        text: '📊',
+      },
+      {
+        bold: false,
+        text: 'Poll',
+      },
+    ];
+  }
+
+  return [
+    {
+      bold: false,
+      text: message.text ?? '',
+    },
+  ];
+};

--- a/examples/SampleApp/src/utils/messageActions.tsx
+++ b/examples/SampleApp/src/utils/messageActions.tsx
@@ -1,20 +1,24 @@
 import { Alert } from 'react-native';
 import { StreamChat } from 'stream-chat';
 import {
+  Colors,
   messageActions,
   MessageActionsParams,
   Time,
   TranslationContextValue,
 } from 'stream-chat-react-native';
+import { Bell } from '../icons/Bell';
 
 export function channelMessageActions({
   params,
   chatClient,
+  colors,
   t,
 }: {
   params: MessageActionsParams;
   chatClient: StreamChat;
   t: TranslationContextValue['t'];
+  colors?: typeof Colors;
 }) {
   const { dismissOverlay } = params;
   const actions = messageActions(params);
@@ -37,7 +41,7 @@ export function channelMessageActions({
     },
     actionType: reminder ? 'remove-from-later' : 'save-for-later',
     title: reminder ? 'Remove from Later' : 'Save for Later',
-    icon: <Time />,
+    icon: <Time pathFill={colors?.grey} />,
   });
   actions.push({
     action: () => {
@@ -82,7 +86,7 @@ export function channelMessageActions({
     },
     actionType: reminder ? 'remove-reminder' : 'remind-me',
     title: reminder ? 'Remove Reminder' : 'Remind Me',
-    icon: <Time />,
+    icon: <Bell height={24} width={24} />,
   });
 
   return actions;

--- a/examples/SampleApp/src/utils/messageActions.tsx
+++ b/examples/SampleApp/src/utils/messageActions.tsx
@@ -1,0 +1,89 @@
+import { Alert } from 'react-native';
+import { StreamChat } from 'stream-chat';
+import {
+  messageActions,
+  MessageActionsParams,
+  Time,
+  TranslationContextValue,
+} from 'stream-chat-react-native';
+
+export function channelMessageActions({
+  params,
+  chatClient,
+  t,
+}: {
+  params: MessageActionsParams;
+  chatClient: StreamChat;
+  t: TranslationContextValue['t'];
+}) {
+  const { dismissOverlay } = params;
+  const actions = messageActions(params);
+
+  // We cannot use the useMessageReminder hook here because it is a hook.
+  const reminder = chatClient.reminders.getFromState(params.message.id);
+
+  actions.push({
+    action: async () => {
+      try {
+        if (reminder) {
+          await chatClient.reminders.deleteReminder(reminder.id);
+        } else {
+          await chatClient.reminders.createReminder({ messageId: params.message.id });
+        }
+        dismissOverlay();
+      } catch (error) {
+        console.error('Error creating reminder:', error);
+      }
+    },
+    actionType: reminder ? 'remove-from-later' : 'save-for-later',
+    title: reminder ? 'Remove from Later' : 'Save for Later',
+    icon: <Time />,
+  });
+  actions.push({
+    action: () => {
+      if (reminder) {
+        Alert.alert('Remove Reminder', 'Are you sure you want to remove this reminder?', [
+          {
+            text: 'Cancel',
+            style: 'cancel',
+          },
+          {
+            text: 'Remove',
+            onPress: () => {
+              chatClient.reminders.deleteReminder(reminder.id).catch((error) => {
+                console.error('Error deleting reminder:', error);
+              });
+            },
+            style: 'destructive',
+          },
+        ]);
+      } else {
+        Alert.alert(
+          'Select Reminder Time',
+          'When would you like to be reminded?',
+          chatClient.reminders.scheduledOffsetsMs.map((offsetMs) => ({
+            text: t('timestamp/Remind me', { milliseconds: offsetMs }),
+            onPress: () => {
+              chatClient.reminders
+                .upsertReminder({
+                  messageId: params.message.id,
+                  remind_at: new Date(new Date().getTime() + offsetMs).toISOString(),
+                })
+                .catch((error) => {
+                  console.error('Error creating reminder:', error);
+                });
+            },
+            style: 'default',
+          })),
+        );
+      }
+
+      dismissOverlay();
+    },
+    actionType: reminder ? 'remove-reminder' : 'remind-me',
+    title: reminder ? 'Remove Reminder' : 'Remind Me',
+    icon: <Time />,
+  });
+
+  return actions;
+}

--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -783,7 +783,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.25.9"
     "@babel/plugin-transform-typescript" "^7.25.9"
 
-"@babel/runtime@^7.17.2", "@babel/runtime@^7.25.0", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.25.0", "@babel/runtime@^7.8.4":
   version "7.26.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.9.tgz#aa4c6facc65b9cb3f87d75125ffd47781b475433"
   integrity sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==
@@ -5117,13 +5117,6 @@ hyochan-welcome@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyochan-welcome/-/hyochan-welcome-1.0.1.tgz#a949de8bc3c1e18fe096016bc273aa191c844971"
   integrity sha512-WRZNH5grESkOXP/r7xc7TMhO9cUqxaJIuZcQDAjzHWs6viGP+sWtVbiBigxc9YVRrw3hnkESQWwzqg+oOga65A==
 
-i18next@^21.10.0:
-  version "21.10.0"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-21.10.0.tgz#85429af55fdca4858345d0e16b584ec29520197d"
-  integrity sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
-
 i18next@^25.2.1:
   version "25.2.1"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-25.2.1.tgz#23cf8794904f551f577558d93c84b0fb6cd489a2"
@@ -7901,15 +7894,16 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stream-chat-react-native-core@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-7.2.0.tgz#9c60f0235a84f22077dd56c57a532e19701dcd15"
-  integrity sha512-DXToshO7/6Bu+Rk03fTeP3W3LFlkOpRph/Iu9OtAU0QzDdG2IgMa1tNhiDEmFmJHjWROjFZtBmyV1Cuk4vFiAQ==
+stream-chat-react-native-core@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-8.0.0.tgz#2e2ff0bb578e6144276d6a585ff1ede251194646"
+  integrity sha512-WpaG57BUxGb84XI82GXy8115El2I4B2j7dnkHvlTNUJEOqUxGQ8Q+oCuYjKgh0ZRBmoHHp8ly+K01bo4e8Z5fA==
   dependencies:
     "@gorhom/bottom-sheet" "^5.1.6"
+    "@ungap/structured-clone" "^1.3.0"
     dayjs "1.11.13"
     emoji-regex "^10.4.0"
-    i18next "^21.10.0"
+    i18next "^25.2.1"
     intl-pluralrules "^2.0.1"
     linkifyjs "^4.3.1"
     lodash-es "4.17.21"
@@ -7917,7 +7911,7 @@ stream-chat-react-native-core@7.2.0:
     path "0.12.7"
     react-native-markdown-package "1.8.2"
     react-native-url-polyfill "^2.0.0"
-    stream-chat "^9.7.0"
+    stream-chat "^9.9.0"
     use-sync-external-store "^1.5.0"
 
 "stream-chat-react-native-core@link:../../package":
@@ -7927,21 +7921,6 @@ stream-chat-react-native-core@7.2.0:
 "stream-chat-react-native@link:../../package/native-package":
   version "0.0.0"
   uid ""
-
-stream-chat@^9.7.0:
-  version "9.8.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.8.0.tgz#52782073a3923367fe97638fde39ce18e4eed28a"
-  integrity sha512-iKFVFOKWuW2/GTWBOps9YWZoQBlXdJ05FiOKXI/AnCMCGzOpmvEyaoCtsktvdeMaetmZojVPbw/5jomP36Qg0Q==
-  dependencies:
-    "@types/jsonwebtoken" "^9.0.8"
-    "@types/ws" "^8.5.14"
-    axios "^1.6.0"
-    base64-js "^1.5.1"
-    form-data "^4.0.0"
-    isomorphic-ws "^5.0.0"
-    jsonwebtoken "^9.0.2"
-    linkifyjs "^4.2.0"
-    ws "^8.18.1"
 
 stream-chat@^9.9.0:
   version "9.9.0"

--- a/package/native-package/yarn.lock
+++ b/package/native-package/yarn.lock
@@ -300,19 +300,17 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/runtime@^7.17.2":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.7.tgz#f4f0d5530e8dbdf59b3451b9b3e594b6ba082e12"
-  integrity sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
 "@babel/runtime@^7.25.0":
   version "7.26.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.9.tgz#aa4c6facc65b9cb3f87d75125ffd47781b475433"
   integrity sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==
   dependencies:
     regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.27.1":
+  version "7.27.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
+  integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
 
 "@babel/template@^7.25.0":
   version "7.25.0"
@@ -753,6 +751,11 @@
   integrity sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@ungap/structured-clone@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
+  integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -1499,12 +1502,12 @@ https-proxy-agent@^7.0.5:
     agent-base "^7.1.2"
     debug "4"
 
-i18next@^21.10.0:
-  version "21.10.0"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-21.10.0.tgz#85429af55fdca4858345d0e16b584ec29520197d"
-  integrity sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==
+i18next@^25.2.1:
+  version "25.2.1"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-25.2.1.tgz#23cf8794904f551f577558d93c84b0fb6cd489a2"
+  integrity sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==
   dependencies:
-    "@babel/runtime" "^7.17.2"
+    "@babel/runtime" "^7.27.1"
 
 ieee754@^1.1.13:
   version "1.2.1"
@@ -2611,15 +2614,16 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stream-chat-react-native-core@7.2.1:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-7.2.1.tgz#3e6f0d59852c7090541cc07684c02947cb6bf88b"
-  integrity sha512-PSAQZSBS00d4KQ68maMV8DEzo0qSQLfIDKrnczPwFH5Cg503JZcbgghWpdJl54LX05cp3Ighhpen6CTIumERDw==
+stream-chat-react-native-core@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/stream-chat-react-native-core/-/stream-chat-react-native-core-8.0.0.tgz#2e2ff0bb578e6144276d6a585ff1ede251194646"
+  integrity sha512-WpaG57BUxGb84XI82GXy8115El2I4B2j7dnkHvlTNUJEOqUxGQ8Q+oCuYjKgh0ZRBmoHHp8ly+K01bo4e8Z5fA==
   dependencies:
     "@gorhom/bottom-sheet" "^5.1.6"
+    "@ungap/structured-clone" "^1.3.0"
     dayjs "1.11.13"
     emoji-regex "^10.4.0"
-    i18next "^21.10.0"
+    i18next "^25.2.1"
     intl-pluralrules "^2.0.1"
     linkifyjs "^4.3.1"
     lodash-es "4.17.21"
@@ -2627,13 +2631,13 @@ stream-chat-react-native-core@7.2.1:
     path "0.12.7"
     react-native-markdown-package "1.8.2"
     react-native-url-polyfill "^2.0.0"
-    stream-chat "^9.7.0"
+    stream-chat "^9.9.0"
     use-sync-external-store "^1.5.0"
 
-stream-chat@^9.7.0:
-  version "9.8.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.8.0.tgz#52782073a3923367fe97638fde39ce18e4eed28a"
-  integrity sha512-iKFVFOKWuW2/GTWBOps9YWZoQBlXdJ05FiOKXI/AnCMCGzOpmvEyaoCtsktvdeMaetmZojVPbw/5jomP36Qg0Q==
+stream-chat@^9.9.0:
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.10.0.tgz#6867afe05f29c05bf6b42aee0d611d72408d0cb9"
+  integrity sha512-T+2Qct1hOjco03ouLz6YPlx0gpSl6abNvvmOjq99Xn9LtInWrxQ0E7YOgV0tpcWTtVqMogCy94zHJvoO/mXV7Q==
   dependencies:
     "@types/jsonwebtoken" "^9.0.8"
     "@types/ws" "^8.5.14"

--- a/package/src/components/Chat/Chat.tsx
+++ b/package/src/components/Chat/Chat.tsx
@@ -235,10 +235,14 @@ const ChatWithContext = (props: PropsWithChildren<ChatProps>) => {
 
     client.threads.registerSubscriptions();
     client.polls.registerSubscriptions();
+    client.reminders.registerSubscriptions();
+    client.reminders.initTimers();
 
     return () => {
       client.threads.unregisterSubscriptions();
       client.polls.unregisterSubscriptions();
+      client.reminders.unregisterSubscriptions();
+      client.reminders.clearTimers();
     };
   }, [client]);
 

--- a/package/src/contexts/index.ts
+++ b/package/src/contexts/index.ts
@@ -12,6 +12,7 @@ export * from './messageInputContext/MessageInputContext';
 export * from './messageInputContext/hooks/useMessageComposer';
 export * from './messageInputContext/hooks/useAttachmentManagerState';
 export * from './messageInputContext/hooks/useMessageComposerHasSendableData';
+export * from './messageComposerContext/MessageComposerAPIContext';
 export * from './messagesContext/MessagesContext';
 export * from './paginatedMessageListContext/PaginatedMessageListContext';
 export * from './overlayContext/OverlayContext';

--- a/package/src/hooks/index.ts
+++ b/package/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useStateStore';
 export * from './useStableCallback';
 export * from './useLoadingImage';
 export * from './useMessageReminder';
+export * from './useQueryReminders';

--- a/package/src/hooks/index.ts
+++ b/package/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './useScreenDimensions';
 export * from './useStateStore';
 export * from './useStableCallback';
 export * from './useLoadingImage';
+export * from './useMessageReminder';

--- a/package/src/hooks/useMessageReminder.ts
+++ b/package/src/hooks/useMessageReminder.ts
@@ -1,7 +1,10 @@
 import { useCallback } from 'react';
 
 import type { ReminderManagerState } from 'stream-chat';
-import { useChatContext, useStateStore } from 'stream-chat-react-native';
+
+import { useStateStore } from './useStateStore';
+
+import { useChatContext } from '../contexts/chatContext/ChatContext';
 
 export const useMessageReminder = (messageId: string) => {
   const { client } = useChatContext();

--- a/package/src/hooks/useQueryReminders.ts
+++ b/package/src/hooks/useQueryReminders.ts
@@ -132,19 +132,14 @@ export const useQueryReminders = () => {
     };
   }, [client]);
 
-  const onEndReached = useCallback(async () => {
-    await client.reminders.queryNextReminders();
-  }, [client.reminders]);
-
-  const onRefresh = useCallback(async () => {
+  const loadNext = useCallback(async () => {
     await client.reminders.queryNextReminders();
   }, [client.reminders]);
 
   return {
     data,
     isLoading,
-    onEndReached,
-    onRefresh,
+    loadNext,
     setData,
   };
 };

--- a/package/src/hooks/useQueryReminders.ts
+++ b/package/src/hooks/useQueryReminders.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Event, PaginatorState, ReminderFilters, ReminderResponse } from 'stream-chat';
+
+import { useStateStore } from './useStateStore';
+
+import { useChatContext } from '../contexts/chatContext/ChatContext';
+
+const selector = (nextValue: PaginatorState<ReminderResponse>) =>
+  ({
+    isLoading: nextValue.isLoading,
+    items: nextValue.items,
+  }) as const;
+
+// Utility to sort reminders by remind_at date in ascending order
+const sortRemindersByDate = (reminders: ReminderResponse[]) => {
+  return reminders.sort((a, b) => {
+    if (!a.remind_at || !b.remind_at) {
+      return 0; // If either remind_at is missing, keep original order
+    }
+    // Sort by remind_at date
+    return new Date(a.remind_at).getTime() - new Date(b.remind_at).getTime();
+  });
+};
+
+// Utility functions to check reminder status
+const isReminderOverdue = (reminder?: ReminderResponse) => {
+  return reminder?.remind_at && new Date(reminder.remind_at) < new Date();
+};
+
+const isReminderUpcoming = (reminder?: ReminderResponse) => {
+  return reminder?.remind_at && new Date(reminder.remind_at) > new Date();
+};
+
+// Utility to check if all reminders should be shown based on filters
+const showAllReminders = (filters?: ReminderFilters) => {
+  return filters && Object.keys(filters).length === 0;
+};
+
+/**
+ * Custom hook to query reminders from the Stream Chat client.
+ * It handles fetching, updating, and deleting reminders, and provides
+ * a way to refresh the list and load more reminders.
+ *
+ * @returns {Object} - Contains data, isLoading, onEndReached, onRefresh, and setData.
+ */
+export const useQueryReminders = () => {
+  const { client } = useChatContext();
+  const { isLoading, items } = useStateStore(client.reminders.paginator.state, selector);
+  const [data, setData] = useState<ReminderResponse[]>(items ?? []);
+  // The deletion and updates are not handled by the paginator, so we need to cache them
+  // to avoid showing deleted or updated reminders in the list.
+  const deletedOrUpdatedRemindersCache = useRef<Record<string, ReminderResponse>>({});
+
+  useEffect(() => {
+    setData((prevData) => {
+      if (!items) {
+        return prevData;
+      }
+      const newData: ReminderResponse[] = [];
+      items.forEach((reminder) => {
+        if (prevData.includes(reminder)) {
+          newData.push(reminder);
+        } else {
+          if (!deletedOrUpdatedRemindersCache.current[reminder.message_id]) {
+            newData.push(reminder);
+          }
+        }
+      });
+      return newData;
+    });
+  }, [items, client.reminders.paginator.filters]);
+
+  useEffect(() => {
+    const handleReminderDeleted = (event: Event) => {
+      if (!event.reminder?.message_id) {
+        return;
+      }
+      deletedOrUpdatedRemindersCache.current[event.reminder.message_id] = event.reminder;
+      setData((prevData) => {
+        return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
+      });
+    };
+
+    const handleReminderCreated = (event: Event) => {
+      setData((prevData) => {
+        if (!event.reminder) {
+          return prevData;
+        }
+        const updatedData = [...prevData, event.reminder];
+        return sortRemindersByDate(updatedData);
+      });
+    };
+
+    const handleReminderUpdated = (event: Event) => {
+      const { reminder } = event;
+      if (!reminder || showAllReminders(client.reminders.paginator.filters)) {
+        return; // No update needed if reminder is undefined or filters is empty
+      }
+      deletedOrUpdatedRemindersCache.current[reminder.message_id] = reminder;
+      setData((prevData) => {
+        const existingReminder = prevData.find((item) => item.message_id === reminder?.message_id);
+        if (!existingReminder) {
+          return prevData; // No update needed if reminder not found
+        }
+
+        if (existingReminder.remind_at && !event.reminder?.remind_at) {
+          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
+        }
+        if (!existingReminder.remind_at && event.reminder?.remind_at) {
+          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
+        }
+        if (isReminderOverdue(existingReminder) && !isReminderOverdue(event.reminder)) {
+          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
+        }
+        if (isReminderUpcoming(existingReminder) && !isReminderUpcoming(event.reminder)) {
+          return prevData.filter((item) => item.message_id !== event.reminder?.message_id);
+        }
+
+        return prevData;
+      });
+    };
+
+    const listeners = [
+      client.on('reminder.created', handleReminderCreated),
+      client.on('reminder.deleted', handleReminderDeleted),
+      client.on('reminder.updated', handleReminderUpdated),
+    ];
+
+    return () => {
+      listeners.forEach((l) => l.unsubscribe());
+    };
+  }, [client]);
+
+  const onEndReached = useCallback(async () => {
+    await client.reminders.queryNextReminders();
+  }, [client.reminders]);
+
+  const onRefresh = useCallback(async () => {
+    await client.reminders.queryNextReminders();
+  }, [client.reminders]);
+
+  return {
+    data,
+    isLoading,
+    onEndReached,
+    onRefresh,
+    setData,
+  };
+};

--- a/package/src/store/SqliteClient.ts
+++ b/package/src/store/SqliteClient.ts
@@ -51,8 +51,6 @@ export class SqliteClient {
         name: SqliteClient.dbName,
       });
 
-      console.log(this.db.getDbPath());
-
       await this.db?.execute('PRAGMA foreign_keys = ON', []);
     } catch (e) {
       this.logger?.('error', `Error opening database ${SqliteClient.dbName}`, {

--- a/package/src/store/SqliteClient.ts
+++ b/package/src/store/SqliteClient.ts
@@ -28,7 +28,7 @@ import type { PreparedBatchQueries, PreparedQueries, Scalar, Table } from './typ
  * This way usage @op-engineering/op-sqlite package is scoped to a single class/file.
  */
 export class SqliteClient {
-  static dbVersion = 11;
+  static dbVersion = 12;
 
   static dbName = DB_NAME;
   static dbLocation = DB_LOCATION;
@@ -50,6 +50,8 @@ export class SqliteClient {
         location: SqliteClient.dbLocation,
         name: SqliteClient.dbName,
       });
+
+      console.log(this.db.getDbPath());
 
       await this.db?.execute('PRAGMA foreign_keys = ON', []);
     } catch (e) {

--- a/package/src/store/apis/getChannelMessages.ts
+++ b/package/src/store/apis/getChannelMessages.ts
@@ -51,6 +51,17 @@ export const getChannelMessages = async ({
     messageIdsVsPolls[message.poll_id] = pollsById[message.poll_id];
   });
 
+  const messageIdsVsReminders: Record<string, TableRow<'reminders'>> = {};
+  const reminders = (await SqliteClient.executeSql.apply(
+    null,
+    createSelectQuery('reminders', ['*'], {
+      messageId: messageIds,
+    }),
+  )) as unknown as TableRow<'reminders'>[];
+  reminders.forEach((reminder) => {
+    messageIdsVsReminders[reminder.messageId] = reminder;
+  });
+
   // Populate the messages.
   const cidVsMessages: Record<string, MessageResponse[]> = {};
   messageRows.forEach((m) => {
@@ -65,6 +76,7 @@ export const getChannelMessages = async ({
           messageRow: m,
           pollRow: messageIdsVsPolls[m.poll_id],
           reactionRows: messageIdVsReactions[m.id],
+          reminderRow: messageIdsVsReminders[m.id],
         }),
       );
     }

--- a/package/src/store/apis/upsertMessages.ts
+++ b/package/src/store/apis/upsertMessages.ts
@@ -3,6 +3,7 @@ import type { LocalMessage, MessageResponse } from 'stream-chat';
 import { mapMessageToStorable } from '../mappers/mapMessageToStorable';
 import { mapPollToStorable } from '../mappers/mapPollToStorable';
 import { mapReactionToStorable } from '../mappers/mapReactionToStorable';
+import { mapReminderToStorable } from '../mappers/mapReminderToStorable';
 import { mapUserToStorable } from '../mappers/mapUserToStorable';
 import { createUpsertQuery } from '../sqlite-utils/createUpsertQuery';
 import { SqliteClient } from '../SqliteClient';
@@ -18,6 +19,7 @@ export const upsertMessages = async ({
   const storableUsers: Array<ReturnType<typeof mapUserToStorable>> = [];
   const storableReactions: Array<ReturnType<typeof mapReactionToStorable>> = [];
   const storablePolls: Array<ReturnType<typeof mapPollToStorable>> = [];
+  const storableReminders: Array<ReturnType<typeof mapReminderToStorable>> = [];
 
   messages?.forEach((message: MessageResponse | LocalMessage) => {
     storableMessages.push(mapMessageToStorable(message));
@@ -33,6 +35,9 @@ export const upsertMessages = async ({
     if (message.poll) {
       storablePolls.push(mapPollToStorable(message.poll));
     }
+    if (message.reminder) {
+      storableReminders.push(mapReminderToStorable(message.reminder));
+    }
   });
 
   const finalQueries = [
@@ -42,6 +47,9 @@ export const upsertMessages = async ({
       createUpsertQuery('reactions', storableReaction),
     ),
     ...storablePolls.map((storablePoll) => createUpsertQuery('poll', storablePoll)),
+    ...storableReminders.map((storableReminder) =>
+      createUpsertQuery('reminders', storableReminder),
+    ),
   ];
 
   SqliteClient.logger?.('info', 'upsertMessages', {
@@ -49,6 +57,7 @@ export const upsertMessages = async ({
     messages: storableMessages,
     polls: storablePolls,
     reactions: storableReactions,
+    reminders: storableReminders,
     users: storableUsers,
   });
 

--- a/package/src/store/mappers/mapMessageToStorable.ts
+++ b/package/src/store/mappers/mapMessageToStorable.ts
@@ -21,6 +21,8 @@ export const mapMessageToStorable = (
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     poll,
     poll_id,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    reminder,
     reaction_groups,
     text,
     type,

--- a/package/src/store/mappers/mapReminderToStorable.ts
+++ b/package/src/store/mappers/mapReminderToStorable.ts
@@ -1,0 +1,18 @@
+import type { ReminderResponseBase } from 'stream-chat';
+
+import { mapDateTimeToStorable } from './mapDateTimeToStorable';
+
+import type { TableRow } from '../types';
+
+export const mapReminderToStorable = (reminder: ReminderResponseBase): TableRow<'reminders'> => {
+  const { channel_cid, created_at, message_id, remind_at, updated_at, user_id } = reminder;
+
+  return {
+    channelCid: channel_cid,
+    createdAt: mapDateTimeToStorable(created_at),
+    messageId: message_id,
+    remindAt: mapDateTimeToStorable(remind_at),
+    updatedAt: mapDateTimeToStorable(updated_at),
+    userId: user_id,
+  };
+};

--- a/package/src/store/mappers/mapStorableToMessage.ts
+++ b/package/src/store/mappers/mapStorableToMessage.ts
@@ -3,6 +3,7 @@ import type { MessageResponse } from 'stream-chat';
 import { mapStorableToPoll } from './mapStorableToPoll';
 import { mapStorableToReaction } from './mapStorableToReaction';
 
+import { mapStorableToReminder } from './mapStorableToReminder';
 import { mapStorableToUser } from './mapStorableToUser';
 
 import type { TableRow, TableRowJoinedUser } from '../types';
@@ -12,11 +13,13 @@ export const mapStorableToMessage = ({
   messageRow,
   pollRow,
   reactionRows,
+  reminderRow,
 }: {
   currentUserId: string;
   messageRow: TableRowJoinedUser<'messages'>;
   pollRow: TableRow<'poll'>;
   reactionRows?: TableRowJoinedUser<'reactions'>[];
+  reminderRow?: TableRow<'reminders'>;
 }): MessageResponse => {
   const {
     createdAt,
@@ -47,5 +50,6 @@ export const mapStorableToMessage = ({
     user: mapStorableToUser(user),
     ...(pollRow ? { poll: mapStorableToPoll(pollRow) } : {}),
     ...(extraData ? JSON.parse(extraData) : {}),
+    ...(reminderRow ? { reminder: mapStorableToReminder(reminderRow) } : {}),
   };
 };

--- a/package/src/store/mappers/mapStorableToReminder.ts
+++ b/package/src/store/mappers/mapStorableToReminder.ts
@@ -1,0 +1,16 @@
+import { ReminderResponseBase } from 'stream-chat';
+
+import type { TableRow } from '../types';
+
+export const mapStorableToReminder = (row: TableRow<'reminders'>): ReminderResponseBase => {
+  const { channelCid, createdAt, messageId, remindAt, updatedAt, userId } = row;
+
+  return {
+    channel_cid: channelCid,
+    created_at: createdAt,
+    message_id: messageId,
+    remind_at: remindAt,
+    updated_at: updatedAt,
+    user_id: userId,
+  };
+};

--- a/package/src/store/schema.ts
+++ b/package/src/store/schema.ts
@@ -249,6 +249,24 @@ export const tables: Tables = {
     ],
     primaryKey: ['userId', 'cid'],
   },
+  reminders: {
+    columns: {
+      channelCid: 'TEXT NOT NULL',
+      createdAt: 'TEXT',
+      messageId: 'TEXT NOT NULL',
+      remindAt: 'TEXT',
+      updatedAt: 'TEXT',
+      userId: 'TEXT NOT NULL',
+    },
+    indexes: [
+      {
+        columns: ['messageId'],
+        name: 'index_reminders',
+        unique: false,
+      },
+    ],
+    primaryKey: ['messageId'],
+  },
   users: {
     columns: {
       banned: 'BOOLEAN DEFAULT FALSE',
@@ -409,6 +427,14 @@ export type Schema = {
     lastReadMessageId?: string;
     unreadMessages?: number;
     userId?: string;
+  };
+  reminders: {
+    channelCid: string;
+    createdAt: string;
+    messageId: string;
+    updatedAt: string;
+    userId: string;
+    remindAt?: string;
   };
   users: {
     id: string;

--- a/package/src/utils/i18n/Streami18n.ts
+++ b/package/src/utils/i18n/Streami18n.ts
@@ -1,5 +1,6 @@
 import Dayjs from 'dayjs';
 import calendar from 'dayjs/plugin/calendar';
+import duration from 'dayjs/plugin/duration';
 import localeData from 'dayjs/plugin/localeData';
 import LocalizedFormat from 'dayjs/plugin/localizedFormat';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -465,6 +466,7 @@ export class Streami18n {
        * For some reason Dayjs.isDayjs(this.DateTimeParser()) doesn't work.
        */
       if (this.DateTimeParser && isDayJs(this.DateTimeParser)) {
+        this.DateTimeParser.extend(duration);
         this.DateTimeParser.extend(LocalizedFormat);
         this.DateTimeParser.extend(calendar);
         this.DateTimeParser.extend(localeData);

--- a/package/src/utils/i18n/predefinedFormatters.ts
+++ b/package/src/utils/i18n/predefinedFormatters.ts
@@ -1,7 +1,19 @@
+import { isDayjs } from 'dayjs';
+
+import type { Duration as DayjsDuration } from 'dayjs/plugin/duration';
+
 import { getDateString } from './getDateString';
-import { PredefinedFormatters, TimestampFormatterOptions } from './types';
+import { DurationFormatterOptions, PredefinedFormatters, TimestampFormatterOptions } from './types';
 
 export const predefinedFormatters: PredefinedFormatters = {
+  durationFormatter:
+    (streamI18n) =>
+    (value, _, { format, withSuffix }: DurationFormatterOptions) => {
+      if (format && isDayjs(streamI18n.DateTimeParser)) {
+        return (streamI18n.DateTimeParser.duration(value) as DayjsDuration).format(format);
+      }
+      return streamI18n.DateTimeParser.duration(value).humanize(!!withSuffix);
+    },
   timestampFormatter:
     (streamI18n) =>
     (

--- a/package/src/utils/i18n/types.ts
+++ b/package/src/utils/i18n/types.ts
@@ -9,6 +9,60 @@ export type FormatterFactory<V> = (
 /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
 export type CustomFormatters = Record<string, FormatterFactory<any>>;
 
+/**
+ * import dayjs from 'dayjs';
+ * import duration from 'dayjs/plugin/duration';
+ *
+ * dayjs.extend(duration);
+ *
+ * // Basic formatting
+ * dayjs.duration(1000).format('HH:mm:ss'); // "00:00:01"
+ * dayjs.duration(3661000).format('HH:mm:ss'); // "01:01:01"
+ *
+ * // Different format tokens
+ * dayjs.duration(3661000).format('D[d] H[h] m[m] s[s]'); // "0d 1h 1m 1s"
+ * dayjs.duration(3661000).format('D [days] H [hours] m [minutes] s [seconds]'); // "0 days 1 hours 1 minutes 1 seconds"
+ *
+ * // Zero padding
+ * dayjs.duration(1000).format('HH:mm:ss'); // "00:00:01"
+ * dayjs.duration(1000).format('H:m:s'); // "0:0:1"
+ *
+ * // Different units
+ * dayjs.duration(3661000).format('D'); // "0"
+ * dayjs.duration(3661000).format('H'); // "1"
+ * dayjs.duration(3661000).format('m'); // "1"
+ * dayjs.duration(3661000).format('s'); // "1"
+ *
+ * // Complex examples
+ * dayjs.duration(3661000).format('DD:HH:mm:ss'); // "00:01:01:01"
+ * dayjs.duration(3661000).format('D [days] HH:mm:ss'); // "0 days 01:01:01"
+ * dayjs.duration(3661000).format('H[h] m[m] s[s]'); // "1h 1m 1s"
+ *
+ * // Negative durations
+ * dayjs.duration(-3661000).format('HH:mm:ss'); // "-01:01:01"
+ *
+ * // Long durations
+ * dayjs.duration(86400000).format('D [days]'); // "1 days"
+ * dayjs.duration(2592000000).format('M [months]'); // "30 months"
+ *
+ *
+ * Format tokens:
+ * D - days
+ * H - hours
+ * m - minutes
+ * s - seconds
+ * S - milliseconds
+ * M - months
+ * Y - years
+ * You can also use:
+ * HH, mm, ss for zero-padded numbers
+ * [text] for literal text
+ */
+export type DurationFormatterOptions = {
+  format?: string;
+  withSuffix?: boolean;
+};
+
 export type TimestampFormatterOptions = {
   /* If true, call the `Day.js` calendar function to get the date string to display (e.g. "Yesterday at 3:58 PM"). */
   calendar?: boolean | null;
@@ -16,8 +70,11 @@ export type TimestampFormatterOptions = {
   calendarFormats?: Record<string, string>;
   /* Overrides the default timestamp format if calendar is disabled. */
   format?: string;
+  /* If true, the formatter will return a humanized string with suffix (e.g. "in 5 minutes" or "5 minutes ago"). */
+  withSuffix?: boolean;
 };
 
 export type PredefinedFormatters = {
+  durationFormatter: FormatterFactory<string>;
   timestampFormatter: FormatterFactory<string | Date>;
 };

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -3641,7 +3641,7 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-dayjs@1.11.13:
+dayjs@^1.11.13:
   version "1.11.13"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -3641,7 +3641,7 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-dayjs@^1.11.13:
+dayjs@1.11.13:
   version "1.11.13"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==


### PR DESCRIPTION
The goal of the PR is to add the Reminders implementation to the Sample app and the SDK, and make sure it works. 

**Sample app changes**

The ability to add reminders and mark a message as "Saved for later" is done in the sample app using the message actions. The `MessageHeader` is overridden to display the indicator on top of a message about the current remind_at state. The reminders page is designed in the sample app to list all the reminders and show reminders as per different filters, with the ability to update and delete the reminders.

**SDK changes**
The reminder manager is subscribed in the `Chat.tsx` to listen to changes and respond to it.

The `durationFormatter` is introduced in the predefined Formats for translations, similar to React SDK. This helps us with the translation key for reminders, where you want to show the due time and the future time when the reminder is triggered. This makes it easy for the integrators as well.

The message state is populated with the reminders in the offline DB.

https://github.com/user-attachments/assets/bb8adacb-6edc-4560-8301-6f8e305ed45d


