### PR TITLE
fix: thread messages breaking pagination

### DIFF
--- a/package/src/store/SqliteClient.ts
+++ b/package/src/store/SqliteClient.ts
@@ -28,7 +28,7 @@ import type { PreparedBatchQueries, PreparedQueries, Scalar, Table } from './typ
  * This way usage @op-engineering/op-sqlite package is scoped to a single class/file.
  */
 export class SqliteClient {
-  static dbVersion = 14;
+  static dbVersion = 15;
 
   static dbName = DB_NAME;
   static dbLocation = DB_LOCATION;

--- a/package/src/store/apis/upsertMessages.ts
+++ b/package/src/store/apis/upsertMessages.ts
@@ -24,6 +24,9 @@ export const upsertMessages = async ({
   const storableLocations: Array<ReturnType<typeof mapSharedLocationToStorable>> = [];
 
   messages?.forEach((message: MessageResponse | LocalMessage) => {
+    if (message.parent_id && !message.show_in_channel) {
+      return;
+    }
     storableMessages.push(mapMessageToStorable(message));
     if (message.user) {
       storableUsers.push(mapUserToStorable(message.user));


### PR DESCRIPTION
## 🎯 Goal

This PR fixes an issue where in some instances sending a message within a thread (with lower `message_limit`) would break pagination for the offline support case

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


