### PR TITLE
fix: group styles condition for date separators

### DIFF
--- a/package/src/components/MessageList/utils/getGroupStyles.ts
+++ b/package/src/components/MessageList/utils/getGroupStyles.ts
@@ -40,7 +40,8 @@ const getGroupStyle = (
     previousMessage.type === 'error' ||
     userId !== previousMessage?.user?.id ||
     !!isPrevMessageTypeDeleted ||
-    (!hideDateSeparators && dateSeparators[previousMessage.id]) ||
+    // NOTE: This is needed for the group styles to work after the message separated by date.
+    (!hideDateSeparators && dateSeparators[message.id]) ||
     isEditedMessage(previousMessage);
 
   const isBottomMessage =


### PR DESCRIPTION
Update condition to check for date separators in group styles.
