### PR TITLE
fix: thread messages not being autoscrolled on initial load

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -626,13 +626,15 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
   }, [threadList, messageListLengthAfterUpdate, topMessageAfterUpdate?.id]);
 
   useEffect(() => {
-    if (!processedMessageList.length) {
-      return;
-    }
     if (threadList) {
       setAutoscrollToRecent(true);
       return;
     }
+
+    if (!processedMessageList.length) {
+      return;
+    }
+
     const notLatestSet = channel.state.messages !== channel.state.latestMessages;
     if (notLatestSet) {
       latestNonCurrentMessageBeforeUpdateRef.current =


### PR DESCRIPTION
## 🎯 Goal

A unfortunate regression was introduced with [this change](https://github.com/GetStream/stream-chat-react-native/commit/857d2203559bf093be61c45a019d7e96ff9fd10b), where thread messages were not being scrolled to once loaded properly. The reason for the bug is a bit deeper inside of how `FlatList` handles `prop` changes for MVCP specifically, but I won't go into that many details in the description. Simply making sure that we don't exit early if the list is empty with regards to whether scrolling should happen or not (on threads) is enough to work around this impediment.

Should close [this issue](https://github.com/GetStream/stream-chat-react-native/issues/3155).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


