### PR TITLE
fix: take updated_at into consideration during memo comparation

### DIFF
--- a/package/src/components/Message/MessageSimple/MessageContent.tsx
+++ b/package/src/components/Message/MessageSimple/MessageContent.tsx
@@ -423,7 +423,7 @@ const areEqual = (
     prevMessage.text === nextMessage.text &&
     prevMessage.pinned === nextMessage.pinned &&
     prevMessage.i18n === nextMessage.i18n &&
-    prevMessage.updated_at.getTime() === nextMessage.updated_at.getTime();
+    prevMessage?.updated_at?.getTime?.() === nextMessage?.updated_at?.getTime?.();
   if (!messageEqual) {
     return false;
   }

--- a/package/src/components/Message/MessageSimple/MessageSimple.tsx
+++ b/package/src/components/Message/MessageSimple/MessageSimple.tsx
@@ -515,7 +515,7 @@ const areEqual = (
     prevMessage.text === nextMessage.text &&
     prevMessage.i18n === nextMessage.i18n &&
     prevMessage.pinned === nextMessage.pinned &&
-    prevMessage.updated_at.getTime() === nextMessage.updated_at.getTime();
+    prevMessage?.updated_at?.getTime?.() === nextMessage?.updated_at?.getTime?.();
   if (!messageEqual) {
     return false;
   }


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


