### PR TITLE
fix: swipability regression

### DIFF
--- a/package/src/components/Message/MessageSimple/MessageBubble.tsx
+++ b/package/src/components/Message/MessageSimple/MessageBubble.tsx
@@ -79,13 +79,8 @@ export const SwipableMessageBubble = React.memo(
         'shouldRenderSwipeableWrapper' | 'messageSwipeToReplyHitSlop'
       > & { onSwipe: () => void },
   ) => {
-    const {
-      MessageSwipeContent,
-      shouldRenderSwipeableWrapper,
-      messageSwipeToReplyHitSlop,
-      onSwipe,
-      ...messageBubbleProps
-    } = props;
+    const { MessageSwipeContent, messageSwipeToReplyHitSlop, onSwipe, ...messageBubbleProps } =
+      props;
 
     const {
       theme: {
@@ -96,9 +91,7 @@ export const SwipableMessageBubble = React.memo(
     const translateX = useSharedValue(0);
     const touchStart = useSharedValue<{ x: number; y: number } | null>(null);
     const isSwiping = useSharedValue<boolean>(false);
-    const [shouldRenderAnimatedWrapper, setShouldRenderAnimatedWrapper] = useState<boolean>(
-      shouldRenderSwipeableWrapper,
-    );
+    const [shouldRenderAnimatedWrapper, setShouldRenderAnimatedWrapper] = useState<boolean>(false);
 
     const SWIPABLE_THRESHOLD = 25;
     const MINIMUM_DISTANCE = 8;
@@ -134,10 +127,10 @@ export const SwipableMessageBubble = React.memo(
             // Only activate if there's significant horizontal movement
             if (isHorizontalPanning && hasMinimumDistance) {
               state.activate();
-              isSwiping.value = true;
-              if (!shouldRenderSwipeableWrapper) {
-                runOnJS(setShouldRenderAnimatedWrapper)(isSwiping.value);
+              if (!isSwiping.value) {
+                runOnJS(setShouldRenderAnimatedWrapper)(true);
               }
+              isSwiping.value = true;
             } else if (hasMinimumDistance) {
               // If there's significant movement but not horizontal, fail the gesture
               state.fail();
@@ -168,21 +161,11 @@ export const SwipableMessageBubble = React.memo(
                 stiffness: 1,
               },
               () => {
-                if (!shouldRenderSwipeableWrapper) {
-                  runOnJS(setShouldRenderAnimatedWrapper)(isSwiping.value);
-                }
+                runOnJS(setShouldRenderAnimatedWrapper)(false);
               },
             );
           }),
-      [
-        messageSwipeToReplyHitSlop,
-        touchStart,
-        isSwiping,
-        shouldRenderSwipeableWrapper,
-        translateX,
-        onSwipe,
-        triggerHaptic,
-      ],
+      [messageSwipeToReplyHitSlop, touchStart, isSwiping, translateX, onSwipe, triggerHaptic],
     );
 
     const swipeContentAnimatedStyle = useAnimatedStyle(


### PR DESCRIPTION
## 🎯 Goal

This PR fixes an unfortunate regression introduced by [this change](https://github.com/GetStream/stream-chat-react-native/commit/53739b80414cc28b68b172560906888f3d9ab4c0). It should also improve swiping performance as we now won't call JS methods whenever touches move. 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


