### PR TITLE
fix: unread underlay display for own messages

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -535,8 +535,12 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
 
     const handleEvent = async (event: Event) => {
       const mainChannelUpdated = !event.message?.parent_id || event.message?.show_in_channel;
-      // When the scrollToBottomButtonVisible is true, we need to manually update the channelUnreadState.
-      if (scrollToBottomButtonVisible || channelUnreadState?.first_unread_message_id) {
+      const isMyOwnMessage = event.message?.user?.id === client.user?.id;
+      // When the scrollToBottomButtonVisible is true, we need to manually update the channelUnreadState when its a received message.
+      if (
+        (scrollToBottomButtonVisible || channelUnreadState?.first_unread_message_id) &&
+        !isMyOwnMessage
+      ) {
         setChannelUnreadState((prev) => {
           const previousUnreadCount = prev?.unread_messages ?? 0;
           const previousLastMessage = getPreviousLastMessage(channel.state.messages, event.message);
@@ -749,12 +753,10 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
       const isLastReadMessage =
         channelUnreadState?.last_read_message_id === message.id ||
         (!channelUnreadState?.unread_messages && createdAtTimestamp === lastReadTimestamp);
-      const isMyMessage = message.user?.id === client.userID;
 
       const showUnreadSeparator =
         isLastReadMessage &&
         !isNewestMessage &&
-        !isMyMessage &&
         // The `channelUnreadState?.first_unread_message_id` is here for sent messages unread label
         (!!channelUnreadState?.first_unread_message_id || !!channelUnreadState?.unread_messages);
 


### PR DESCRIPTION
Lately, the unread underlay was not getting displayed for own messages, which shouldn't be the case if we are allowing the mark as unread action for the own messages sent in the message list. This change has been reverted from #3119, and the visibility of the unread label when there are long messages when a new message is sent is fixed, where the event is handled. This is to cover the cases for display of unread underlay for own messages in certain cases, and the unread count increased to one if the condition fixed was met.