### PR TITLE
fix: optionally render attachment picker as per media library availability

### DIFF
--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -1972,7 +1972,9 @@ const ChannelWithContext = (props: PropsWithChildren<ChannelPropsWithContext>) =
                     <MessageComposerProvider value={messageComposerContext}>
                       <MessageInputProvider value={inputMessageInputContext}>
                         <View style={{ height: '100%' }}>{children}</View>
-                        <AttachmentPicker ref={bottomSheetRef} {...attachmentPickerProps} />
+                        {isImageMediaLibraryAvailable() && (
+                          <AttachmentPicker ref={bottomSheetRef} {...attachmentPickerProps} />
+                        )}
                       </MessageInputProvider>
                     </MessageComposerProvider>
                   </AttachmentPickerProvider>


### PR DESCRIPTION
Even when the `expo-media-library` was not installed the attachment picker would render in the UI which shouldn't be done. This is fixed in the PR.