### PR TITLE
fix: crash around audio attachment upload preview in draft mode

### DIFF
--- a/package/src/components/MessageInput/components/AttachmentPreview/AudioAttachmentUploadPreview.tsx
+++ b/package/src/components/MessageInput/components/AttachmentPreview/AudioAttachmentUploadPreview.tsx
@@ -41,7 +41,7 @@ export const AudioAttachmentUploadPreview = ({
   const finalAttachment = useMemo(
     () => ({
       ...attachment,
-      asset_url: attachment.asset_url || (attachment.localMetadata.file as FileReference).uri,
+      asset_url: attachment.asset_url ?? (attachment.localMetadata.file as FileReference).uri,
       id: attachment.localMetadata.id,
       ...audioAttachmentConfig,
     }),


### PR DESCRIPTION
The issue was that when the audio is in draft mode, the `attachment.localMetadata.file.uri` was undefined so we should rely on asset_url for this one.