### PR TITLE
fix: pagination breaking during pruning

### DIFF
--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -637,8 +637,13 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
       }
     };
 
-    if (!maximumMessageLimit && (threadList || isMessageRemovedFromMessageList)) {
-      scrollToBottomIfNeeded();
+    if (threadList || isMessageRemovedFromMessageList) {
+      if (maximumMessageLimit) {
+        // pruning has happened, reset the trackers
+        resetPaginationTrackersRef.current();
+      } else {
+        scrollToBottomIfNeeded();
+      }
     }
 
     messageListLengthBeforeUpdate.current = messageListLengthAfterUpdate;


### PR DESCRIPTION
## 🎯 Goal

With some weird order of events, pagination might end up being broken during pruning.

To reproduce the issue:

- Render a `MessageList`
- Paginate past the `maximumMessageLimit` window (i.e `120` if the window is `100`)
- Start receiving new messages (triggering pruning)
- Stop receiving messages
- Scroll up, trigger pagination (it will work this time)
- Scroll back down, start receiving messages again
- Stop receiving messages again
- Scroll up, try to paginate again

Pagination will now be broken because the length already exists in the pagination trackers.

For now, we can simply reset them - in the long run it would be great to simply rewrite parts of this code. There are many better ways to write guards against double queries.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


