### PR TITLE
chore: pass contentContainerStyle to MessageFlashList

### DIFF
--- a/package/src/components/MessageList/MessageFlashList.tsx
+++ b/package/src/components/MessageList/MessageFlashList.tsx
@@ -992,8 +992,14 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
       styles.contentContainer,
       { paddingBottom: messageInputFloating ? messageInputHeight : 0 },
       contentContainer,
+      additionalFlashListProps?.contentContainerStyle,
     ],
-    [contentContainer, messageInputFloating, messageInputHeight],
+    [
+      additionalFlashListProps?.contentContainerStyle,
+      contentContainer,
+      messageInputFloating,
+      messageInputHeight,
+    ],
   );
 
   const currentListHeightRef = useRef<number | undefined>(undefined);


### PR DESCRIPTION
## 🎯 Goal

This PR enables passing `additionalFlashListProps.contentContainerStyle` to the `<MessageFlashList />` component similar to how it works on `<MessageList />`.

## 🛠 Implementation details

Extends `flatListContentContainerStyle` with `additionalFlashListProps?.contentContainerStyle`.

## 🎨 UI Changes

n/a

## 🧪 Testing

Pass the following as `additionalFlashListProps` to `<MessageFlashList />`:
```
{
  contentContainerStyle: {
backgroundColor: "blue",
  },
}
```

## ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


