### PR TITLE
fix: state sync mismatch and bottom sheet version

### DIFF
--- a/examples/SampleApp/ios/Podfile.lock
+++ b/examples/SampleApp/ios/Podfile.lock
@@ -3522,7 +3522,7 @@ SPEC CHECKSUMS:
   op-sqlite: b9a4028bef60145d7b98fbbc4341c83420cdcfd5
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 300c5eb91114d4339b0bb39505d0f4824d7299b7
   RCTRequired: e0446b01093475b7082fbeee5d1ef4ad1fe20ac4
   RCTTypeSafety: cb974efcdc6695deedf7bf1eb942f2a0603a063f

--- a/examples/SampleApp/ios/SampleApp-tvOS/Info.plist
+++ b/examples/SampleApp/ios/SampleApp-tvOS/Info.plist
@@ -1,53 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.22</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>28</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>CFBundleDevelopmentRegion</key>
-		<string>en</string>
-		<key>CFBundleExecutable</key>
-		<string>$(EXECUTABLE_NAME)</string>
-		<key>CFBundleIdentifier</key>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-		<key>CFBundleInfoDictionaryVersion</key>
-		<string>6.0</string>
-		<key>CFBundleName</key>
-		<string>$(PRODUCT_NAME)</string>
-		<key>CFBundlePackageType</key>
-		<string>APPL</string>
-		<key>CFBundleShortVersionString</key>
-		<string>0.0.22</string>
-		<key>CFBundleSignature</key>
-		<string>????</string>
-		<key>CFBundleVersion</key>
-		<string>28</string>
-		<key>LSRequiresIPhoneOS</key>
-		<true />
-		<key>NSAppTransportSecurity</key>
+		<key>NSExceptionDomains</key>
 		<dict>
-			<key>NSExceptionDomains</key>
+			<key>localhost</key>
 			<dict>
-				<key>localhost</key>
-				<dict>
-					<key>NSExceptionAllowsInsecureHTTPLoads</key>
-					<true />
-				</dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
 			</dict>
 		</dict>
-		<key>NSLocationWhenInUseUsageDescription</key>
-		<string></string>
-		<key>UILaunchStoryboardName</key>
-		<string>LaunchScreen</string>
-		<key>UIRequiredDeviceCapabilities</key>
-		<array>
-			<string>armv7</string>
-		</array>
-		<key>UISupportedInterfaceOrientations</key>
-		<array>
-			<string>UIInterfaceOrientationPortrait</string>
-			<string>UIInterfaceOrientationLandscapeLeft</string>
-			<string>UIInterfaceOrientationLandscapeRight</string>
-		</array>
-		<key>UIViewControllerBasedStatusBarAppearance</key>
-		<false />
 	</dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string></string>
+	<key>RCTNewArchEnabled</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+</dict>
 </plist>

--- a/examples/SampleApp/ios/SampleApp/Info.plist
+++ b/examples/SampleApp/ios/SampleApp/Info.plist
@@ -1,62 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>ChatSample</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.11.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>154</string>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>CFBundleDevelopmentRegion</key>
-		<string>en</string>
-		<key>CFBundleDisplayName</key>
-		<string>ChatSample</string>
-		<key>CFBundleExecutable</key>
-		<string>$(EXECUTABLE_NAME)</string>
-		<key>CFBundleIdentifier</key>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-		<key>CFBundleInfoDictionaryVersion</key>
-		<string>6.0</string>
-		<key>CFBundleName</key>
-		<string>$(PRODUCT_NAME)</string>
-		<key>CFBundlePackageType</key>
-		<string>APPL</string>
-		<key>CFBundleShortVersionString</key>
-		<string>1.11.0</string>
-		<key>CFBundleSignature</key>
-		<string>????</string>
-		<key>CFBundleVersion</key>
-		<string>154</string>
-		<key>FirebaseAppDelegateProxyEnabled</key>
-		<true />
-		<key>ITSAppUsesNonExemptEncryption</key>
-		<false />
-		<key>LSRequiresIPhoneOS</key>
-		<true />
-		<key>NSAppTransportSecurity</key>
-		<dict>
-			<key>NSAllowsArbitraryLoads</key>
-			<false />
-			<key>NSAllowsLocalNetworking</key>
-			<true />
-		</dict>
-		<key>NSCameraUsageDescription</key>
-		<string>$(PRODUCT_NAME) would like to use your camera to share image in a message.</string>
-		<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-		<string>$(PRODUCT_NAME) would like share live location always in a message.</string>
-		<key>NSLocationWhenInUseUsageDescription</key>
-		<string>$(PRODUCT_NAME) would like share live location when in use in a message.</string>
-		<key>NSMicrophoneUsageDescription</key>
-		<string>$(PRODUCT_NAME) would like to use your microphone for voice recording.</string>
-		<key>NSPhotoLibraryUsageDescription</key>
-		<string>$(PRODUCT_NAME) would like access to your photo gallery to share image in a message.</string>
-		<key>UILaunchStoryboardName</key>
-		<string>LaunchScreen</string>
-		<key>UIRequiredDeviceCapabilities</key>
-		<array>
-			<string>arm64</string>
-		</array>
-		<key>UISupportedInterfaceOrientations</key>
-		<array>
-			<string>UIInterfaceOrientationPortrait</string>
-			<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		</array>
-		<key>UIViewControllerBasedStatusBarAppearance</key>
-		<false />
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>$(PRODUCT_NAME) would like to use your camera to share image in a message.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>$(PRODUCT_NAME) would like share live location always in a message.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>$(PRODUCT_NAME) would like share live location when in use in a message.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>$(PRODUCT_NAME) would like to use your microphone for voice recording.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>$(PRODUCT_NAME) would like access to your photo gallery to share image in a message.</string>
+	<key>RCTNewArchEnabled</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+</dict>
 </plist>

--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -1590,18 +1590,18 @@
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.3.tgz#a73bab8eb491d7b8b7be2f0e6c310647835afe83"
   integrity sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==
 
-"@gorhom/bottom-sheet@^5.1.6":
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-5.1.6.tgz#92365894ae4d4eefdbaa577408cfaf62463a9490"
-  integrity sha512-0b5tQj4fTaZAjST1PnkCp0p7d8iRqMezibTcqc8Kkn3N23Vn6upORNTD1fH0bLfwRt6e0WnZ7DjAmq315lrcKQ==
+"@gorhom/bottom-sheet@5.1.8":
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-5.1.8.tgz#65547917f5b1dae5a1291dabd4ea8bfee09feba4"
+  integrity sha512-QuYIVjn3K9bW20n5bgOSjvxBYoWG4YQXiLGOheEAMgISuoT6sMcA270ViSkkb0fenPxcIOwzCnFNuxmr739T9A==
   dependencies:
     "@gorhom/portal" "1.0.14"
     invariant "^2.2.4"
 
-"@gorhom/bottom-sheet@^5.1.8":
-  version "5.1.8"
-  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-5.1.8.tgz#65547917f5b1dae5a1291dabd4ea8bfee09feba4"
-  integrity sha512-QuYIVjn3K9bW20n5bgOSjvxBYoWG4YQXiLGOheEAMgISuoT6sMcA270ViSkkb0fenPxcIOwzCnFNuxmr739T9A==
+"@gorhom/bottom-sheet@^5.1.6":
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-5.1.6.tgz#92365894ae4d4eefdbaa577408cfaf62463a9490"
+  integrity sha512-0b5tQj4fTaZAjST1PnkCp0p7d8iRqMezibTcqc8Kkn3N23Vn6upORNTD1fH0bLfwRt6e0WnZ7DjAmq315lrcKQ==
   dependencies:
     "@gorhom/portal" "1.0.14"
     invariant "^2.2.4"

--- a/package/package.json
+++ b/package/package.json
@@ -68,7 +68,7 @@
     ]
   },
   "dependencies": {
-    "@gorhom/bottom-sheet": "^5.1.8",
+    "@gorhom/bottom-sheet": "5.1.8",
     "@ungap/structured-clone": "^1.3.0",
     "dayjs": "1.11.13",
     "emoji-regex": "^10.4.0",

--- a/package/src/components/Message/MessageSimple/MessageWrapper.tsx
+++ b/package/src/components/Message/MessageSimple/MessageWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import { View } from 'react-native';
 
@@ -14,7 +14,6 @@ import { ThemeProvider, useTheme } from '../../../contexts/themeContext/ThemeCon
 
 import { useStateStore } from '../../../hooks/useStateStore';
 import { ChannelUnreadStateStoreType } from '../../../state-store/channel-unread-state';
-import { MessagePreviousAndNextMessageStoreType } from '../../../state-store/message-list-prev-next-state';
 
 const channelUnreadStateSelector = (state: ChannelUnreadStateStoreType) => ({
   first_unread_message_id: state.channelUnreadState?.first_unread_message_id,
@@ -25,10 +24,12 @@ const channelUnreadStateSelector = (state: ChannelUnreadStateStoreType) => ({
 
 export type MessageWrapperProps = {
   message: LocalMessage;
+  previousMessage?: LocalMessage;
+  nextMessage?: LocalMessage;
 };
 
 export const MessageWrapper = React.memo((props: MessageWrapperProps) => {
-  const { message } = props;
+  const { message, previousMessage, nextMessage } = props;
   const { client } = useChatContext();
   const {
     channelUnreadStateStore,
@@ -47,35 +48,23 @@ export const MessageWrapper = React.memo((props: MessageWrapperProps) => {
     myMessageTheme,
     shouldShowUnreadUnderlay,
   } = useMessagesContext();
-  const {
-    goToMessage,
-    onThreadSelect,
-    noGroupByUser,
-    modifiedTheme,
-    messageListPreviousAndNextMessageStore,
-  } = useMessageListItemContext();
+  const { goToMessage, onThreadSelect, noGroupByUser, modifiedTheme } = useMessageListItemContext();
 
   const dateSeparatorDate = useMessageDateSeparator({
     hideDateSeparators,
     message,
-    messageListPreviousAndNextMessageStore,
+    previousMessage,
   });
 
-  const selector = useCallback(
-    (state: MessagePreviousAndNextMessageStoreType) => ({
-      nextMessage: state.messageList[message.id]?.nextMessage,
-    }),
-    [message.id],
-  );
-  const { nextMessage } = useStateStore(messageListPreviousAndNextMessageStore.state, selector);
   const isNewestMessage = nextMessage === undefined;
   const groupStyles = useMessageGroupStyles({
     dateSeparatorDate,
     getMessageGroupStyle,
     maxTimeBetweenGroupedMessages,
     message,
-    messageListPreviousAndNextMessageStore,
+    nextMessage,
     noGroupByUser,
+    previousMessage,
   });
 
   const { first_unread_message_id, last_read_timestamp, last_read_message_id, unread_messages } =

--- a/package/src/components/MessageList/MessageFlashList.tsx
+++ b/package/src/components/MessageList/MessageFlashList.tsx
@@ -254,10 +254,6 @@ const getItemTypeInternal = (message: LocalMessage) => {
   return 'generic-message';
 };
 
-const renderItem = ({ item: message }: { item: LocalMessage }) => {
-  return <MessageWrapper message={message} />;
-};
-
 const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) => {
   const LoadingMoreRecentIndicator = props.threadList
     ? InlineLoadingMoreRecentThreadIndicator
@@ -350,17 +346,27 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
     [myMessageThemeString, theme],
   );
 
-  const {
-    messageListPreviousAndNextMessageStore,
-    processedMessageList,
-    rawMessageList,
-    viewabilityChangedCallback,
-  } = useMessageList({
+  const { processedMessageList, rawMessageList, viewabilityChangedCallback } = useMessageList({
     isFlashList: true,
     isLiveStreaming,
     noGroupByUser,
     threadList,
   });
+
+  const renderItem = useCallback(
+    ({ item: message, index }: { item: LocalMessage; index: number }) => {
+      const previousMessage = processedMessageList[index - 1];
+      const nextMessage = processedMessageList[index + 1];
+      return (
+        <MessageWrapper
+          message={message}
+          nextMessage={nextMessage}
+          previousMessage={previousMessage}
+        />
+      );
+    },
+    [processedMessageList],
+  );
 
   /**
    * We need topMessage and channelLastRead values to set the initial scroll position.
@@ -722,18 +728,11 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
   const messageListItemContextValue: MessageListItemContextValue = useMemo(
     () => ({
       goToMessage,
-      messageListPreviousAndNextMessageStore,
       modifiedTheme,
       noGroupByUser,
       onThreadSelect,
     }),
-    [
-      goToMessage,
-      messageListPreviousAndNextMessageStore,
-      modifiedTheme,
-      noGroupByUser,
-      onThreadSelect,
-    ],
+    [goToMessage, modifiedTheme, noGroupByUser, onThreadSelect],
   );
 
   const messagesWithImages =

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -233,10 +233,6 @@ type MessageListPropsWithContext = Pick<
     isLiveStreaming?: boolean;
   };
 
-const renderItem = ({ item: message }: { item: LocalMessage }) => {
-  return <MessageWrapper message={message} />;
-};
-
 /**
  * The message list component renders a list of messages. It consumes the following contexts:
  *
@@ -320,16 +316,30 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
    * NOTE: rawMessageList changes only when messages array state changes
    * processedMessageList changes on any state change
    */
-  const {
-    messageListPreviousAndNextMessageStore,
-    processedMessageList,
-    rawMessageList,
-    viewabilityChangedCallback,
-  } = useMessageList({
+  const { processedMessageList, rawMessageList, viewabilityChangedCallback } = useMessageList({
     isLiveStreaming,
     noGroupByUser,
     threadList,
   });
+
+  const processedMessageListRef = useRef(processedMessageList);
+  processedMessageListRef.current = processedMessageList;
+
+  const renderItem = useCallback(
+    ({ item: message, index }: { item: LocalMessage; index: number }) => {
+      const previousMessage = processedMessageListRef.current[index + 1];
+      const nextMessage = processedMessageListRef.current[index - 1];
+      return (
+        <MessageWrapper
+          message={message}
+          nextMessage={nextMessage}
+          previousMessage={previousMessage}
+        />
+      );
+    },
+    [processedMessageListRef],
+  );
+
   const messageListLengthBeforeUpdate = useRef(0);
   const messageListLengthAfterUpdate = processedMessageList.length;
 
@@ -771,18 +781,11 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
   const messageListItemContextValue: MessageListItemContextValue = useMemo(
     () => ({
       goToMessage,
-      messageListPreviousAndNextMessageStore,
       modifiedTheme,
       noGroupByUser,
       onThreadSelect,
     }),
-    [
-      goToMessage,
-      messageListPreviousAndNextMessageStore,
-      modifiedTheme,
-      noGroupByUser,
-      onThreadSelect,
-    ],
+    [goToMessage, modifiedTheme, noGroupByUser, onThreadSelect],
   );
 
   /**

--- a/package/src/components/MessageList/__tests__/useMessageDateSeparator.test.ts
+++ b/package/src/components/MessageList/__tests__/useMessageDateSeparator.test.ts
@@ -2,15 +2,12 @@ import { renderHook } from '@testing-library/react-native';
 
 import { LocalMessage } from 'stream-chat';
 
-import { MessagePreviousAndNextMessageStore } from '../../../state-store/message-list-prev-next-state';
 import { useMessageDateSeparator } from '../hooks/useMessageDateSeparator';
 
 describe('useMessageDateSeparator', () => {
-  let messageListPreviousAndNextMessageStore: MessagePreviousAndNextMessageStore;
   let messages: LocalMessage[];
 
   beforeEach(() => {
-    messageListPreviousAndNextMessageStore = new MessagePreviousAndNextMessageStore();
     messages = [
       {
         created_at: new Date('2020-01-01T00:00:00.000Z'),
@@ -28,13 +25,10 @@ describe('useMessageDateSeparator', () => {
         text: 'Hello World',
       },
     ] as LocalMessage[];
-    messageListPreviousAndNextMessageStore.setMessageListPreviousAndNextMessage({ messages });
   });
 
   it('should return undefined if no message is passed', () => {
-    const { result } = renderHook(() =>
-      useMessageDateSeparator({ message: undefined, messageListPreviousAndNextMessageStore }),
-    );
+    const { result } = renderHook(() => useMessageDateSeparator({ message: undefined }));
     expect(result.current).toBeUndefined();
   });
 
@@ -43,7 +37,7 @@ describe('useMessageDateSeparator', () => {
       useMessageDateSeparator({
         hideDateSeparators: true,
         message: messages[1],
-        messageListPreviousAndNextMessageStore,
+        previousMessage: messages[0],
       }),
     );
     expect(result.current).toBeUndefined();
@@ -51,7 +45,7 @@ describe('useMessageDateSeparator', () => {
 
   it('should return the date separator for a message if previous message is not the same day', () => {
     const { result } = renderHook(() =>
-      useMessageDateSeparator({ message: messages[1], messageListPreviousAndNextMessageStore }),
+      useMessageDateSeparator({ message: messages[1], previousMessage: messages[0] }),
     );
     expect(result.current).toBe(messages[1].created_at);
   });
@@ -69,14 +63,12 @@ describe('useMessageDateSeparator', () => {
         text: 'World',
       },
     ] as LocalMessage[];
-    const messageListPreviousAndNextMessageStore = new MessagePreviousAndNextMessageStore();
-    messageListPreviousAndNextMessageStore.setMessageListPreviousAndNextMessage({ messages });
     const { result: resultOfFirstMessage } = renderHook(() =>
-      useMessageDateSeparator({ message: messages[0], messageListPreviousAndNextMessageStore }),
+      useMessageDateSeparator({ message: messages[0], previousMessage: undefined }),
     );
     expect(resultOfFirstMessage.current).toBe(messages[0].created_at);
     const { result: resultOfSecondMessage } = renderHook(() =>
-      useMessageDateSeparator({ message: messages[1], messageListPreviousAndNextMessageStore }),
+      useMessageDateSeparator({ message: messages[1], previousMessage: messages[0] }),
     );
     expect(resultOfSecondMessage.current).toBeUndefined();
   });

--- a/package/src/components/MessageList/hooks/useMessageDateSeparator.ts
+++ b/package/src/components/MessageList/hooks/useMessageDateSeparator.ts
@@ -1,12 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { LocalMessage } from 'stream-chat';
-
-import { useStateStore } from '../../../hooks/useStateStore';
-import {
-  MessagePreviousAndNextMessageStore,
-  MessagePreviousAndNextMessageStoreType,
-} from '../../../state-store/message-list-prev-next-state';
 
 export const getDateSeparatorValue = ({
   hideDateSeparators,
@@ -37,20 +31,12 @@ export const getDateSeparatorValue = ({
 export const useMessageDateSeparator = ({
   hideDateSeparators,
   message,
-  messageListPreviousAndNextMessageStore,
+  previousMessage,
 }: {
   hideDateSeparators?: boolean;
   message?: LocalMessage;
-  messageListPreviousAndNextMessageStore: MessagePreviousAndNextMessageStore;
+  previousMessage?: LocalMessage;
 }) => {
-  const selector = useCallback(
-    (state: MessagePreviousAndNextMessageStoreType) => ({
-      previousMessage: message ? state.messageList[message.id]?.previousMessage : undefined,
-    }),
-    [message],
-  );
-  const { previousMessage } = useStateStore(messageListPreviousAndNextMessageStore.state, selector);
-
   const dateSeparatorDate = useMemo(() => {
     if (!message && !previousMessage) {
       return undefined;

--- a/package/src/components/MessageList/hooks/useMessageGroupStyles.ts
+++ b/package/src/components/MessageList/hooks/useMessageGroupStyles.ts
@@ -1,15 +1,10 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { LocalMessage } from 'stream-chat';
 
 import { useMessageDateSeparator } from './useMessageDateSeparator';
 
 import { MessagesContextValue } from '../../../contexts/messagesContext/MessagesContext';
-import { useStateStore } from '../../../hooks/useStateStore';
-import {
-  MessagePreviousAndNextMessageStore,
-  MessagePreviousAndNextMessageStoreType,
-} from '../../../state-store/message-list-prev-next-state';
 import { getGroupStyle } from '../utils/getGroupStyles';
 
 /**
@@ -20,7 +15,8 @@ export const useMessageGroupStyles = ({
   dateSeparatorDate,
   maxTimeBetweenGroupedMessages,
   message,
-  messageListPreviousAndNextMessageStore,
+  previousMessage,
+  nextMessage,
   getMessageGroupStyle = getGroupStyle,
 }: {
   noGroupByUser?: boolean;
@@ -28,24 +24,13 @@ export const useMessageGroupStyles = ({
   dateSeparatorDate?: Date;
   maxTimeBetweenGroupedMessages?: number;
   message: LocalMessage;
-  messageListPreviousAndNextMessageStore: MessagePreviousAndNextMessageStore;
+  previousMessage?: LocalMessage;
+  nextMessage?: LocalMessage;
 }) => {
-  const selector = useCallback(
-    (state: MessagePreviousAndNextMessageStoreType) => ({
-      nextMessage: state.messageList[message.id]?.nextMessage,
-      previousMessage: state.messageList[message.id]?.previousMessage,
-    }),
-    [message.id],
-  );
-  const { previousMessage, nextMessage } = useStateStore(
-    messageListPreviousAndNextMessageStore.state,
-    selector,
-  );
-
   // This is needed to calculate the group styles for the next message
   const nextMessageDateSeparatorDate = useMessageDateSeparator({
     message: nextMessage,
-    messageListPreviousAndNextMessageStore,
+    previousMessage: message,
   });
 
   const groupStyles = useMemo(() => {

--- a/package/src/components/MessageList/hooks/useMessageList.ts
+++ b/package/src/components/MessageList/hooks/useMessageList.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef } from 'react';
 
 import type { LocalMessage } from 'stream-chat';
 
@@ -12,7 +12,6 @@ import { usePaginatedMessageListContext } from '../../../contexts/paginatedMessa
 import { useThreadContext } from '../../../contexts/threadContext/ThreadContext';
 
 import { useRAFCoalescedValue } from '../../../hooks';
-import { MessagePreviousAndNextMessageStore } from '../../../state-store/message-list-prev-next-state';
 import { DateSeparators, getDateSeparators } from '../utils/getDateSeparators';
 import { getGroupStyles } from '../utils/getGroupStyles';
 
@@ -70,9 +69,6 @@ export const useMessageList = (params: UseMessageListParams) => {
   const { messages, viewabilityChangedCallback } = usePaginatedMessageListContext();
   const { threadMessages } = useThreadContext();
   const messageList = threadList ? threadMessages : messages;
-  const [messageListPreviousAndNextMessageStore] = useState(
-    () => new MessagePreviousAndNextMessageStore(),
-  );
 
   const processedMessageList = useMemo<LocalMessage[]>(() => {
     const newMessageList = [];
@@ -93,13 +89,6 @@ export const useMessageList = (params: UseMessageListParams) => {
     }
     return newMessageList;
   }, [messageList, deletedMessagesVisibilityType, client.userID, isFlashList]);
-
-  useEffect(() => {
-    messageListPreviousAndNextMessageStore.setMessageListPreviousAndNextMessage({
-      isFlashList,
-      messages: processedMessageList,
-    });
-  }, [processedMessageList, messageListPreviousAndNextMessageStore, isFlashList]);
 
   /**
    * @deprecated use `useDateSeparator` hook instead directly in the Message.
@@ -156,13 +145,12 @@ export const useMessageList = (params: UseMessageListParams) => {
       dateSeparatorsRef,
       /** Message group styles */
       messageGroupStylesRef,
-      messageListPreviousAndNextMessageStore,
       /** Messages enriched with dates/readby/groups and also reversed in order */
       processedMessageList: data,
       /** Raw messages from the channel state */
       rawMessageList: messageList,
       viewabilityChangedCallback,
     }),
-    [data, messageList, messageListPreviousAndNextMessageStore, viewabilityChangedCallback],
+    [data, messageList, viewabilityChangedCallback],
   );
 };

--- a/package/src/components/MessageList/utils/getGroupStyles.ts
+++ b/package/src/components/MessageList/utils/getGroupStyles.ts
@@ -10,8 +10,8 @@ import type { GroupType } from '../hooks/useMessageList';
 
 export type MessageGroupStylesParams = {
   message: LocalMessage;
-  previousMessage: LocalMessage;
-  nextMessage: LocalMessage;
+  previousMessage?: LocalMessage;
+  nextMessage?: LocalMessage;
   maxTimeBetweenGroupedMessages?: number;
   dateSeparatorDate?: Date;
   nextMessageDateSeparatorDate?: Date;

--- a/package/src/components/Thread/Thread.tsx
+++ b/package/src/components/Thread/Thread.tsx
@@ -68,6 +68,7 @@ type ThreadPropsWithContext = Pick<ChatContextValue, 'client'> &
      * Call custom function on closing thread if handling thread state elsewhere
      */
     onThreadDismount?: () => void;
+    shouldUseFlashList?: boolean;
   };
 
 const ThreadWithContext = (props: ThreadPropsWithContext) => {
@@ -86,6 +87,7 @@ const ThreadWithContext = (props: ThreadPropsWithContext) => {
     parentMessagePreventPress = true,
     thread,
     threadInstance,
+    shouldUseFlashList = false,
   } = props;
 
   useEffect(() => {
@@ -125,7 +127,7 @@ const ThreadWithContext = (props: ThreadPropsWithContext) => {
 
   return (
     <React.Fragment key={`thread-${thread.id}`}>
-      {FlashList ? (
+      {FlashList && shouldUseFlashList ? (
         <MessageFlashList
           HeaderComponent={MemoizedThreadFooterComponent}
           threadList

--- a/package/src/contexts/messageListItemContext/MessageListItemContext.tsx
+++ b/package/src/contexts/messageListItemContext/MessageListItemContext.tsx
@@ -1,7 +1,6 @@
 import React, { createContext, PropsWithChildren, useContext } from 'react';
 
 import { MessageListProps } from '../../components/MessageList/MessageList';
-import { MessagePreviousAndNextMessageStore } from '../../state-store/message-list-prev-next-state';
 
 import { Theme } from '../themeContext/utils/theme';
 import { DEFAULT_BASE_CONTEXT_VALUE } from '../utils/defaultBaseContextValue';
@@ -15,10 +14,6 @@ export type MessageListItemContextValue = {
    * @returns void
    */
   goToMessage: (messageId: string) => void;
-  /**
-   * Store to get the previous and next message in the message list
-   */
-  messageListPreviousAndNextMessageStore: MessagePreviousAndNextMessageStore;
   /**
    * Theme to use for the message list item
    */

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -1362,7 +1362,7 @@
     "@eslint/core" "^0.14.0"
     levn "^0.4.1"
 
-"@gorhom/bottom-sheet@^5.1.8":
+"@gorhom/bottom-sheet@5.1.8":
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-5.1.8.tgz#65547917f5b1dae5a1291dabd4ea8bfee09feba4"
   integrity sha512-QuYIVjn3K9bW20n5bgOSjvxBYoWG4YQXiLGOheEAMgISuoT6sMcA270ViSkkb0fenPxcIOwzCnFNuxmr739T9A==


### PR DESCRIPTION
## 🎯 Goal

This PR is a backport of this fix from `develop`. 

Additionally, it provides a pinned version of `@gorhom/bottom-sheet` to try better in avoiding buggy version mismatches. 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


