### PR TITLE
Fix the scroll-to-bottom issue when deleting the last sent message

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -594,7 +594,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
       if (
         topMessageBeforeUpdate.current?.created_at &&
         topMessageAfterUpdate?.created_at &&
-        topMessageBeforeUpdate.current.created_at < topMessageAfterUpdate.created_at
+        topMessageBeforeUpdate.current.created_at <= topMessageAfterUpdate.created_at
       ) {
         channelResyncScrollSet.current = false;
         setScrollToBottomButtonVisible(false);


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->
Fix an issue where, after deleting the last message sent by the user, the message list would leave an empty space at the top. This space would remain visible until the user manually interacted with the list (e.g., scrolling). The goal is to ensure that the list adjusts automatically and removes that empty space immediately after deletion.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

The issue was caused by a strict comparison in the scroll validation logic. Originally, the condition checked whether the created_at of topMessageBeforeUpdate was strictly less than the one from topMessageAfterUpdate, which failed in cases where both messages had the same timestamp.

To fix this, the condition was adjusted to use <= instead of <, allowing the scroll logic to be triggered even when both messages share the same timestamp.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

This fix can be tested by sending a message, then immediately deleting it.
Expected behavior:

The message list should scroll to the top programmatically after the deletion.

No empty space should remain.

The list should behave normally and reset its scroll position properly.

This behavior was tested on both iOS and Android devices using the main example app.



## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [x] New code is tested in main example apps, including all possible scenarios
  - [x] SampleApp iOS and Android
  - [x] Expo iOS and Android


