### PR TITLE
fix: portal content disappearing when mounted and relayouted

### DIFF
--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -842,8 +842,8 @@ const MessageWithContext = (props: MessagePropsWithContext) => {
             />
           ) : null}
           {/*TODO: V9: Find a way to separate these in a dedicated file*/}
-          {overlayActive && rect ? (
-            <Portal hostName='top-item'>
+          <Portal hostName={overlayActive && rect ? 'top-item' : undefined}>
+            {overlayActive && rect ? (
               <View
                 onLayout={(e) => {
                   const { width: w, height: h } = e.nativeEvent.layout;
@@ -861,16 +861,30 @@ const MessageWithContext = (props: MessagePropsWithContext) => {
                   handleReaction={ownCapabilities.sendReaction ? handleReaction : undefined}
                 />
               </View>
-            </Portal>
-          ) : null}
+            ) : null}
+          </Portal>
           <Portal
             hostName={overlayActive ? 'message-overlay' : undefined}
             style={overlayActive && rect ? { width: rect.w } : undefined}
           >
             <MessageSimple ref={messageWrapperRef} />
           </Portal>
-          {overlayActive && rect ? (
-            <Portal hostName='bottom-item'>
+          {showMessageReactions ? (
+            <BottomSheetModal
+              lazy={true}
+              onClose={() => setShowMessageReactions(false)}
+              visible={showMessageReactions}
+              height={424}
+            >
+              <MessageUserReactions
+                message={message}
+                MessageUserReactionsAvatar={MessageUserReactionsAvatar}
+                MessageUserReactionsItem={MessageUserReactionsItem}
+              />
+            </BottomSheetModal>
+          ) : null}
+          <Portal hostName={overlayActive && rect ? 'bottom-item' : undefined}>
+            {overlayActive && rect ? (
               <View
                 onLayout={(e) => {
                   const { width: w, height: h } = e.nativeEvent.layout;
@@ -888,22 +902,8 @@ const MessageWithContext = (props: MessagePropsWithContext) => {
                   messageActions={messageActions}
                 />
               </View>
-            </Portal>
-          ) : null}
-          {showMessageReactions ? (
-            <BottomSheetModal
-              lazy={true}
-              onClose={() => setShowMessageReactions(false)}
-              visible={showMessageReactions}
-              height={424}
-            >
-              <MessageUserReactions
-                message={message}
-                MessageUserReactionsAvatar={MessageUserReactionsAvatar}
-                MessageUserReactionsItem={MessageUserReactionsItem}
-              />
-            </BottomSheetModal>
-          ) : null}
+            ) : null}
+          </Portal>
           {isBounceDialogOpen ? (
             <MessageBounce setIsBounceDialogOpen={setIsBounceDialogOpen} />
           ) : null}

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -382,6 +382,7 @@ exports[`Thread should match thread snapshot 1`] = `
                     }
                     testID="message-wrapper"
                   >
+                    <View />
                     <View>
                       <View>
                         <View
@@ -681,6 +682,7 @@ exports[`Thread should match thread snapshot 1`] = `
                         </View>
                       </View>
                     </View>
+                    <View />
                   </View>
                 </View>
               </View>
@@ -735,6 +737,7 @@ exports[`Thread should match thread snapshot 1`] = `
                     }
                     testID="message-wrapper"
                   >
+                    <View />
                     <View>
                       <View>
                         <View
@@ -1034,6 +1037,7 @@ exports[`Thread should match thread snapshot 1`] = `
                         </View>
                       </View>
                     </View>
+                    <View />
                   </View>
                 </View>
               </View>
@@ -1113,6 +1117,7 @@ exports[`Thread should match thread snapshot 1`] = `
                     }
                     testID="message-wrapper"
                   >
+                    <View />
                     <View>
                       <View>
                         <View
@@ -1412,6 +1417,7 @@ exports[`Thread should match thread snapshot 1`] = `
                         </View>
                       </View>
                     </View>
+                    <View />
                   </View>
                 </View>
               </View>
@@ -1467,6 +1473,7 @@ exports[`Thread should match thread snapshot 1`] = `
                     }
                     testID="message-wrapper"
                   >
+                    <View />
                     <View>
                       <View>
                         <View
@@ -1771,6 +1778,7 @@ exports[`Thread should match thread snapshot 1`] = `
                         </View>
                       </View>
                     </View>
+                    <View />
                   </View>
                 </View>
               </View>


### PR DESCRIPTION
## 🎯 Goal

This PR fixes a really weird issue with `Portal` components on `iOS`, where if the `Portal` component is mounted (with a fixed `hostName`) and then immediately re-layouted (this does not imply `onLayout` being called necessarily, but rather it changing position - like for example padding being added to its parent view, like a `FlatList` for example or `flex: 1` forcing the parent to change its layout) the content of that `Portal` would disappear from the reparented view and its reference would be lost. 

Through some debugging, I've confirmed its not any animated values causing this issue nor is the `View` unmounted. I'll invest some more time into this when I have more of it. For now, benchmarks show that having the top/bottom item `Portal`s mounted at all times (but with no `children` nor `hostName`) adds no overhead whatsoever and so the short-term fix is this. I'm not 100% certain whether it's a bug in `react-native-teleport` or in our own handling, but will get to the bottom of it at some point. This does NOT happen on `Android`.

The reproduction steps are quite convoluted too:

- Open a `Channel`
- Long-press a message (any in the viewport) and close the overlay after
- Open the keyboard (or attachment picker), then long press on a message and then close the overlay after
- Paginate a few pages (I assume something messes with the `contentSize` of the underlying `FlatList`), around 30-40 extra messages will do
- Go to the same `message` we've been looking at
- Press and hold the message (normally) and close the overlay
- Immediately after, open the keyboard (or attachment picker), press and hold **the same message**
- Observe how the top and bottom item in the context menu disappear after the overlay is fully opened

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


