### PR TITLE
fix: expo audio crash with options been passed to prepareToRecordAsync

### DIFF
--- a/package/expo-package/src/optionalDependencies/Audio.ts
+++ b/package/expo-package/src/optionalDependencies/Audio.ts
@@ -227,7 +227,7 @@ class ExpoAudioRecordingAdapter {
       onRecordingStatusUpdate(status);
     }, progressUpdateInterval);
     this.uri = null;
-    await this.recording.prepareToRecordAsync(this.options);
+    await this.recording.prepareToRecordAsync();
     this.recording.record();
   };
 


### PR DESCRIPTION
Fixes #3228 