### PR TITLE
fix: keep editing message composer with up-to-date edited message reference

### DIFF
--- a/package/src/contexts/messageInputContext/hooks/useCreateMessageComposer.ts
+++ b/package/src/contexts/messageInputContext/hooks/useCreateMessageComposer.ts
@@ -38,7 +38,10 @@ export const useCreateMessageComposer = ({
       const tag = MessageComposer.constructTag(cachedEditedMessage);
 
       const cachedComposer = queueCache.get(tag);
-      if (cachedComposer) return cachedComposer;
+      if (cachedComposer) {
+        cachedComposer.editedMessage = cachedEditedMessage;
+        return cachedComposer;
+      }
 
       return new MessageComposer({
         client,


### PR DESCRIPTION
Fixes a similar issue as https://github.com/GetStream/stream-chat-react/issues/2845 in RN SDK