### PR TITLE
feat: implement message composer slots

### DIFF
--- a/package/src/components/MessageInput/MessageComposerLeadingView.tsx
+++ b/package/src/components/MessageInput/MessageComposerLeadingView.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import Animated, { LinearTransition } from 'react-native-reanimated';
+
+import { InputButtons } from './components/InputButtons';
+import { idleRecordingStateSelector } from './utils/audioRecorderSelectors';
+
+import { useMessageInputContext } from '../../contexts/messageInputContext/MessageInputContext';
+import { useTheme } from '../../contexts/themeContext/ThemeContext';
+import { useStateStore } from '../../hooks/useStateStore';
+
+export const MessageComposerLeadingView = () => {
+  const {
+    theme: {
+      messageInput: { inputButtonsContainer },
+    },
+  } = useTheme();
+  const { audioRecorderManager, messageInputFloating } = useMessageInputContext();
+  const { isRecordingStateIdle } = useStateStore(
+    audioRecorderManager.state,
+    idleRecordingStateSelector,
+  );
+
+  return isRecordingStateIdle ? (
+    <Animated.View
+      layout={LinearTransition.duration(200)}
+      style={[
+        styles.inputButtonsContainer,
+        messageInputFloating ? styles.shadow : null,
+        inputButtonsContainer,
+      ]}
+    >
+      <InputButtons />
+    </Animated.View>
+  ) : null;
+};
+
+const styles = StyleSheet.create({
+  inputButtonsContainer: {
+    alignSelf: 'flex-end',
+  },
+  shadow: {
+    elevation: 6,
+
+    shadowColor: 'hsla(0, 0%, 0%, 0.24)',
+    shadowOffset: { height: 4, width: 0 },
+    shadowOpacity: 0.24,
+    shadowRadius: 12,
+  },
+});

--- a/package/src/components/MessageInput/MessageComposerTrailingView.tsx
+++ b/package/src/components/MessageInput/MessageComposerTrailingView.tsx
@@ -1,0 +1,3 @@
+export const MessageComposerTrailingView = () => {
+  return null;
+};

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -14,14 +14,16 @@ import Animated, {
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { type MessageComposerState, type TextComposerState, type UserResponse } from 'stream-chat';
+import { type UserResponse } from 'stream-chat';
 
-import { InputButtons } from './components/InputButtons';
-import { LinkPreviewList } from './components/LinkPreviewList';
-import { OutputButtons } from './components/OutputButtons';
 import { MicPositionProvider } from './contexts/MicPositionContext';
+import { MessageComposerLeadingView } from './MessageComposerLeadingView';
+import { MessageComposerTrailingView } from './MessageComposerTrailingView';
+import { MessageInputHeaderView } from './MessageInputHeaderView';
+import { MessageInputLeadingView } from './MessageInputLeadingView';
+import { MessageInputTrailingView } from './MessageInputTrailingView';
 
-import { useHasLinkPreviews } from './hooks/useLinkPreviews';
+import { audioRecorderSelector } from './utils/audioRecorderSelectors';
 
 import { ChatContextValue, useChatContext, useOwnCapabilitiesContext } from '../../contexts';
 import {
@@ -36,7 +38,6 @@ import {
   MessageComposerAPIContextValue,
   useMessageComposerAPIContext,
 } from '../../contexts/messageComposerContext/MessageComposerAPIContext';
-import { useHasAttachments } from '../../contexts/messageInputContext/hooks/useHasAttachments';
 import { useMessageComposer } from '../../contexts/messageInputContext/hooks/useMessageComposer';
 import {
   MessageInputContextValue,
@@ -60,7 +61,6 @@ import { MessageInputHeightState } from '../../state-store/message-input-height-
 import { primitives } from '../../theme';
 import { AutoCompleteInput } from '../AutoCompleteInput/AutoCompleteInput';
 import { CreatePoll } from '../Poll/CreatePollContent';
-import { GiphyBadge } from '../ui/GiphyBadge';
 import { SafeAreaViewWrapper } from '../UIComponents/SafeAreaViewWrapper';
 
 const useStyles = () => {
@@ -198,14 +198,6 @@ type MessageInputPropsWithContext = Pick<
     isRecordingStateIdle?: boolean;
     recordingStatus?: string;
   };
-
-const textComposerStateSelector = (state: TextComposerState) => ({
-  command: state.command,
-});
-
-const messageComposerStateStoreSelector = (state: MessageComposerState) => ({
-  quotedMessage: state.quotedMessage,
-});
 
 const messageInputHeightStoreSelector = (state: MessageInputHeightState) => ({
   height: state.height,
@@ -510,154 +502,6 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
   );
 };
 
-/**
- * PRAGMA: MessageComposerLeadingView
- * @param state
- */
-
-const idleRecordingStateSelector = (state: AudioRecorderManagerState) => ({
-  isRecordingStateIdle: state.status === 'idle',
-});
-
-export const MessageComposerLeadingView = () => {
-  const {
-    theme: {
-      messageInput: { inputButtonsContainer },
-    },
-  } = useTheme();
-  const styles = useStyles();
-
-  const { audioRecorderManager, messageInputFloating } = useMessageInputContext();
-  const { isRecordingStateIdle } = useStateStore(
-    audioRecorderManager.state,
-    idleRecordingStateSelector,
-  );
-
-  return isRecordingStateIdle ? (
-    <Animated.View
-      layout={LinearTransition.duration(200)}
-      style={[
-        styles.inputButtonsContainer,
-        messageInputFloating ? styles.shadow : null,
-        inputButtonsContainer,
-      ]}
-    >
-      <InputButtons />
-    </Animated.View>
-  ) : null;
-};
-
-/**
- * PRAGMA: MessageComposerTrailingView
- * @param state
- */
-
-export const MessageComposerTrailingView = () => {
-  return null;
-};
-
-/**
- * PRAGMA: MessageInputHeaderView
- * @param prevProps
- */
-
-export const MessageInputHeaderView = () => {
-  const {
-    theme: {
-      messageInput: { contentContainer },
-    },
-  } = useTheme();
-  const styles = useStyles();
-
-  const messageComposer = useMessageComposer();
-  const editing = !!messageComposer.editedMessage;
-  const { clearEditingState } = useMessageComposerAPIContext();
-  const { quotedMessage } = useStateStore(messageComposer.state, messageComposerStateStoreSelector);
-  const hasLinkPreviews = useHasLinkPreviews();
-  const { audioRecorderManager, AttachmentUploadPreviewList } = useMessageInputContext();
-  const { Reply } = useMessagesContext();
-  const { isRecordingStateIdle } = useStateStore(
-    audioRecorderManager.state,
-    idleRecordingStateSelector,
-  );
-  const hasAttachments = useHasAttachments();
-
-  return isRecordingStateIdle ? (
-    <Animated.View
-      layout={LinearTransition.duration(200)}
-      style={[
-        styles.contentContainer,
-        {
-          paddingTop:
-            hasAttachments || quotedMessage || editing || hasLinkPreviews
-              ? primitives.spacingXs
-              : 0,
-        },
-        contentContainer,
-      ]}
-    >
-      {editing ? (
-        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)}>
-          <Reply
-            mode='edit'
-            onDismiss={clearEditingState}
-            quotedMessage={messageComposer.editedMessage}
-          />
-        </Animated.View>
-      ) : null}
-      {quotedMessage ? (
-        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)}>
-          <Reply mode='reply' />
-        </Animated.View>
-      ) : null}
-      <AttachmentUploadPreviewList />
-      <LinkPreviewList />
-    </Animated.View>
-  ) : null;
-};
-
-/**
- * PRAGMA: MessageInputLeadingView
- * @param prevProps
- */
-
-export const MessageInputLeadingView = () => {
-  const styles = useStyles();
-  const messageComposer = useMessageComposer();
-  const { textComposer } = messageComposer;
-  const { command } = useStateStore(textComposer.state, textComposerStateSelector);
-
-  return command ? (
-    <View style={styles.giphyContainer}>
-      <GiphyBadge />
-    </View>
-  ) : null;
-};
-
-/**
- * MessageInputTrailingView
- * @param prevProps
- */
-
-export const MessageInputTrailingView = () => {
-  const styles = useStyles();
-  const {
-    theme: {
-      messageInput: { outputButtonsContainer },
-    },
-  } = useTheme();
-  const { audioRecorderManager } = useMessageInputContext();
-  const { micLocked, recordingStatus } = useStateStore(
-    audioRecorderManager.state,
-    audioRecorderSelector,
-  );
-  return (recordingStatus === 'idle' || recordingStatus === 'recording') && !micLocked ? (
-    <View style={[styles.outputButtonsContainer, outputButtonsContainer]}>
-      <OutputButtons />
-    </View>
-  ) : null;
-};
-
 const areEqual = (
   prevProps: MessageInputPropsWithContext,
   nextProps: MessageInputPropsWithContext,
@@ -799,12 +643,6 @@ const MemoizedMessageInput = React.memo(
 ) as typeof MessageInputWithContext;
 
 export type MessageInputProps = Partial<MessageInputPropsWithContext>;
-
-const audioRecorderSelector = (state: AudioRecorderManagerState) => ({
-  micLocked: state.micLocked,
-  isRecordingStateIdle: state.status === 'idle',
-  recordingStatus: state.status,
-});
 
 /**
  * UI Component for message input

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -16,6 +16,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { type MessageComposerState, type TextComposerState, type UserResponse } from 'stream-chat';
 
+import { InputButtons } from './components/InputButtons';
 import { LinkPreviewList } from './components/LinkPreviewList';
 import { OutputButtons } from './components/OutputButtons';
 
@@ -39,6 +40,7 @@ import {
   MessageComposerAPIContextValue,
   useMessageComposerAPIContext,
 } from '../../contexts/messageComposerContext/MessageComposerAPIContext';
+import { useHasAttachments } from '../../contexts/messageInputContext/hooks/useHasAttachments';
 import { useMessageComposer } from '../../contexts/messageInputContext/hooks/useMessageComposer';
 import {
   MessageInputContextValue,
@@ -191,7 +193,6 @@ type MessageInputPropsWithContext = Pick<
   Pick<MessageComposerAPIContextValue, 'clearEditingState'> &
   Pick<AudioRecorderManagerState, 'micLocked'> & {
     editing: boolean;
-    hasAttachments: boolean;
     isKeyboardVisible: boolean;
     TextInputComponent?: React.ComponentType<
       TextInputProps & {
@@ -204,8 +205,6 @@ type MessageInputPropsWithContext = Pick<
 
 const textComposerStateSelector = (state: TextComposerState) => ({
   command: state.command,
-  mentionedUsers: state.mentionedUsers,
-  suggestions: state.suggestions,
 });
 
 const messageComposerStateStoreSelector = (state: MessageComposerState) => ({
@@ -226,7 +225,6 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
     additionalTextInputProps,
     asyncMessagesLockDistance,
     asyncMessagesSlideToCancelDistance,
-    AttachmentUploadPreviewList,
     AudioRecorder,
     AudioRecordingInProgress,
     AudioRecordingLockIndicator,
@@ -237,15 +235,12 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
     CreatePollContent,
     disableAttachmentPicker,
     editing,
-    hasAttachments,
     messageInputFloating,
     messageInputHeightStore,
     Input,
     inputBoxRef,
-    InputButtons,
     isKeyboardVisible,
     members,
-    Reply,
     threadList,
     sendMessage,
     showPollCreationDialog,
@@ -259,17 +254,8 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
 
   const styles = useStyles();
   const messageComposer = useMessageComposer();
-  const { clearEditingState } = useMessageComposerAPIContext();
-  const onDismissEditMessage = () => {
-    clearEditingState();
-  };
-  const { textComposer } = messageComposer;
-  const { command } = useStateStore(textComposer.state, textComposerStateSelector);
-  const { quotedMessage } = useStateStore(messageComposer.state, messageComposerStateStoreSelector);
 
   const { height } = useStateStore(messageInputHeightStore.store, messageInputHeightStoreSelector);
-
-  const hasLinkPreviews = useHasLinkPreviews();
 
   const {
     theme: {
@@ -277,15 +263,12 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
       messageInput: {
         attachmentSelectionBar,
         container,
-        contentContainer,
         floatingWrapper,
         focusedInputBoxContainer,
         inputBoxContainer,
         inputBoxWrapper,
         inputContainer,
-        inputButtonsContainer,
         inputFloatingContainer,
-        outputButtonsContainer,
         suggestionsListContainer: { container: suggestionListContainer },
         wrapper,
       },
@@ -412,18 +395,7 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
           <Input additionalTextInputProps={additionalTextInputProps} getUsers={getUsers} />
         ) : (
           <View style={[styles.container, container]}>
-            {isRecordingStateIdle ? (
-              <Animated.View
-                layout={LinearTransition.duration(200)}
-                style={[
-                  styles.inputButtonsContainer,
-                  messageInputFloating ? styles.shadow : null,
-                  inputButtonsContainer,
-                ]}
-              >
-                {InputButtons && <InputButtons />}
-              </Animated.View>
-            ) : null}
+            <MessageComposerLeadingView />
             <Animated.View
               layout={LinearTransition.duration(200)}
               style={[
@@ -439,44 +411,8 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
                 ) : micLocked ? (
                   <AudioRecordingInProgress />
                 ) : null}
-                {isRecordingStateIdle ? (
-                  <Animated.View
-                    layout={LinearTransition.duration(200)}
-                    style={[
-                      styles.contentContainer,
-                      {
-                        paddingTop:
-                          hasAttachments || quotedMessage || editing || hasLinkPreviews
-                            ? primitives.spacingXs
-                            : 0,
-                      },
-                      contentContainer,
-                    ]}
-                  >
-                    {editing ? (
-                      <Animated.View
-                        entering={FadeIn.duration(200)}
-                        exiting={FadeOut.duration(200)}
-                      >
-                        <Reply
-                          mode='edit'
-                          onDismiss={onDismissEditMessage}
-                          quotedMessage={messageComposer.editedMessage}
-                        />
-                      </Animated.View>
-                    ) : null}
-                    {quotedMessage ? (
-                      <Animated.View
-                        entering={FadeIn.duration(200)}
-                        exiting={FadeOut.duration(200)}
-                      >
-                        <Reply mode='reply' />
-                      </Animated.View>
-                    ) : null}
-                    <AttachmentUploadPreviewList />
-                    <LinkPreviewList />
-                  </Animated.View>
-                ) : null}
+
+                <MessageInputHeaderView />
 
                 <Animated.View
                   style={[styles.inputContainer, inputContainer]}
@@ -486,11 +422,7 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
                     <AudioRecorder slideToCancelStyle={slideToCancelAnimatedStyle} />
                   ) : (
                     <>
-                      {command ? (
-                        <View style={styles.giphyContainer}>
-                          <GiphyBadge />
-                        </View>
-                      ) : null}
+                      <MessageInputLeadingView />
 
                       <AutoCompleteInput
                         TextInputComponent={TextInputComponent}
@@ -499,11 +431,10 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
                     </>
                   )}
 
-                  {(recordingStatus === 'idle' || recordingStatus === 'recording') && !micLocked ? (
-                    <View style={[styles.outputButtonsContainer, outputButtonsContainer]}>
-                      <OutputButtons micPositionX={micPositionX} micPositionY={micPositionY} />
-                    </View>
-                  ) : null}
+                  <MessageInputTrailingView
+                    micPositionX={micPositionX}
+                    micPositionY={micPositionY}
+                  />
                 </Animated.View>
               </View>
             </Animated.View>
@@ -527,7 +458,9 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
             style={lockIndicatorAnimatedStyle}
           />
         </View>
-      ) : null}
+      ) : (
+        <MessageComposerTrailingView />
+      )}
 
       <Animated.View
         entering={FadeIn.duration(200)}
@@ -577,6 +510,163 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
   );
 };
 
+/**
+ * PRAGMA: MessageComposerLeadingView
+ * @param state
+ */
+
+const idleRecordingStateSelector = (state: AudioRecorderManagerState) => ({
+  isRecordingStateIdle: state.status === 'idle',
+});
+
+export const MessageComposerLeadingView = () => {
+  const {
+    theme: {
+      messageInput: { inputButtonsContainer },
+    },
+  } = useTheme();
+  const styles = useStyles();
+
+  const { audioRecorderManager, messageInputFloating } = useMessageInputContext();
+  const { isRecordingStateIdle } = useStateStore(
+    audioRecorderManager.state,
+    idleRecordingStateSelector,
+  );
+
+  return isRecordingStateIdle ? (
+    <Animated.View
+      layout={LinearTransition.duration(200)}
+      style={[
+        styles.inputButtonsContainer,
+        messageInputFloating ? styles.shadow : null,
+        inputButtonsContainer,
+      ]}
+    >
+      <InputButtons />
+    </Animated.View>
+  ) : null;
+};
+
+/**
+ * PRAGMA: MessageComposerTrailingView
+ * @param state
+ */
+
+export const MessageComposerTrailingView = () => {
+  return null;
+};
+
+/**
+ * PRAGMA: MessageInputHeaderView
+ * @param prevProps
+ */
+
+export const MessageInputHeaderView = () => {
+  const {
+    theme: {
+      messageInput: { contentContainer },
+    },
+  } = useTheme();
+  const styles = useStyles();
+
+  const messageComposer = useMessageComposer();
+  const editing = !!messageComposer.editedMessage;
+  const { clearEditingState } = useMessageComposerAPIContext();
+  const onDismissEditMessage = () => {
+    clearEditingState();
+  };
+  const { quotedMessage } = useStateStore(messageComposer.state, messageComposerStateStoreSelector);
+  const hasLinkPreviews = useHasLinkPreviews();
+  const { audioRecorderManager, AttachmentUploadPreviewList } = useMessageInputContext();
+  const { Reply } = useMessagesContext();
+  const { isRecordingStateIdle } = useStateStore(
+    audioRecorderManager.state,
+    idleRecordingStateSelector,
+  );
+  const hasAttachments = useHasAttachments();
+
+  return isRecordingStateIdle ? (
+    <Animated.View
+      layout={LinearTransition.duration(200)}
+      style={[
+        styles.contentContainer,
+        {
+          paddingTop:
+            hasAttachments || quotedMessage || editing || hasLinkPreviews
+              ? primitives.spacingXs
+              : 0,
+        },
+        contentContainer,
+      ]}
+    >
+      {editing ? (
+        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)}>
+          <Reply
+            mode='edit'
+            onDismiss={onDismissEditMessage}
+            quotedMessage={messageComposer.editedMessage}
+          />
+        </Animated.View>
+      ) : null}
+      {quotedMessage ? (
+        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)}>
+          <Reply mode='reply' />
+        </Animated.View>
+      ) : null}
+      <AttachmentUploadPreviewList />
+      <LinkPreviewList />
+    </Animated.View>
+  ) : null;
+};
+
+/**
+ * PRAGMA: MessageInputLeadingView
+ * @param prevProps
+ */
+
+export const MessageInputLeadingView = () => {
+  const styles = useStyles();
+  const messageComposer = useMessageComposer();
+  const { textComposer } = messageComposer;
+  const { command } = useStateStore(textComposer.state, textComposerStateSelector);
+
+  return command ? (
+    <View style={styles.giphyContainer}>
+      <GiphyBadge />
+    </View>
+  ) : null;
+};
+
+/**
+ * MessageInputTrailingView
+ * @param prevProps
+ */
+
+export const MessageInputTrailingView = ({
+  micPositionX,
+  micPositionY,
+}: {
+  micPositionX: Animated.SharedValue<number>;
+  micPositionY: Animated.SharedValue<number>;
+}) => {
+  const styles = useStyles();
+  const {
+    theme: {
+      messageInput: { outputButtonsContainer },
+    },
+  } = useTheme();
+  const { audioRecorderManager } = useMessageInputContext();
+  const { micLocked, recordingStatus } = useStateStore(
+    audioRecorderManager.state,
+    audioRecorderSelector,
+  );
+  return (recordingStatus === 'idle' || recordingStatus === 'recording') && !micLocked ? (
+    <View style={[styles.outputButtonsContainer, outputButtonsContainer]}>
+      <OutputButtons micPositionX={micPositionX} micPositionY={micPositionY} />
+    </View>
+  ) : null;
+};
+
 const areEqual = (
   prevProps: MessageInputPropsWithContext,
   nextProps: MessageInputPropsWithContext,
@@ -613,7 +703,6 @@ const areEqual = (
     editing: nextEditing,
     isKeyboardVisible: nextIsKeyboardVisible,
     isOnline: nextIsOnline,
-    hasAttachments: nextHasAttachments,
     openPollCreationDialog: nextOpenPollCreationDialog,
     selectedPicker: nextSelectedPicker,
     showPollCreationDialog: nextShowPollCreationDialog,
@@ -673,11 +762,6 @@ const areEqual = (
 
   const editingEqual = !!prevEditing === !!nextEditing;
   if (!editingEqual) {
-    return false;
-  }
-
-  const hasAttachmentsEqual = prevHasAttachments === nextHasAttachments;
-  if (!hasAttachmentsEqual) {
     return false;
   }
 
@@ -798,7 +882,6 @@ export const MessageInput = (props: MessageInputProps) => {
   const { clearEditingState } = useMessageComposerAPIContext();
 
   const { Reply } = useMessagesContext();
-  const { attachments } = useAttachmentManagerState();
   const isKeyboardVisible = useKeyboardVisibility();
 
   const { micLocked, isRecordingStateIdle, recordingStatus } = useStateStore(
@@ -854,7 +937,6 @@ export const MessageInput = (props: MessageInputProps) => {
         disableAttachmentPicker,
         editing,
         FileSelectorIcon,
-        hasAttachments: attachments.length > 0,
         ImageSelectorIcon,
         Input,
         inputBoxRef,

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -19,15 +19,11 @@ import { type MessageComposerState, type TextComposerState, type UserResponse } 
 import { InputButtons } from './components/InputButtons';
 import { LinkPreviewList } from './components/LinkPreviewList';
 import { OutputButtons } from './components/OutputButtons';
+import { MicPositionProvider } from './contexts/MicPositionContext';
 
 import { useHasLinkPreviews } from './hooks/useLinkPreviews';
 
-import {
-  ChatContextValue,
-  useAttachmentManagerState,
-  useChatContext,
-  useOwnCapabilitiesContext,
-} from '../../contexts';
+import { ChatContextValue, useChatContext, useOwnCapabilitiesContext } from '../../contexts';
 import {
   AttachmentPickerContextValue,
   useAttachmentPickerContext,
@@ -363,150 +359,154 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
 
   const BOTTOM_OFFSET = isKeyboardVisible ? 16 : bottom ? bottom : 16;
 
+  const micPositionContextValue = useMemo(
+    () => ({ micPositionX, micPositionY }),
+    [micPositionX, micPositionY],
+  );
+
   return (
-    <>
-      <Animated.View
-        layout={LinearTransition.duration(200)}
-        onLayout={({
-          nativeEvent: {
-            layout: { height: newHeight },
-          },
-        }) =>
-          messageInputHeightStore.setHeight(
-            messageInputFloating ? newHeight + BOTTOM_OFFSET : newHeight,
-          )
-        } // BOTTOM OFFSET is the position of the input from the bottom of the screen
-        style={
-          messageInputFloating
-            ? [styles.wrapper, styles.floatingWrapper, { bottom: BOTTOM_OFFSET }, floatingWrapper]
-            : [
-                styles.wrapper,
-                {
-                  borderTopWidth: 1,
-                  backgroundColor: semantics.composerBg,
-                  borderColor: semantics.borderCoreDefault,
-                  paddingBottom: BOTTOM_OFFSET,
-                },
-                wrapper,
-              ]
-        }
-      >
-        {Input ? (
-          <Input additionalTextInputProps={additionalTextInputProps} getUsers={getUsers} />
-        ) : (
-          <View style={[styles.container, container]}>
-            <MessageComposerLeadingView />
-            <Animated.View
-              layout={LinearTransition.duration(200)}
-              style={[
-                styles.inputBoxWrapper,
-                messageInputFloating ? [styles.shadow, inputFloatingContainer] : null,
-                inputBoxWrapper,
-                isFocused ? focusedInputBoxContainer : null,
-              ]}
-            >
-              <View style={[styles.inputBoxContainer, inputBoxContainer]}>
-                {recordingStatus === 'stopped' ? (
-                  <AudioRecordingPreview />
-                ) : micLocked ? (
-                  <AudioRecordingInProgress />
-                ) : null}
-
-                <MessageInputHeaderView />
-
-                <Animated.View
-                  style={[styles.inputContainer, inputContainer]}
-                  layout={LinearTransition.duration(200)}
-                >
-                  {!isRecordingStateIdle ? (
-                    <AudioRecorder slideToCancelStyle={slideToCancelAnimatedStyle} />
-                  ) : (
-                    <>
-                      <MessageInputLeadingView />
-
-                      <AutoCompleteInput
-                        TextInputComponent={TextInputComponent}
-                        {...additionalTextInputProps}
-                      />
-                    </>
-                  )}
-
-                  <MessageInputTrailingView
-                    micPositionX={micPositionX}
-                    micPositionY={micPositionY}
-                  />
-                </Animated.View>
-              </View>
-            </Animated.View>
-          </View>
-        )}
-        <ShowThreadMessageInChannelButton threadList={threadList} />
-      </Animated.View>
-
-      {!isRecordingStateIdle ? (
-        <View
-          style={[
-            styles.audioLockIndicatorWrapper,
-            {
-              bottom: messageInputFloating ? 0 : 16,
+    <MicPositionProvider value={micPositionContextValue}>
+      <>
+        <Animated.View
+          layout={LinearTransition.duration(200)}
+          onLayout={({
+            nativeEvent: {
+              layout: { height: newHeight },
             },
-          ]}
+          }) =>
+            messageInputHeightStore.setHeight(
+              messageInputFloating ? newHeight + BOTTOM_OFFSET : newHeight,
+            )
+          } // BOTTOM OFFSET is the position of the input from the bottom of the screen
+          style={
+            messageInputFloating
+              ? [styles.wrapper, styles.floatingWrapper, { bottom: BOTTOM_OFFSET }, floatingWrapper]
+              : [
+                  styles.wrapper,
+                  {
+                    borderTopWidth: 1,
+                    backgroundColor: semantics.composerBg,
+                    borderColor: semantics.borderCoreDefault,
+                    paddingBottom: BOTTOM_OFFSET,
+                  },
+                  wrapper,
+                ]
+          }
         >
-          <AudioRecordingLockIndicator
-            messageInputHeight={height}
-            micLocked={micLocked}
-            style={lockIndicatorAnimatedStyle}
-          />
-        </View>
-      ) : (
-        <MessageComposerTrailingView />
-      )}
+          {Input ? (
+            <Input additionalTextInputProps={additionalTextInputProps} getUsers={getUsers} />
+          ) : (
+            <View style={[styles.container, container]}>
+              <MessageComposerLeadingView />
+              <Animated.View
+                layout={LinearTransition.duration(200)}
+                style={[
+                  styles.inputBoxWrapper,
+                  messageInputFloating ? [styles.shadow, inputFloatingContainer] : null,
+                  inputBoxWrapper,
+                  isFocused ? focusedInputBoxContainer : null,
+                ]}
+              >
+                <View style={[styles.inputBoxContainer, inputBoxContainer]}>
+                  {recordingStatus === 'stopped' ? (
+                    <AudioRecordingPreview />
+                  ) : micLocked ? (
+                    <AudioRecordingInProgress />
+                  ) : null}
 
-      <Animated.View
-        entering={FadeIn.duration(200)}
-        exiting={FadeOut.duration(200)}
-        layout={LinearTransition.duration(200)}
-        style={[styles.suggestionsListContainer, { bottom: height }, suggestionListContainer]}
-      >
-        <AutoCompleteSuggestionList />
-      </Animated.View>
-      {!disableAttachmentPicker && selectedPicker ? (
+                  <MessageInputHeaderView />
+
+                  <Animated.View
+                    style={[styles.inputContainer, inputContainer]}
+                    layout={LinearTransition.duration(200)}
+                  >
+                    {!isRecordingStateIdle ? (
+                      <AudioRecorder slideToCancelStyle={slideToCancelAnimatedStyle} />
+                    ) : (
+                      <>
+                        <MessageInputLeadingView />
+
+                        <AutoCompleteInput
+                          TextInputComponent={TextInputComponent}
+                          {...additionalTextInputProps}
+                        />
+                      </>
+                    )}
+
+                    <MessageInputTrailingView />
+                  </Animated.View>
+                </View>
+              </Animated.View>
+            </View>
+          )}
+          <ShowThreadMessageInChannelButton threadList={threadList} />
+        </Animated.View>
+
+        {!isRecordingStateIdle ? (
+          <View
+            style={[
+              styles.audioLockIndicatorWrapper,
+              {
+                bottom: messageInputFloating ? 0 : 16,
+              },
+            ]}
+          >
+            <AudioRecordingLockIndicator
+              messageInputHeight={height}
+              micLocked={micLocked}
+              style={lockIndicatorAnimatedStyle}
+            />
+          </View>
+        ) : (
+          <MessageComposerTrailingView />
+        )}
+
         <Animated.View
           entering={FadeIn.duration(200)}
           exiting={FadeOut.duration(200)}
-          style={[
-            {
-              backgroundColor: semantics.composerBg,
-              height:
-                attachmentPickerBottomSheetHeight + attachmentSelectionBarHeight - bottomInset,
-            },
-            attachmentSelectionBar,
-          ]}
+          layout={LinearTransition.duration(200)}
+          style={[styles.suggestionsListContainer, { bottom: height }, suggestionListContainer]}
         >
-          <AttachmentPickerSelectionBar />
+          <AutoCompleteSuggestionList />
         </Animated.View>
-      ) : null}
-
-      {showPollCreationDialog ? (
-        <View style={{ alignItems: 'center', flex: 1, justifyContent: 'center' }}>
-          <Modal
-            animationType='slide'
-            onRequestClose={closePollCreationDialog}
-            visible={showPollCreationDialog}
+        {!disableAttachmentPicker && selectedPicker ? (
+          <Animated.View
+            entering={FadeIn.duration(200)}
+            exiting={FadeOut.duration(200)}
+            style={[
+              {
+                backgroundColor: semantics.composerBg,
+                height:
+                  attachmentPickerBottomSheetHeight + attachmentSelectionBarHeight - bottomInset,
+              },
+              attachmentSelectionBar,
+            ]}
           >
-            <GestureHandlerRootView style={{ flex: 1 }}>
-              <SafeAreaViewWrapper style={{ flex: 1 }}>
-                <CreatePoll
-                  closePollCreationDialog={closePollCreationDialog}
-                  CreatePollContent={CreatePollContent}
-                  sendMessage={sendMessage}
-                />
-              </SafeAreaViewWrapper>
-            </GestureHandlerRootView>
-          </Modal>
-        </View>
-      ) : null}
-    </>
+            <AttachmentPickerSelectionBar />
+          </Animated.View>
+        ) : null}
+
+        {showPollCreationDialog ? (
+          <View style={{ alignItems: 'center', flex: 1, justifyContent: 'center' }}>
+            <Modal
+              animationType='slide'
+              onRequestClose={closePollCreationDialog}
+              visible={showPollCreationDialog}
+            >
+              <GestureHandlerRootView style={{ flex: 1 }}>
+                <SafeAreaViewWrapper style={{ flex: 1 }}>
+                  <CreatePoll
+                    closePollCreationDialog={closePollCreationDialog}
+                    CreatePollContent={CreatePollContent}
+                    sendMessage={sendMessage}
+                  />
+                </SafeAreaViewWrapper>
+              </GestureHandlerRootView>
+            </Modal>
+          </View>
+        ) : null}
+      </>
+    </MicPositionProvider>
   );
 };
 
@@ -572,9 +572,6 @@ export const MessageInputHeaderView = () => {
   const messageComposer = useMessageComposer();
   const editing = !!messageComposer.editedMessage;
   const { clearEditingState } = useMessageComposerAPIContext();
-  const onDismissEditMessage = () => {
-    clearEditingState();
-  };
   const { quotedMessage } = useStateStore(messageComposer.state, messageComposerStateStoreSelector);
   const hasLinkPreviews = useHasLinkPreviews();
   const { audioRecorderManager, AttachmentUploadPreviewList } = useMessageInputContext();
@@ -603,7 +600,7 @@ export const MessageInputHeaderView = () => {
         <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)}>
           <Reply
             mode='edit'
-            onDismiss={onDismissEditMessage}
+            onDismiss={clearEditingState}
             quotedMessage={messageComposer.editedMessage}
           />
         </Animated.View>
@@ -642,13 +639,7 @@ export const MessageInputLeadingView = () => {
  * @param prevProps
  */
 
-export const MessageInputTrailingView = ({
-  micPositionX,
-  micPositionY,
-}: {
-  micPositionX: Animated.SharedValue<number>;
-  micPositionY: Animated.SharedValue<number>;
-}) => {
+export const MessageInputTrailingView = () => {
   const styles = useStyles();
   const {
     theme: {
@@ -662,7 +653,7 @@ export const MessageInputTrailingView = ({
   );
   return (recordingStatus === 'idle' || recordingStatus === 'recording') && !micLocked ? (
     <View style={[styles.outputButtonsContainer, outputButtonsContainer]}>
-      <OutputButtons micPositionX={micPositionX} micPositionY={micPositionY} />
+      <OutputButtons />
     </View>
   ) : null;
 };
@@ -680,7 +671,6 @@ const areEqual = (
     channel: prevChannel,
     closePollCreationDialog: prevClosePollCreationDialog,
     editing: prevEditing,
-    hasAttachments: prevHasAttachments,
     isKeyboardVisible: prevIsKeyboardVisible,
     isOnline: prevIsOnline,
     openPollCreationDialog: prevOpenPollCreationDialog,

--- a/package/src/components/MessageInput/MessageInputHeaderView.tsx
+++ b/package/src/components/MessageInput/MessageInputHeaderView.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
+
+import { LinkPreviewList } from './components/LinkPreviewList';
+import { useHasLinkPreviews } from './hooks/useLinkPreviews';
+
+import { idleRecordingStateSelector } from './utils/audioRecorderSelectors';
+import { messageComposerStateStoreSelector } from './utils/messageComposerSelectors';
+
+import { useMessageComposerAPIContext } from '../../contexts/messageComposerContext/MessageComposerAPIContext';
+import { useHasAttachments } from '../../contexts/messageInputContext/hooks/useHasAttachments';
+import { useMessageComposer } from '../../contexts/messageInputContext/hooks/useMessageComposer';
+import { useMessageInputContext } from '../../contexts/messageInputContext/MessageInputContext';
+import { useMessagesContext } from '../../contexts/messagesContext/MessagesContext';
+import { useTheme } from '../../contexts/themeContext/ThemeContext';
+import { useStateStore } from '../../hooks/useStateStore';
+import { primitives } from '../../theme';
+
+export const MessageInputHeaderView = () => {
+  const {
+    theme: {
+      messageInput: { contentContainer },
+    },
+  } = useTheme();
+  const messageComposer = useMessageComposer();
+  const editing = !!messageComposer.editedMessage;
+  const { clearEditingState } = useMessageComposerAPIContext();
+  const { quotedMessage } = useStateStore(messageComposer.state, messageComposerStateStoreSelector);
+  const hasLinkPreviews = useHasLinkPreviews();
+  const { audioRecorderManager, AttachmentUploadPreviewList } = useMessageInputContext();
+  const { Reply } = useMessagesContext();
+  const { isRecordingStateIdle } = useStateStore(
+    audioRecorderManager.state,
+    idleRecordingStateSelector,
+  );
+  const hasAttachments = useHasAttachments();
+
+  return isRecordingStateIdle ? (
+    <Animated.View
+      layout={LinearTransition.duration(200)}
+      style={[
+        styles.contentContainer,
+        {
+          paddingTop:
+            hasAttachments || quotedMessage || editing || hasLinkPreviews
+              ? primitives.spacingXs
+              : 0,
+        },
+        contentContainer,
+      ]}
+    >
+      {editing ? (
+        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)}>
+          <Reply
+            mode='edit'
+            onDismiss={clearEditingState}
+            quotedMessage={messageComposer.editedMessage}
+          />
+        </Animated.View>
+      ) : null}
+      {quotedMessage ? (
+        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)}>
+          <Reply mode='reply' />
+        </Animated.View>
+      ) : null}
+      <AttachmentUploadPreviewList />
+      <LinkPreviewList />
+    </Animated.View>
+  ) : null;
+};
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    gap: primitives.spacingXxs,
+    overflow: 'hidden',
+    paddingHorizontal: primitives.spacingXs,
+  },
+});

--- a/package/src/components/MessageInput/MessageInputLeadingView.tsx
+++ b/package/src/components/MessageInput/MessageInputLeadingView.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { textComposerStateSelector } from './utils/messageComposerSelectors';
+
+import { useMessageComposer } from '../../contexts/messageInputContext/hooks/useMessageComposer';
+import { useStateStore } from '../../hooks/useStateStore';
+import { primitives } from '../../theme';
+import { GiphyBadge } from '../ui/GiphyBadge';
+
+export const MessageInputLeadingView = () => {
+  const messageComposer = useMessageComposer();
+  const { textComposer } = messageComposer;
+  const { command } = useStateStore(textComposer.state, textComposerStateSelector);
+
+  return command ? (
+    <View style={styles.giphyContainer}>
+      <GiphyBadge />
+    </View>
+  ) : null;
+};
+
+const styles = StyleSheet.create({
+  giphyContainer: {
+    padding: primitives.spacingXs,
+  },
+});

--- a/package/src/components/MessageInput/MessageInputTrailingView.tsx
+++ b/package/src/components/MessageInput/MessageInputTrailingView.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { OutputButtons } from './components/OutputButtons';
+
+import { audioRecorderSelector } from './utils/audioRecorderSelectors';
+
+import { useMessageInputContext } from '../../contexts/messageInputContext/MessageInputContext';
+import { useTheme } from '../../contexts/themeContext/ThemeContext';
+import { useStateStore } from '../../hooks/useStateStore';
+import { primitives } from '../../theme';
+
+export const MessageInputTrailingView = () => {
+  const {
+    theme: {
+      messageInput: { outputButtonsContainer },
+    },
+  } = useTheme();
+  const { audioRecorderManager } = useMessageInputContext();
+  const { micLocked, recordingStatus } = useStateStore(
+    audioRecorderManager.state,
+    audioRecorderSelector,
+  );
+  return (recordingStatus === 'idle' || recordingStatus === 'recording') && !micLocked ? (
+    <View style={[styles.outputButtonsContainer, outputButtonsContainer]}>
+      <OutputButtons />
+    </View>
+  ) : null;
+};
+
+const styles = StyleSheet.create({
+  outputButtonsContainer: {
+    alignSelf: 'flex-end',
+    padding: primitives.spacingXs,
+  },
+});

--- a/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.js.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.js.snap
@@ -40,7 +40,7 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": false,
               "expanded": undefined,
               "selected": undefined,
             }
@@ -393,7 +393,7 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": false,
               "expanded": undefined,
               "selected": undefined,
             }
@@ -746,7 +746,7 @@ exports[`AttachButton should render an disabled AttachButton 1`] = `
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": true,
               "expanded": undefined,
               "selected": undefined,
             }

--- a/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.js.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.js.snap
@@ -39,7 +39,7 @@ exports[`SendButton should render a SendButton 1`] = `
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": false,
               "expanded": undefined,
               "selected": undefined,
             }
@@ -389,7 +389,7 @@ exports[`SendButton should render a disabled SendButton 1`] = `
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": true,
               "expanded": undefined,
               "selected": undefined,
             }

--- a/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingButton.tsx
+++ b/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingButton.tsx
@@ -23,7 +23,8 @@ import { useStateStore } from '../../../../hooks/useStateStore';
 import { NewMic } from '../../../../icons/NewMic';
 import { NativeHandlers } from '../../../../native';
 import { AudioRecorderManagerState } from '../../../../state-store/audio-recorder-manager';
-import { Button } from '../../../ui';
+import { primitives } from '../../../../theme';
+import { ButtonStylesConfig, useButtonStyles } from '../../../ui/Button/hooks/useButtonStyles';
 
 export type AudioRecordingButtonPropsWithContext = Pick<
   MessageInputContextValue,
@@ -54,6 +55,11 @@ export type AudioRecordingButtonPropsWithContext = Pick<
     cancellableDuration: boolean;
   };
 
+const buttonStylesConfig: ButtonStylesConfig = {
+  variant: 'secondary',
+  type: 'ghost',
+};
+
 /**
  * Component to display the mic button on the Message Input.
  */
@@ -77,13 +83,16 @@ export const AudioRecordingButtonWithContext = (props: AudioRecordingButtonProps
   } = props;
   const activeAudioPlayer = useActiveAudioPlayer();
   const scale = useSharedValue(1);
+  const pressed = useSharedValue(false);
 
   const { t } = useTranslationContext();
   const {
     theme: {
       messageInput: { micButtonContainer },
+      semantics,
     },
   } = useTheme();
+  const buttonStyles = useButtonStyles(buttonStylesConfig);
 
   const onPressHandler = useStableCallback(() => {
     if (handlePress) {
@@ -147,9 +156,9 @@ export const AudioRecordingButtonWithContext = (props: AudioRecordingButtonProps
   const onTouchGestureEnd = useStableCallback(() => {
     if (status === 'recording') {
       if (cancellableDuration) {
-        runOnJS(onEarlyReleaseHandler)();
+        onEarlyReleaseHandler();
       } else {
-        runOnJS(uploadVoiceRecording)(asyncMessagesMultiSendEnabled);
+        uploadVoiceRecording(asyncMessagesMultiSendEnabled);
       }
     }
   });
@@ -160,17 +169,19 @@ export const AudioRecordingButtonWithContext = (props: AudioRecordingButtonProps
         .minDuration(asyncMessagesMinimumPressDuration)
         .onBegin(() => {
           scale.value = withSpring(0.8, { mass: 0.5 });
+          pressed.value = true;
         })
         .onStart(() => {
           runOnJS(onLongPressHandler)();
         })
         .onFinalize((e) => {
           scale.value = withSpring(1, { mass: 0.5 });
+          pressed.value = false;
           if (e.state === State.FAILED) {
             runOnJS(onPressHandler)();
           }
         }),
-    [asyncMessagesMinimumPressDuration, onLongPressHandler, onPressHandler, scale],
+    [asyncMessagesMinimumPressDuration, onLongPressHandler, onPressHandler, scale, pressed],
   );
 
   const panGesture = useMemo(
@@ -222,24 +233,14 @@ export const AudioRecordingButtonWithContext = (props: AudioRecordingButtonProps
   const animatedStyle = useAnimatedStyle(() => {
     return {
       transform: [{ scale: scale.value }],
+      backgroundColor: pressed.value ? semantics.backgroundCorePressed : 'transparent',
     };
   });
 
   return (
     <GestureDetector gesture={Gesture.Simultaneous(panGesture, tapGesture)}>
       <Animated.View style={[styles.container, animatedStyle, micButtonContainer]}>
-        <Button
-          accessibilityLabel='Start recording'
-          variant='secondary'
-          type='ghost'
-          delayLongPress={asyncMessagesMinimumPressDuration}
-          LeadingIcon={NewMic}
-          onLongPress={onLongPressHandler}
-          onPress={onPressHandler}
-          size='sm'
-          iconOnly
-          disabled={true}
-        />
+        <NewMic height={20} width={20} strokeWidth={1.5} stroke={buttonStyles.foregroundColor} />
       </Animated.View>
     </GestureDetector>
   );
@@ -300,5 +301,11 @@ export const AudioRecordingButton = (props: AudioRecordingButtonProps) => {
 AudioRecordingButton.displayName = 'AudioRecordingButton{messageInput}';
 
 const styles = StyleSheet.create({
-  container: {},
+  container: {
+    borderRadius: primitives.radiusMax,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 32,
+    width: 32,
+  },
 });

--- a/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingButton.tsx
+++ b/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingButton.tsx
@@ -5,7 +5,6 @@ import { Gesture, GestureDetector, State } from 'react-native-gesture-handler';
 import Animated, {
   clamp,
   runOnJS,
-  SharedValue,
   useAnimatedStyle,
   useSharedValue,
   withSpring,
@@ -25,6 +24,7 @@ import { NativeHandlers } from '../../../../native';
 import { AudioRecorderManagerState } from '../../../../state-store/audio-recorder-manager';
 import { primitives } from '../../../../theme';
 import { ButtonStylesConfig, useButtonStyles } from '../../../ui/Button/hooks/useButtonStyles';
+import { useMicPositionContext } from '../../contexts/MicPositionContext';
 
 export type AudioRecordingButtonPropsWithContext = Pick<
   MessageInputContextValue,
@@ -50,8 +50,6 @@ export type AudioRecordingButtonPropsWithContext = Pick<
      * Handler to determine what should happen on press of the mic button.
      */
     handlePress?: () => void;
-    micPositionX: SharedValue<number>;
-    micPositionY: SharedValue<number>;
     cancellableDuration: boolean;
   };
 
@@ -75,12 +73,11 @@ export const AudioRecordingButtonWithContext = (props: AudioRecordingButtonProps
     uploadVoiceRecording,
     handleLongPress,
     handlePress,
-    micPositionX,
-    micPositionY,
     cancellableDuration,
     status,
     recording,
   } = props;
+  const { micPositionX, micPositionY } = useMicPositionContext();
   const activeAudioPlayer = useActiveAudioPlayer();
   const scale = useSharedValue(1);
   const pressed = useSharedValue(false);
@@ -246,10 +243,7 @@ export const AudioRecordingButtonWithContext = (props: AudioRecordingButtonProps
   );
 };
 
-export type AudioRecordingButtonProps = Partial<AudioRecordingButtonPropsWithContext> & {
-  micPositionX: SharedValue<number>;
-  micPositionY: SharedValue<number>;
-};
+export type AudioRecordingButtonProps = Partial<AudioRecordingButtonPropsWithContext>;
 
 const MemoizedAudioRecordingButton = React.memo(
   AudioRecordingButtonWithContext,

--- a/package/src/components/MessageInput/components/OutputButtons/index.tsx
+++ b/package/src/components/MessageInput/components/OutputButtons/index.tsx
@@ -24,10 +24,7 @@ import { useStateStore } from '../../../../hooks/useStateStore';
 import { AIStates, useAIState } from '../../../AITypingIndicatorView';
 import { useIsCooldownActive } from '../../hooks/useIsCooldownActive';
 
-export type OutputButtonsProps = Partial<OutputButtonsWithContextProps> & {
-  micPositionX: Animated.SharedValue<number>;
-  micPositionY: Animated.SharedValue<number>;
-};
+export type OutputButtonsProps = Partial<OutputButtonsWithContextProps>;
 
 export type OutputButtonsWithContextProps = Pick<ChatContextValue, 'isOnline'> &
   Pick<ChannelContextValue, 'channel'> &
@@ -43,8 +40,6 @@ export type OutputButtonsWithContextProps = Pick<ChatContextValue, 'isOnline'> &
     | 'StopMessageStreamingButton'
     | 'StartAudioRecordingButton'
   > & {
-    micPositionX: Animated.SharedValue<number>;
-    micPositionY: Animated.SharedValue<number>;
     cooldownIsActive: boolean;
   };
 
@@ -62,8 +57,6 @@ export const OutputButtonsWithContext = (props: OutputButtonsWithContextProps) =
     SendButton,
     StopMessageStreamingButton,
     StartAudioRecordingButton,
-    micPositionX,
-    micPositionY,
   } = props;
   const {
     theme: {
@@ -120,7 +113,7 @@ export const OutputButtonsWithContext = (props: OutputButtonsWithContextProps) =
         key='audio-recording-button'
         style={audioRecordingButtonContainer}
       >
-        <StartAudioRecordingButton micPositionX={micPositionX} micPositionY={micPositionY} />
+        <StartAudioRecordingButton />
       </Animated.View>
     );
   } else {

--- a/package/src/components/MessageInput/contexts/MicPositionContext.tsx
+++ b/package/src/components/MessageInput/contexts/MicPositionContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, PropsWithChildren, useContext } from 'react';
+
+import { SharedValue } from 'react-native-reanimated';
+
+import { DEFAULT_BASE_CONTEXT_VALUE } from '../../../contexts/utils/defaultBaseContextValue';
+import { isTestEnvironment } from '../../../contexts/utils/isTestEnvironment';
+
+export type MicPositionContextValue = {
+  micPositionX: SharedValue<number>;
+  micPositionY: SharedValue<number>;
+};
+
+const MicPositionContext = createContext(
+  DEFAULT_BASE_CONTEXT_VALUE as unknown as MicPositionContextValue,
+);
+
+export const MicPositionProvider = ({
+  children,
+  value,
+}: PropsWithChildren<{ value: MicPositionContextValue }>) => (
+  <MicPositionContext.Provider value={value}>{children}</MicPositionContext.Provider>
+);
+
+export const useMicPositionContext = () => {
+  const contextValue = useContext(MicPositionContext) as unknown as MicPositionContextValue;
+
+  if (contextValue === DEFAULT_BASE_CONTEXT_VALUE && !isTestEnvironment()) {
+    throw new Error(
+      'The useMicPositionContext hook was called outside of the MicPositionProvider. Make sure MessageInput wraps the subtree where mic positions are used.',
+    );
+  }
+
+  return contextValue;
+};

--- a/package/src/components/MessageInput/utils/audioRecorderSelectors.ts
+++ b/package/src/components/MessageInput/utils/audioRecorderSelectors.ts
@@ -1,0 +1,11 @@
+import { AudioRecorderManagerState } from '../../../state-store/audio-recorder-manager';
+
+export const idleRecordingStateSelector = (state: AudioRecorderManagerState) => ({
+  isRecordingStateIdle: state.status === 'idle',
+});
+
+export const audioRecorderSelector = (state: AudioRecorderManagerState) => ({
+  micLocked: state.micLocked,
+  isRecordingStateIdle: state.status === 'idle',
+  recordingStatus: state.status,
+});

--- a/package/src/components/MessageInput/utils/messageComposerSelectors.ts
+++ b/package/src/components/MessageInput/utils/messageComposerSelectors.ts
@@ -1,0 +1,9 @@
+import { MessageComposerState, TextComposerState } from 'stream-chat';
+
+export const textComposerStateSelector = (state: TextComposerState) => ({
+  command: state.command,
+});
+
+export const messageComposerStateStoreSelector = (state: MessageComposerState) => ({
+  quotedMessage: state.quotedMessage,
+});

--- a/package/src/components/MessageList/__tests__/__snapshots__/ScrollToBottomButton.test.js.snap
+++ b/package/src/components/MessageList/__tests__/__snapshots__/ScrollToBottomButton.test.js.snap
@@ -53,7 +53,7 @@ exports[`ScrollToBottomButton should render the message notification and match s
           {
             "busy": undefined,
             "checked": undefined,
-            "disabled": undefined,
+            "disabled": false,
             "expanded": undefined,
             "selected": undefined,
           }

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -1951,7 +1951,7 @@ exports[`Thread should match thread snapshot 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": undefined,
+                    "disabled": false,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -2200,7 +2200,7 @@ exports[`Thread should match thread snapshot 1`] = `
                         {
                           "busy": undefined,
                           "checked": undefined,
-                          "disabled": undefined,
+                          "disabled": true,
                           "expanded": undefined,
                           "selected": undefined,
                         }

--- a/package/src/components/index.ts
+++ b/package/src/components/index.ts
@@ -133,6 +133,7 @@ export * from './MessageInput/components/AudioRecorder/AudioRecordingInProgress'
 export * from './MessageInput/components/AudioRecorder/AudioRecordingLockIndicator';
 export * from './MessageInput/components/AudioRecorder/AudioRecordingPreview';
 export * from './MessageInput/components/AudioRecorder/AudioRecordingWaveform';
+export * from './MessageInput/contexts/MicPositionContext';
 
 export * from './MessageInput/components/AttachmentPreview/AttachmentUnsupportedIndicator';
 export * from './MessageInput/components/AttachmentPreview/AttachmentUploadProgressIndicator';

--- a/package/src/components/index.ts
+++ b/package/src/components/index.ts
@@ -123,6 +123,11 @@ export * from './MessageInput/components/AttachmentPreview/AttachmentUploadPrevi
 export * from './MessageInput/components/OutputButtons/CooldownTimer';
 export * from './MessageInput/components/InputButtons';
 export * from './MessageInput/MessageInput';
+export * from './MessageInput/MessageComposerLeadingView';
+export * from './MessageInput/MessageComposerTrailingView';
+export * from './MessageInput/MessageInputHeaderView';
+export * from './MessageInput/MessageInputLeadingView';
+export * from './MessageInput/MessageInputTrailingView';
 export * from './MessageInput/components/OutputButtons/SendButton';
 export * from './MessageInput/SendMessageDisallowedIndicator';
 export * from './MessageInput/ShowThreadMessageInChannelButton';

--- a/package/src/components/ui/Button/Button.tsx
+++ b/package/src/components/ui/Button/Button.tsx
@@ -97,6 +97,7 @@ export const Button = ({
           styles.container,
           { paddingHorizontal: buttonPadding[size] },
         ]}
+        disabled={disabled}
         {...rest}
       >
         {LeftIcon ? (

--- a/package/src/components/ui/Button/hooks/useButtonStyles.ts
+++ b/package/src/components/ui/Button/hooks/useButtonStyles.ts
@@ -24,13 +24,15 @@ export type ButtonStyle = {
   disabledBorderColor?: ColorValue;
 };
 
+export type ButtonStylesConfig = Pick<ButtonProps, 'variant' | 'type'>;
+
 /**
  * Returns the styles for the button based on the button style and type.
  * @param buttonStyle - The style of the button.
  * @param type - The type of the button.
  * @returns The styles for the button.
  */
-export const useButtonStyles = ({ variant, type }: Pick<ButtonProps, 'variant' | 'type'>) => {
+export const useButtonStyles = ({ variant, type }: ButtonStylesConfig) => {
   const {
     theme: { semantics },
   } = useTheme();

--- a/package/src/contexts/messageInputContext/hooks/useHasAttachments.ts
+++ b/package/src/contexts/messageInputContext/hooks/useHasAttachments.ts
@@ -1,0 +1,15 @@
+import type { AttachmentManagerState } from 'stream-chat';
+
+import { useMessageComposer } from './useMessageComposer';
+
+import { useStateStore } from '../../../hooks/useStateStore';
+
+const stateSelector = (state: AttachmentManagerState) => ({
+  hasAttachments: state.attachments.length > 0,
+});
+
+export const useHasAttachments = () => {
+  const { attachmentManager } = useMessageComposer();
+  const { hasAttachments } = useStateStore(attachmentManager.state, stateSelector);
+  return hasAttachments;
+};


### PR DESCRIPTION
## 🎯 Goal

This PR implements message composer slots as discussed with the other SDKs. The composer slots are meant to be an easy way to override larger chunks of the composer while maintaining the other bits intact.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


