### PR TITLE
fix: revert back to old pagination defaults

### DIFF
--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -8349,10 +8349,10 @@ stream-chat-react-native-core@8.1.0:
   version "0.0.0"
   uid ""
 
-stream-chat@^9.27.2:
-  version "9.27.2"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.27.2.tgz#5b41173e513f3606c47c93f391693b589e663968"
-  integrity sha512-OdALDzg8lO8CAdl8deydJ1+O4wJ7mM9dPLeCwDppq/OQ4aFIS9X38P+IdXPcOCsgSS97UoVUuxD2/excC5PEeg==
+stream-chat@^9.33.0:
+  version "9.35.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.35.1.tgz#d828854a9c27ea7e45e6642d9107966c6606f552"
+  integrity sha512-649sgO7+llFuW+y/Ja0K4d94aUC+EMxYUVo5mq5AFGT86vUAIXmRIMVHYHA/jw4MYoqfWAFrDK6L9Rhyn/eMkQ==
   dependencies:
     "@types/jsonwebtoken" "^9.0.8"
     "@types/ws" "^8.5.14"

--- a/package/src/components/Channel/__tests__/useMessageListPagination.test.js
+++ b/package/src/components/Channel/__tests__/useMessageListPagination.test.js
@@ -161,8 +161,8 @@ describe('useMessageListPagination', () => {
 
       await waitFor(() => {
         expect(queryFn).toHaveBeenCalledWith({
-          messages: { id_lt: messages[0].id },
-          watchers: {},
+          messages: { id_lt: messages[0].id, limit: 25 },
+          watchers: { limit: 25 },
         });
         expect(result.current.state.hasMore).toBe(true);
         expect(result.current.state.messages.length).toBe(40);
@@ -252,8 +252,8 @@ describe('useMessageListPagination', () => {
 
       await waitFor(() => {
         expect(queryFn).toHaveBeenCalledWith({
-          messages: { id_gt: messages[messages.length - 1].id },
-          watchers: {},
+          messages: { id_gt: messages[messages.length - 1].id, limit: 10 },
+          watchers: { limit: 10 },
         });
         expect(result.current.state.hasMore).toBe(true);
         expect(result.current.state.messages.length).toBe(40);

--- a/package/src/components/Channel/hooks/useMessageListPagination.tsx
+++ b/package/src/components/Channel/hooks/useMessageListPagination.tsx
@@ -74,7 +74,7 @@ export const useMessageListPagination = ({ channel }: { channel: Channel }) => {
   /**
    * This function loads more messages before the first message in current channel state.
    */
-  const loadMore = useStableCallback(async (limit?: number) => {
+  const loadMore = useStableCallback(async (limit: number = 25) => {
     if (!channel.state.messagePagination.hasPrev) {
       return;
     }
@@ -103,7 +103,7 @@ export const useMessageListPagination = ({ channel }: { channel: Channel }) => {
   /**
    * This function loads more messages after the most recent message in current channel state.
    */
-  const loadMoreRecent = useStableCallback(async (limit?: number) => {
+  const loadMoreRecent = useStableCallback(async (limit: number = 10) => {
     if (!channel.state.messagePagination.hasNext) {
       return;
     }

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -150,7 +150,7 @@ type MessageListPropsWithContext = Pick<
   > &
   Pick<ChatContextValue, 'client'> &
   Pick<ImageGalleryContextValue, 'setMessages'> &
-  Pick<PaginatedMessageListContextValue, 'loadMore' | 'loadMoreRecent'> &
+  Pick<PaginatedMessageListContextValue, 'loadMore' | 'loadMoreRecent' | 'hasMore'> &
   Pick<
     MessagesContextValue,
     | 'DateHeader'
@@ -165,7 +165,7 @@ type MessageListPropsWithContext = Pick<
   > &
   Pick<
     ThreadContextValue,
-    'loadMoreRecentThread' | 'loadMoreThread' | 'thread' | 'threadInstance'
+    'loadMoreRecentThread' | 'loadMoreThread' | 'threadHasMore' | 'thread' | 'threadInstance'
   > & {
     /**
      * Besides existing (default) UX behavior of underlying FlatList of MessageList component, if you want
@@ -297,6 +297,8 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
     TypingIndicator,
     TypingIndicatorContainer,
     UnreadMessagesNotification,
+    hasMore,
+    threadHasMore,
   } = props;
   const [isUnreadNotificationOpen, setIsUnreadNotificationOpen] = useState<boolean>(false);
   const { theme } = useTheme();
@@ -858,8 +860,12 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
    * 3. If the call to `loadMoreRecent` is in progress, we wait for it to finish to make sure scroll doesn't jump.
    */
   const maybeCallOnEndReached = useStableCallback(async () => {
+    const shouldQuery = (threadList && threadHasMore) || (!threadList && hasMore);
     // If onEndReached has already been called for given messageList length, then ignore.
-    if (processedMessageList?.length && onEndReachedTracker.current[processedMessageList.length]) {
+    if (
+      (processedMessageList?.length && onEndReachedTracker.current[processedMessageList.length]) ||
+      !shouldQuery
+    ) {
       return;
     }
 
@@ -1301,8 +1307,9 @@ export const MessageList = (props: MessageListProps) => {
     TypingIndicatorContainer,
     UnreadMessagesNotification,
   } = useMessagesContext();
-  const { loadMore, loadMoreRecent } = usePaginatedMessageListContext();
-  const { loadMoreRecentThread, loadMoreThread, thread, threadInstance } = useThreadContext();
+  const { loadMore, loadMoreRecent, hasMore } = usePaginatedMessageListContext();
+  const { loadMoreRecentThread, loadMoreThread, threadHasMore, thread, threadInstance } =
+    useThreadContext();
 
   return (
     <MessageListWithContext
@@ -1319,6 +1326,7 @@ export const MessageList = (props: MessageListProps) => {
         enableMessageGroupingByUser,
         error,
         FlatList,
+        hasMore,
         hideStickyDateHeader,
         highlightedMessageId,
         InlineDateSeparator,
@@ -1351,6 +1359,7 @@ export const MessageList = (props: MessageListProps) => {
         StickyHeader,
         targetedMessage,
         thread,
+        threadHasMore,
         threadInstance,
         threadList,
         TypingIndicator,


### PR DESCRIPTION
## 🎯 Goal

<!-- Describe why we are making this change -->

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


