### PR TITLE
fix: include size in response so that LLC can recognize media library uploads as file reference

### DIFF
--- a/package/expo-package/src/optionalDependencies/getPhotos.ts
+++ b/package/expo-package/src/optionalDependencies/getPhotos.ts
@@ -59,6 +59,7 @@ export const getPhotos = MediaLibrary
               duration: asset.duration * 1000,
               height: asset.height,
               name: asset.filename,
+              size: 0,
               thumb_url: asset.mediaType === 'photo' ? undefined : asset.uri,
               type: mimeType,
               uri: localUri || asset.uri,


### PR DESCRIPTION
Fixes #3161 