### PR TITLE
fix: image tap functionality on android

### DIFF
--- a/package/src/components/Message/MessageSimple/MessageBubble.tsx
+++ b/package/src/components/Message/MessageSimple/MessageBubble.tsx
@@ -101,6 +101,7 @@ export const SwipableMessageBubble = React.memo(
     );
 
     const SWIPABLE_THRESHOLD = 25;
+    const MINIMUM_DISTANCE = 8;
 
     const triggerHaptic = NativeHandlers.triggerHaptic;
 
@@ -120,14 +121,17 @@ export const SwipableMessageBubble = React.memo(
             const xDiff = Math.abs(event.changedTouches[0].x - touchStart.value.x);
             const yDiff = Math.abs(event.changedTouches[0].y - touchStart.value.y);
             const isHorizontalPanning = xDiff > yDiff;
+            const hasMinimumDistance = xDiff > MINIMUM_DISTANCE || yDiff > MINIMUM_DISTANCE;
 
-            if (isHorizontalPanning) {
+            // Only activate if there's significant horizontal movement
+            if (isHorizontalPanning && hasMinimumDistance) {
               state.activate();
               isSwiping.value = true;
               if (!shouldRenderSwipeableWrapper) {
                 runOnJS(setShouldRenderAnimatedWrapper)(isSwiping.value);
               }
-            } else {
+            } else if (hasMinimumDistance) {
+              // If there's significant movement but not horizontal, fail the gesture
               state.fail();
             }
           })


### PR DESCRIPTION
## 🎯 Goal

On certain Android devices, tapping on images in messages requires multiple taps to work when enableSwipeToReply is enabled. The issue occurs because the pan gesture detector intercepts touch events before they can reach the image Pressable components.

## 🛠 Implementation details
This pull request introduces an improvement to the swipe gesture handling in the `SwipableMessageBubble` component. The change ensures that swipe gestures are only activated when the user's touch movement exceeds a minimum distance, which helps prevent accidental activations from small or unintended touches.

Gesture handling improvements:

* Added a `MINIMUM_DISTANCE` threshold (set to 8) and updated the gesture logic to require a minimum movement before activating or failing the swipe gesture, reducing false positives from minor touch movements. (`package/src/components/Message/MessageSimple/MessageBubble.tsx`) [[1]](diffhunk://#diff-78869e39c4e5a321d52b07aae9183d0bc2aff8c2f2a2d7405cb2547740865793R104) [[2]](diffhunk://#diff-78869e39c4e5a321d52b07aae9183d0bc2aff8c2f2a2d7405cb2547740865793R124-R134)
<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After:     </td>
            
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->
Tested on Galaxy S22 and Iphone 16

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


