### PR TITLE
fix(message-action-handlers): copy translated message

### DIFF
--- a/package/src/components/Message/hooks/useMessageActionHandlers.ts
+++ b/package/src/components/Message/hooks/useMessageActionHandlers.ts
@@ -7,6 +7,7 @@ import type { MessageContextValue } from '../../../contexts/messageContext/Messa
 import type { MessagesContextValue } from '../../../contexts/messagesContext/MessagesContext';
 
 import { useTranslationContext } from '../../../contexts/translationContext/TranslationContext';
+import { useTranslatedMessage } from '../../../hooks/useTranslatedMessage';
 import { NativeHandlers } from '../../../native';
 
 export const useMessageActionHandlers = ({
@@ -29,6 +30,7 @@ export const useMessageActionHandlers = ({
   Pick<MessageComposerAPIContextValue, 'setEditingState' | 'setQuotedMessage'>) => {
   const { t } = useTranslationContext();
   const handleResendMessage = () => retrySendMessage(message);
+  const translatedMessage = useTranslatedMessage(message);
 
   const handleQuotedReplyMessage = () => {
     setQuotedMessage(message);
@@ -42,7 +44,7 @@ export const useMessageActionHandlers = ({
     if (!message.text) {
       return;
     }
-    NativeHandlers.setClipboardString(message.text);
+    NativeHandlers.setClipboardString(translatedMessage?.text ?? message.text);
   };
 
   const handleDeleteMessage = () => {


### PR DESCRIPTION
## 🎯 Goal

- Closes #3324

## 🛠 Implementation details

Applies the translated message text to the clipboard if available. Otherwise, falls back to the original message text (which is the current implementation).

## 🧪 Testing

While running a React Native app in development with the Metro Server, make the same edits to `node_modules/stream-chat-react-native-core/src/components/Message/hooks/useMessageActionHandlers.ts` and follow the reproduction steps in the issue. You will see that after the applied changes, the copied text matches expectations (the string the user is reading), rather than the original untranslated text.

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


