### PR TITLE
fix: use latest options value on new client creation

### DIFF
--- a/package/src/components/Chat/hooks/useCreateChatClient.ts
+++ b/package/src/components/Chat/hooks/useCreateChatClient.ts
@@ -32,10 +32,12 @@ export const useCreateChatClient = ({
   optionsRef.current = options;
 
   useEffect(() => {
+    const userData = userDataRef.current;
+
     const client = new StreamChat(apiKey, undefined, optionsRef.current);
     let didUserConnectInterrupt = false;
 
-    const connectionPromise = client.connectUser(userDataRef.current, tokenOrProvider).then(() => {
+    const connectionPromise = client.connectUser(userData, tokenOrProvider).then(() => {
       if (!didUserConnectInterrupt) {
         setChatClient(client);
       }
@@ -47,7 +49,7 @@ export const useCreateChatClient = ({
       connectionPromise
         .then(() => client.disconnectUser())
         .then(() => {
-          console.log(`Connection for user "${userDataRef.current.id}" has been closed`);
+          console.log(`Connection for user "${userData.id}" has been closed`);
         });
     };
     // we should recompute the client on user id change


### PR DESCRIPTION
## 🎯 Goal

On client re-computation (triggered by any change among `apiKey`, `userId`, `tokenOrProvider`), the latest `options`value should be used

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


