### PR TITLE
fix: dark mode improvements

### DIFF
--- a/examples/SampleApp/src/components/AttachmentPickerSelectionBar.tsx
+++ b/examples/SampleApp/src/components/AttachmentPickerSelectionBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import {
   AttachmentTypePickerButton,
@@ -10,6 +10,7 @@ import {
   PollPickerButton,
   useAttachmentPickerContext,
   useStableCallback,
+  useTheme,
 } from 'stream-chat-react-native';
 import { ShareLocationIcon } from '../icons/ShareLocationIcon';
 import { LiveLocationCreateModal } from './LocationSharing/CreateLocationModal';
@@ -18,6 +19,8 @@ export const CustomAttachmentPickerSelectionBar = () => {
   const [modalVisible, setModalVisible] = useState(false);
   const { attachmentPickerStore } = useAttachmentPickerContext();
   const { selectedPicker } = useAttachmentPickerState();
+
+  const styles = useStyles();
 
   const onRequestClose = () => {
     setModalVisible(false);
@@ -47,11 +50,15 @@ export const CustomAttachmentPickerSelectionBar = () => {
   );
 };
 
-const styles = StyleSheet.create({
-  selectionBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingBottom: 12,
-  },
-});
+const useStyles = () => {
+  const { theme: { semantics }} = useTheme();
+  return useMemo(() => StyleSheet.create({
+    selectionBar: {
+      backgroundColor: semantics.composerBg,
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 16,
+      paddingBottom: 12,
+    },
+  }), [semantics])
+}

--- a/examples/SampleApp/src/hooks/useStreamChatTheme.ts
+++ b/examples/SampleApp/src/hooks/useStreamChatTheme.ts
@@ -61,16 +61,6 @@ const getChatStyle = (colorScheme: ColorSchemeName): DeepPartial<Theme> => ({
           white_smoke: '#F2F2F2',
           white_snow: '#FCFCFC',
         },
-  ...(colorScheme === 'dark'
-    ? {
-        messageSimple: {
-          content: {
-            receiverMessageBackgroundColor: '#2D2F2F',
-            senderMessageBackgroundColor: '#101418',
-          },
-        },
-      }
-    : {}),
 });
 
 export const useStreamChatTheme = () => {

--- a/package/src/components/Message/MessageSimple/MessageContent.tsx
+++ b/package/src/components/Message/MessageSimple/MessageContent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import {
   AnimatableNumericValue,
   ColorValue,
@@ -117,7 +117,6 @@ export type MessageContentPropsWithContext = Pick<
  * Child of MessageSimple that displays a message's content
  */
 const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
-  const [longPressFired, setLongPressFired] = useState(false);
   const {
     additionalPressableProps,
     Attachment,
@@ -238,7 +237,6 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
     <Pressable
       disabled={preventPress}
       onLongPress={(event) => {
-        setLongPressFired(true);
         if (onLongPress) {
           onLongPress({
             emitter: 'messageContent',
@@ -262,10 +260,9 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
           });
         }
       }}
-      style={({ pressed }) => [{ opacity: pressed && !longPressFired ? 0.5 : 1 }, container]}
+      style={container}
       {...additionalPressableProps}
       onPressOut={(event) => {
-        setLongPressFired(false);
         setNativeScrollability(true);
 
         if (additionalPressableProps?.onPressOut) {
@@ -382,6 +379,7 @@ const areEqual = (
   nextProps: MessageContentPropsWithContext,
 ) => {
   const {
+    backgroundColor: prevBackgroundColor,
     preventPress: prevPreventPress,
     goToMessage: prevGoToMessage,
     groupStyles: prevGroupStyles,
@@ -393,6 +391,7 @@ const areEqual = (
     t: prevT,
   } = prevProps;
   const {
+    backgroundColor: nextBackgroundColor,
     preventPress: nextPreventPress,
     goToMessage: nextGoToMessage,
     groupStyles: nextGroupStyles,
@@ -402,6 +401,10 @@ const areEqual = (
     otherAttachments: nextOtherAttachments,
     t: nextT,
   } = nextProps;
+
+  if (prevBackgroundColor !== nextBackgroundColor) {
+    return false;
+  }
 
   if (prevPreventPress !== nextPreventPress) {
     return false;

--- a/package/src/components/Message/MessageSimple/MessageSimple.tsx
+++ b/package/src/components/Message/MessageSimple/MessageSimple.tsx
@@ -120,16 +120,12 @@ const MessageSimpleWithContext = forwardRef<View, MessageSimplePropsWithContext>
 
   const {
     theme: {
-      colors: { blue_alice, grey_gainsboro, light_blue, light_gray, transparent },
+      semantics,
+      colors: { blue_alice, grey_gainsboro, transparent },
       messageSimple: {
         container,
         repliesContainer,
-        content: {
-          container: contentContainer,
-          errorContainer,
-          receiverMessageBackgroundColor,
-          senderMessageBackgroundColor,
-        },
+        content: { container: contentContainer, errorContainer },
         headerWrapper,
         lastMessageContainer,
         messageGroupedSingleOrBottomContainer,
@@ -168,7 +164,7 @@ const MessageSimpleWithContext = forwardRef<View, MessageSimplePropsWithContext>
     }
   }
 
-  let backgroundColor = senderMessageBackgroundColor ?? light_blue;
+  let backgroundColor = semantics.chatBgOutgoing;
   if (onlyEmojis && !message.quoted_message) {
     backgroundColor = transparent;
   } else if (otherAttachments.length) {
@@ -178,7 +174,7 @@ const MessageSimpleWithContext = forwardRef<View, MessageSimplePropsWithContext>
       backgroundColor = blue_alice;
     }
   } else if (isMessageReceivedOrErrorType) {
-    backgroundColor = receiverMessageBackgroundColor ?? light_gray;
+    backgroundColor = semantics.chatBgIncoming;
   }
 
   const onSwipeActionHandler = useStableCallback(() => {

--- a/package/src/components/Message/MessageSimple/__tests__/__snapshots__/MessageAvatar.test.js.snap
+++ b/package/src/components/Message/MessageSimple/__tests__/__snapshots__/MessageAvatar.test.js.snap
@@ -22,10 +22,10 @@ exports[`MessageAvatar should render message avatar 1`] = `
             "width": 32,
           },
           {
-            "backgroundColor": "#d1f3f6",
+            "backgroundColor": "#003a3f",
           },
           {
-            "borderColor": "rgba(0, 0, 0, 0.1)",
+            "borderColor": "rgba(255, 255, 255, 0.2)",
             "borderWidth": 1,
           },
           undefined,

--- a/package/src/components/Message/MessageSimple/__tests__/__snapshots__/MessageTextContainer.test.tsx.snap
+++ b/package/src/components/Message/MessageSimple/__tests__/__snapshots__/MessageTextContainer.test.tsx.snap
@@ -29,9 +29,7 @@ exports[`MessageTextContainer should render message text container 1`] = `
           "alignItems": "flex-start",
           "flexDirection": "row",
           "flexWrap": "wrap",
-          "fontSize": 15,
           "justifyContent": "flex-start",
-          "lineHeight": 20,
           "marginBottom": 8,
           "marginTop": 8,
         }

--- a/package/src/components/Message/MessageSimple/__tests__/__snapshots__/MessageTextContainer.test.tsx.snap
+++ b/package/src/components/Message/MessageSimple/__tests__/__snapshots__/MessageTextContainer.test.tsx.snap
@@ -29,7 +29,9 @@ exports[`MessageTextContainer should render message text container 1`] = `
           "alignItems": "flex-start",
           "flexDirection": "row",
           "flexWrap": "wrap",
+          "fontSize": 15,
           "justifyContent": "flex-start",
+          "lineHeight": 20,
           "marginBottom": 8,
           "marginTop": 8,
         }

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -34,7 +34,7 @@ import type { MessageContextValue } from '../../../../contexts/messageContext/Me
 import type { Colors, MarkdownStyle } from '../../../../contexts/themeContext/utils/theme';
 
 import { primitives } from '../../../../theme';
-import { escapeRegExp, hasOnlyEmojis } from '../../../../utils/utils';
+import { escapeRegExp } from '../../../../utils/utils';
 
 type ReactNodeOutput = NodeOutput<React.ReactNode>;
 type ReactOutput = Output<React.ReactNode>;
@@ -125,14 +125,12 @@ const defaultMarkdownStyles: MarkdownStyle = {
   },
   paragraph: {
     marginBottom: 8,
-    // fontSize: primitives.typographyFontSizeMd,
-    // lineHeight: primitives.typographyLineHeightNormal,
+    fontSize: primitives.typographyFontSizeMd,
     marginTop: 8,
   },
   paragraphCenter: {
     marginBottom: 8,
-    // fontSize: primitives.typographyFontSizeMd,
-    // lineHeight: primitives.typographyLineHeightNormal,
+    fontSize: primitives.typographyFontSizeMd,
     marginTop: 8,
   },
   paragraphWithImage: {
@@ -201,6 +199,16 @@ export const renderText = (params: RenderTextParams) => {
   const styles: MarkdownStyle = {
     ...defaultMarkdownStyles,
     ...markdownStyles,
+    paragraph: {
+      ...(onlyEmojis ? {} : { lineHeight: primitives.typographyLineHeightNormal }),
+      ...defaultMarkdownStyles.paragraph,
+      ...markdownStyles?.paragraph,
+    },
+    paragraphCenter: {
+      ...(onlyEmojis ? {} : { lineHeight: primitives.typographyLineHeightNormal }),
+      ...defaultMarkdownStyles.paragraphCenter,
+      ...markdownStyles?.paragraphCenter,
+    },
     autolink: {
       fontSize: primitives.typographyFontSizeMd,
       lineHeight: primitives.typographyLineHeightNormal,
@@ -279,9 +287,7 @@ export const renderText = (params: RenderTextParams) => {
     },
     text: {
       fontSize: primitives.typographyFontSizeMd,
-      ...(markdownText && hasOnlyEmojis(markdownText)
-        ? {}
-        : { lineHeight: primitives.typographyLineHeightNormal }),
+      ...(onlyEmojis ? {} : { lineHeight: primitives.typographyLineHeightNormal }),
       ...defaultMarkdownStyles.text,
       color: colors.black,
       ...markdownStyles?.text,

--- a/package/src/components/Message/MessageSimple/utils/renderText.tsx
+++ b/package/src/components/Message/MessageSimple/utils/renderText.tsx
@@ -34,7 +34,7 @@ import type { MessageContextValue } from '../../../../contexts/messageContext/Me
 import type { Colors, MarkdownStyle } from '../../../../contexts/themeContext/utils/theme';
 
 import { primitives } from '../../../../theme';
-import { escapeRegExp } from '../../../../utils/utils';
+import { escapeRegExp, hasOnlyEmojis } from '../../../../utils/utils';
 
 type ReactNodeOutput = NodeOutput<React.ReactNode>;
 type ReactOutput = Output<React.ReactNode>;
@@ -125,14 +125,14 @@ const defaultMarkdownStyles: MarkdownStyle = {
   },
   paragraph: {
     marginBottom: 8,
-    fontSize: primitives.typographyFontSizeMd,
-    lineHeight: primitives.typographyLineHeightNormal,
+    // fontSize: primitives.typographyFontSizeMd,
+    // lineHeight: primitives.typographyLineHeightNormal,
     marginTop: 8,
   },
   paragraphCenter: {
     marginBottom: 8,
-    fontSize: primitives.typographyFontSizeMd,
-    lineHeight: primitives.typographyLineHeightNormal,
+    // fontSize: primitives.typographyFontSizeMd,
+    // lineHeight: primitives.typographyLineHeightNormal,
     marginTop: 8,
   },
   paragraphWithImage: {
@@ -279,7 +279,9 @@ export const renderText = (params: RenderTextParams) => {
     },
     text: {
       fontSize: primitives.typographyFontSizeMd,
-      lineHeight: primitives.typographyLineHeightNormal,
+      ...(markdownText && hasOnlyEmojis(markdownText)
+        ? {}
+        : { lineHeight: primitives.typographyLineHeightNormal }),
       ...defaultMarkdownStyles.text,
       color: colors.black,
       ...markdownStyles?.text,

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -71,6 +71,16 @@ const useStyles = () => {
   } = useTheme();
   return useMemo(() => {
     return StyleSheet.create({
+      pollModalWrapper: {
+        alignItems: 'center',
+        flex: 1,
+        justifyContent: 'center',
+        backgroundColor: semantics.backgroundElevationElevation1,
+      },
+      pollSafeArea: {
+        flex: 1,
+        backgroundColor: semantics.backgroundElevationElevation1,
+      },
       container: {
         alignItems: 'center',
         flexDirection: 'row',
@@ -454,14 +464,14 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
       </Animated.View>
 
       {showPollCreationDialog ? (
-        <View style={{ alignItems: 'center', flex: 1, justifyContent: 'center' }}>
+        <View style={styles.pollModalWrapper}>
           <Modal
             animationType='slide'
             onRequestClose={closePollCreationDialog}
             visible={showPollCreationDialog}
           >
-            <GestureHandlerRootView style={{ flex: 1 }}>
-              <SafeAreaViewWrapper style={{ flex: 1 }}>
+            <GestureHandlerRootView style={styles.pollSafeArea}>
+              <SafeAreaViewWrapper style={styles.pollSafeArea}>
                 <CreatePoll
                   closePollCreationDialog={closePollCreationDialog}
                   CreatePollContent={CreatePollContent}

--- a/package/src/components/MessageList/MessageFlashList.tsx
+++ b/package/src/components/MessageList/MessageFlashList.tsx
@@ -340,18 +340,7 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
 
   const channelResyncScrollSet = useRef<boolean>(true);
   const { theme } = useTheme();
-
-  const {
-    colors: { white_snow },
-    messageList: {
-      container,
-      contentContainer,
-      listContainer,
-      scrollToBottomButtonContainer,
-      stickyHeaderContainer,
-      unreadMessagesNotificationContainer,
-    },
-  } = theme;
+  const styles = useStyles();
 
   const myMessageThemeString = useMemo(() => JSON.stringify(myMessageTheme), [myMessageTheme]);
 
@@ -979,20 +968,19 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
   }
 
   const flatListStyle = useMemo(
-    () => [styles.listContainer, listContainer, additionalFlashListProps?.style],
-    [additionalFlashListProps?.style, listContainer],
+    () => [styles.listContainer, additionalFlashListProps?.style],
+    [additionalFlashListProps?.style, styles.listContainer],
   );
 
   const flatListContentContainerStyle = useMemo(
     () => [
       styles.contentContainer,
       { paddingBottom: messageInputFloating ? messageInputHeight : 0 },
-      contentContainer,
       additionalFlashListProps?.contentContainerStyle,
     ],
     [
       additionalFlashListProps?.contentContainerStyle,
-      contentContainer,
+      styles.contentContainer,
       messageInputFloating,
       messageInputHeight,
     ],
@@ -1016,7 +1004,7 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
 
   if (loading) {
     return (
-      <View style={[styles.container, { backgroundColor: white_snow }, container]}>
+      <View style={styles.container}>
         <LoadingIndicator listType='message' />
       </View>
     );
@@ -1029,13 +1017,9 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
   }
 
   return (
-    <View
-      onLayout={onLayout}
-      style={[styles.container, { backgroundColor: white_snow }, container]}
-      testID='message-flat-list-wrapper'
-    >
+    <View onLayout={onLayout} style={styles.container} testID='message-flat-list-wrapper'>
       {processedMessageList.length === 0 && !thread ? (
-        <View style={[styles.flex, { backgroundColor: white_snow }]} testID='empty-state'>
+        <View style={styles.flex} testID='empty-state'>
           {EmptyStateIndicator ? <EmptyStateIndicator listType='message' /> : null}
         </View>
       ) : (
@@ -1071,7 +1055,7 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
           />
         </MessageListItemProvider>
       )}
-      <View style={[styles.stickyHeaderContainer, stickyHeaderContainer]}>
+      <View style={styles.stickyHeaderContainer}>
         {messageListLengthAfterUpdate && StickyHeader ? (
           <StickyHeader date={stickyHeaderDate} DateHeader={DateHeader} />
         ) : null}
@@ -1086,7 +1070,6 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
         style={[
           styles.scrollToBottomButtonContainer,
           { bottom: messageInputFloating ? messageInputHeight : 16 },
-          scrollToBottomButtonContainer,
         ]}
       >
         <ScrollToBottomButton
@@ -1097,9 +1080,7 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
       </Animated.View>
       <NetworkDownIndicator />
       {isUnreadNotificationOpen && !threadList ? (
-        <View
-          style={[styles.unreadMessagesNotificationContainer, unreadMessagesNotificationContainer]}
-        >
+        <View style={styles.unreadMessagesNotificationContainer}>
           <UnreadMessagesNotification onCloseHandler={onUnreadNotificationClose} />
         </View>
       ) : null}
@@ -1219,38 +1200,75 @@ export const MessageFlashList = (props: MessageFlashListProps) => {
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    width: '100%',
-  },
-  contentContainer: {
-    /**
-     * paddingBottom is set to 4 to account for the default date
-     * header and inline indicator alignment. The top margin is 8
-     * on the header but 4 on the inline date, this adjusts the spacing
-     * to allow the "first" inline date to align with the date header.
-     */
-    paddingBottom: 4,
-  },
-  flex: { flex: 1 },
-  listContainer: {
-    flex: 1,
-    width: '100%',
-  },
-  scrollToBottomButtonContainer: {
-    position: 'absolute',
-    right: 16,
-  },
-  stickyHeaderContainer: {
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: primitives.spacingXs,
-  },
-  unreadMessagesNotificationContainer: {
-    alignSelf: 'center',
-    position: 'absolute',
-    top: 8,
-  },
-});
+const useStyles = () => {
+  const {
+    theme: {
+      semantics,
+      messageList: {
+        container,
+        contentContainer,
+        listContainer,
+        stickyHeaderContainer,
+        scrollToBottomButtonContainer,
+        unreadMessagesNotificationContainer,
+      },
+    },
+  } = useTheme();
+
+  const { backgroundCoreApp } = semantics;
+
+  return useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          width: '100%',
+          backgroundColor: backgroundCoreApp,
+          ...container,
+        },
+        contentContainer: {
+          /**
+           * paddingBottom is set to 4 to account for the default date
+           * header and inline indicator alignment. The top margin is 8
+           * on the header but 4 on the inline date, this adjusts the spacing
+           * to allow the "first" inline date to align with the date header.
+           */
+          paddingBottom: 4,
+          ...contentContainer,
+        },
+        flex: { flex: 1, backgroundColor: backgroundCoreApp },
+        listContainer: {
+          flex: 1,
+          width: '100%',
+          ...listContainer,
+        },
+        scrollToBottomButtonContainer: {
+          position: 'absolute',
+          right: 16,
+          ...scrollToBottomButtonContainer,
+        },
+        stickyHeaderContainer: {
+          left: 0,
+          position: 'absolute',
+          right: 0,
+          top: primitives.spacingXs,
+          ...stickyHeaderContainer,
+        },
+        unreadMessagesNotificationContainer: {
+          alignSelf: 'center',
+          position: 'absolute',
+          top: 8,
+          ...unreadMessagesNotificationContainer,
+        },
+      }),
+    [
+      backgroundCoreApp,
+      container,
+      contentContainer,
+      listContainer,
+      scrollToBottomButtonContainer,
+      stickyHeaderContainer,
+      unreadMessagesNotificationContainer,
+    ],
+  );
+};

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -74,41 +74,79 @@ import { MessageWrapper } from '../Message/MessageSimple/MessageWrapper';
 // TODO: Think if we really need this and strive to remove it if we can.
 const WAIT_FOR_SCROLL_TIMEOUT = 0;
 const MAX_RETRIES_AFTER_SCROLL_FAILURE = 10;
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    width: '100%',
-  },
-  contentContainer: {
-    /**
-     * paddingBottom is set to 4 to account for the default date
-     * header and inline indicator alignment. The top margin is 8
-     * on the header but 4 on the inline date, this adjusts the spacing
-     * to allow the "first" inline date to align with the date header.
-     */
-    paddingBottom: 4,
-  },
-  flex: { flex: 1 },
-  listContainer: {
-    flex: 1,
-    width: '100%',
-  },
-  scrollToBottomButtonContainer: {
-    position: 'absolute',
-    right: 16,
-  },
-  stickyHeaderContainer: {
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: primitives.spacingXs,
-  },
-  unreadMessagesNotificationContainer: {
-    alignSelf: 'center',
-    position: 'absolute',
-    top: 8,
-  },
-});
+
+const useStyles = () => {
+  const {
+    theme: {
+      semantics,
+      messageList: {
+        container,
+        contentContainer,
+        listContainer,
+        stickyHeaderContainer,
+        scrollToBottomButtonContainer,
+        unreadMessagesNotificationContainer,
+      },
+    },
+  } = useTheme();
+
+  const { backgroundCoreApp } = semantics;
+
+  return useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          width: '100%',
+          backgroundColor: backgroundCoreApp,
+          ...container,
+        },
+        contentContainer: {
+          /**
+           * paddingBottom is set to 4 to account for the default date
+           * header and inline indicator alignment. The top margin is 8
+           * on the header but 4 on the inline date, this adjusts the spacing
+           * to allow the "first" inline date to align with the date header.
+           */
+          paddingBottom: 4,
+          ...contentContainer,
+        },
+        flex: { flex: 1, backgroundColor: backgroundCoreApp },
+        listContainer: {
+          flex: 1,
+          width: '100%',
+          ...listContainer,
+        },
+        scrollToBottomButtonContainer: {
+          position: 'absolute',
+          right: 16,
+          ...scrollToBottomButtonContainer,
+        },
+        stickyHeaderContainer: {
+          left: 0,
+          position: 'absolute',
+          right: 0,
+          top: primitives.spacingXs,
+          ...stickyHeaderContainer,
+        },
+        unreadMessagesNotificationContainer: {
+          alignSelf: 'center',
+          position: 'absolute',
+          top: 8,
+          ...unreadMessagesNotificationContainer,
+        },
+      }),
+    [
+      backgroundCoreApp,
+      container,
+      contentContainer,
+      listContainer,
+      scrollToBottomButtonContainer,
+      stickyHeaderContainer,
+      unreadMessagesNotificationContainer,
+    ],
+  );
+};
 
 const keyExtractor = (derivedItem: MessageListItemWithNeighbours) => {
   const { message: item } = derivedItem;
@@ -330,22 +368,11 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
   } = props;
   const [isUnreadNotificationOpen, setIsUnreadNotificationOpen] = useState<boolean>(false);
   const { theme } = useTheme();
+  const styles = useStyles();
   const { height: messageInputHeight } = useStateStore(
     messageInputHeightStore.store,
     messageInputHeightStoreSelector,
   );
-
-  const {
-    colors: { white_snow },
-    messageList: {
-      container,
-      contentContainer,
-      listContainer,
-      stickyHeaderContainer,
-      scrollToBottomButtonContainer,
-      unreadMessagesNotificationContainer,
-    },
-  } = theme;
 
   const myMessageThemeString = useMemo(() => JSON.stringify(myMessageTheme), [myMessageTheme]);
 
@@ -1123,19 +1150,19 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
   }
 
   const flatListStyle = useMemo(
-    () => [styles.listContainer, listContainer, additionalFlatListProps?.style],
-    [additionalFlatListProps?.style, listContainer],
+    () => [styles.listContainer, additionalFlatListProps?.style],
+    [additionalFlatListProps?.style],
   );
 
   const flatListContentContainerStyle = useMemo(
     () => [
       { paddingTop: messageInputFloating ? messageInputHeight : 0 },
+      styles.contentContainer,
       additionalFlatListProps?.contentContainerStyle,
-      contentContainer,
     ],
     [
       additionalFlatListProps?.contentContainerStyle,
-      contentContainer,
+      styles.contentContainer,
       messageInputHeight,
       messageInputFloating,
     ],
@@ -1193,7 +1220,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
 
   if (loading) {
     return (
-      <View style={[styles.container, { backgroundColor: white_snow }, container]}>
+      <View style={styles.container}>
         <LoadingIndicator listType='message' />
       </View>
     );
@@ -1201,13 +1228,10 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
 
   // TODO: Make sure this is actually overridable as the previous FlatList was.
   return (
-    <View
-      style={[styles.container, { backgroundColor: white_snow }, container]}
-      testID='message-flat-list-wrapper'
-    >
+    <View style={styles.container} testID='message-flat-list-wrapper'>
       {/* Don't show the empty list indicator for Thread messages */}
       {processedMessageList.length === 0 && !thread ? (
-        <View style={[styles.flex, { backgroundColor: white_snow }]} testID='empty-state'>
+        <View style={styles.flex} testID='empty-state'>
           {EmptyStateIndicator ? <EmptyStateIndicator listType='message' /> : null}
         </View>
       ) : (
@@ -1254,7 +1278,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
           />
         </MessageListItemProvider>
       )}
-      <View style={[styles.stickyHeaderContainer, stickyHeaderContainer]}>
+      <View style={styles.stickyHeaderContainer}>
         {messageListLengthAfterUpdate && StickyHeader ? (
           <StickyHeader date={stickyHeaderDate} DateHeader={DateHeader} />
         ) : null}
@@ -1268,9 +1292,8 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
         <Animated.View
           layout={LinearTransition.duration(200)}
           style={[
-            styles.scrollToBottomButtonContainer,
             { bottom: messageInputFloating ? messageInputHeight : 16 },
-            scrollToBottomButtonContainer,
+            styles.scrollToBottomButtonContainer,
           ]}
         >
           <ScrollToBottomButton
@@ -1283,9 +1306,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
 
       <NetworkDownIndicator />
       {isUnreadNotificationOpen && !threadList ? (
-        <View
-          style={[styles.unreadMessagesNotificationContainer, unreadMessagesNotificationContainer]}
-        >
+        <View style={styles.unreadMessagesNotificationContainer}>
           <UnreadMessagesNotification onCloseHandler={onUnreadNotificationClose} />
         </View>
       ) : null}

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -1151,7 +1151,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
 
   const flatListStyle = useMemo(
     () => [styles.listContainer, additionalFlatListProps?.style],
-    [additionalFlatListProps?.style],
+    [additionalFlatListProps?.style, styles.listContainer],
   );
 
   const flatListContentContainerStyle = useMemo(

--- a/package/src/components/Poll/CreatePollContent.tsx
+++ b/package/src/components/Poll/CreatePollContent.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { StyleSheet, Switch, Text, View } from 'react-native';
+import { StyleSheet, Switch, Text, useColorScheme, View } from 'react-native';
 
 import { ScrollView } from 'react-native-gesture-handler';
 import { useSharedValue } from 'react-native-reanimated';
@@ -60,7 +60,6 @@ export const CreatePollContent = () => {
 
   const {
     theme: {
-      colors: { white },
       poll: {
         createContent: { addComment, anonymousPoll, optionCardWrapper, scrollView, suggestOption },
       },
@@ -150,7 +149,7 @@ export const CreatePollContent = () => {
       />
       <ScrollView
         contentContainerStyle={styles.contentContainerStyle}
-        style={[styles.scrollView, { backgroundColor: white }, scrollView]}
+        style={[styles.scrollView, scrollView]}
       >
         <NameField />
         <CreatePollOptions currentOptionPositions={currentOptionPositions} />
@@ -248,7 +247,11 @@ const useStyles = () => {
   } = useTheme();
   return useMemo(() => {
     return StyleSheet.create({
-      scrollView: { flex: 1, padding: primitives.spacingMd },
+      scrollView: {
+        flex: 1,
+        padding: primitives.spacingMd,
+        backgroundColor: semantics.backgroundElevationElevation1,
+      },
       contentContainerStyle: { paddingBottom: 70 },
       title: {
         color: semantics.textPrimary,

--- a/package/src/components/Poll/CreatePollContent.tsx
+++ b/package/src/components/Poll/CreatePollContent.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { StyleSheet, Switch, Text, useColorScheme, View } from 'react-native';
+import { StyleSheet, Switch, Text, View } from 'react-native';
 
 import { ScrollView } from 'react-native-gesture-handler';
 import { useSharedValue } from 'react-native-reanimated';

--- a/package/src/components/Poll/components/CreatePollHeader.tsx
+++ b/package/src/components/Poll/components/CreatePollHeader.tsx
@@ -92,6 +92,7 @@ const useStyles = () => {
         alignItems: 'center',
         justifyContent: 'space-between',
         padding: primitives.spacingMd,
+        backgroundColor: semantics.backgroundElevationElevation1,
       },
       title: {
         color: semantics.textPrimary,

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -19,16 +19,11 @@ exports[`Thread should match thread snapshot 1`] = `
   >
     <View
       style={
-        [
-          {
-            "flex": 1,
-            "width": "100%",
-          },
-          {
-            "backgroundColor": "#FCFCFC",
-          },
-          {},
-        ]
+        {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "width": "100%",
+        }
       }
       testID="message-flat-list-wrapper"
     >
@@ -40,8 +35,10 @@ exports[`Thread should match thread snapshot 1`] = `
             {
               "paddingTop": 0,
             },
+            {
+              "paddingBottom": 4,
+            },
             undefined,
-            {},
           ]
         }
         data={
@@ -297,7 +294,6 @@ exports[`Thread should match thread snapshot 1`] = `
                 "flex": 1,
                 "width": "100%",
               },
-              {},
               undefined,
             ],
           ]
@@ -528,14 +524,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                   onResponderTerminate={[Function]}
                                   onResponderTerminationRequest={[Function]}
                                   onStartShouldSetResponder={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "opacity": 1,
-                                      },
-                                      {},
-                                    ]
-                                  }
+                                  style={{}}
                                 >
                                   <View
                                     onLayout={[Function]}
@@ -551,7 +540,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                             "overflow": "hidden",
                                           },
                                           {
-                                            "backgroundColor": "#E9EAED",
+                                            "backgroundColor": "#ebeef1",
                                             "borderBottomLeftRadius": 0,
                                             "borderBottomRightRadius": 20,
                                             "borderColor": "#ECEBEB",
@@ -614,9 +603,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                                   "alignItems": "flex-start",
                                                   "flexDirection": "row",
                                                   "flexWrap": "wrap",
-                                                  "fontSize": 15,
                                                   "justifyContent": "flex-start",
-                                                  "lineHeight": 20,
                                                   "marginBottom": 8,
                                                   "marginTop": 8,
                                                 }
@@ -888,14 +875,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                   onResponderTerminate={[Function]}
                                   onResponderTerminationRequest={[Function]}
                                   onStartShouldSetResponder={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "opacity": 1,
-                                      },
-                                      {},
-                                    ]
-                                  }
+                                  style={{}}
                                 >
                                   <View
                                     onLayout={[Function]}
@@ -911,7 +891,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                             "overflow": "hidden",
                                           },
                                           {
-                                            "backgroundColor": "#E9EAED",
+                                            "backgroundColor": "#ebeef1",
                                             "borderBottomLeftRadius": 0,
                                             "borderBottomRightRadius": 20,
                                             "borderColor": "#ECEBEB",
@@ -974,9 +954,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                                   "alignItems": "flex-start",
                                                   "flexDirection": "row",
                                                   "flexWrap": "wrap",
-                                                  "fontSize": 15,
                                                   "justifyContent": "flex-start",
-                                                  "lineHeight": 20,
                                                   "marginBottom": 8,
                                                   "marginTop": 8,
                                                 }
@@ -1273,14 +1251,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                   onResponderTerminate={[Function]}
                                   onResponderTerminationRequest={[Function]}
                                   onStartShouldSetResponder={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "opacity": 1,
-                                      },
-                                      {},
-                                    ]
-                                  }
+                                  style={{}}
                                 >
                                   <View
                                     onLayout={[Function]}
@@ -1296,7 +1267,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                             "overflow": "hidden",
                                           },
                                           {
-                                            "backgroundColor": "#E9EAED",
+                                            "backgroundColor": "#ebeef1",
                                             "borderBottomLeftRadius": 0,
                                             "borderBottomRightRadius": 20,
                                             "borderColor": "#ECEBEB",
@@ -1359,9 +1330,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                                   "alignItems": "flex-start",
                                                   "flexDirection": "row",
                                                   "flexWrap": "wrap",
-                                                  "fontSize": 15,
                                                   "justifyContent": "flex-start",
-                                                  "lineHeight": 20,
                                                   "marginBottom": 8,
                                                   "marginTop": 8,
                                                 }
@@ -1639,14 +1608,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                   onResponderTerminate={[Function]}
                                   onResponderTerminationRequest={[Function]}
                                   onStartShouldSetResponder={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "opacity": 1,
-                                      },
-                                      {},
-                                    ]
-                                  }
+                                  style={{}}
                                 >
                                   <View
                                     onLayout={[Function]}
@@ -1662,7 +1624,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                             "overflow": "hidden",
                                           },
                                           {
-                                            "backgroundColor": "#E9EAED",
+                                            "backgroundColor": "#ebeef1",
                                             "borderBottomLeftRadius": 0,
                                             "borderBottomRightRadius": 20,
                                             "borderColor": "#ECEBEB",
@@ -1725,9 +1687,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                                   "alignItems": "flex-start",
                                                   "flexDirection": "row",
                                                   "flexWrap": "wrap",
-                                                  "fontSize": 15,
                                                   "justifyContent": "flex-start",
-                                                  "lineHeight": 20,
                                                   "marginBottom": 8,
                                                   "marginTop": 8,
                                                 }
@@ -1907,15 +1867,12 @@ exports[`Thread should match thread snapshot 1`] = `
       </RCTScrollView>
       <View
         style={
-          [
-            {
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 8,
-            },
-            {},
-          ]
+          {
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 8,
+          }
         }
       />
     </View>

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -603,7 +603,9 @@ exports[`Thread should match thread snapshot 1`] = `
                                                   "alignItems": "flex-start",
                                                   "flexDirection": "row",
                                                   "flexWrap": "wrap",
+                                                  "fontSize": 15,
                                                   "justifyContent": "flex-start",
+                                                  "lineHeight": 20,
                                                   "marginBottom": 8,
                                                   "marginTop": 8,
                                                 }
@@ -954,7 +956,9 @@ exports[`Thread should match thread snapshot 1`] = `
                                                   "alignItems": "flex-start",
                                                   "flexDirection": "row",
                                                   "flexWrap": "wrap",
+                                                  "fontSize": 15,
                                                   "justifyContent": "flex-start",
+                                                  "lineHeight": 20,
                                                   "marginBottom": 8,
                                                   "marginTop": 8,
                                                 }
@@ -1330,7 +1334,9 @@ exports[`Thread should match thread snapshot 1`] = `
                                                   "alignItems": "flex-start",
                                                   "flexDirection": "row",
                                                   "flexWrap": "wrap",
+                                                  "fontSize": 15,
                                                   "justifyContent": "flex-start",
+                                                  "lineHeight": 20,
                                                   "marginBottom": 8,
                                                   "marginTop": 8,
                                                 }
@@ -1687,7 +1693,9 @@ exports[`Thread should match thread snapshot 1`] = `
                                                   "alignItems": "flex-start",
                                                   "flexDirection": "row",
                                                   "flexWrap": "wrap",
+                                                  "fontSize": 15,
                                                   "justifyContent": "flex-start",
+                                                  "lineHeight": 20,
                                                   "marginBottom": 8,
                                                   "marginTop": 8,
                                                 }

--- a/package/src/contexts/themeContext/ThemeContext.tsx
+++ b/package/src/contexts/themeContext/ThemeContext.tsx
@@ -1,8 +1,12 @@
 import React, { PropsWithChildren, useContext, useMemo } from 'react';
 
+import { ColorSchemeName, useColorScheme } from 'react-native';
+
 import merge from 'lodash/merge';
 
 import { defaultTheme, Theme } from './utils/theme';
+
+import { darkSemantics, lightSemantics } from '../../theme';
 
 import { resolveTokensTopologically } from '../../theme/topologicalResolution';
 import { DEFAULT_BASE_CONTEXT_VALUE } from '../utils/defaultBaseContextValue';
@@ -20,6 +24,7 @@ export type ThemeProviderInputValue = {
 export type MergedThemesParams = {
   style?: DeepPartial<Theme>;
   theme?: Theme;
+  scheme?: ColorSchemeName;
 };
 
 export type ThemeContextValue = {
@@ -27,20 +32,22 @@ export type ThemeContextValue = {
 };
 
 export const mergeThemes = (params: MergedThemesParams) => {
-  const { style, theme } = params;
-  const finalTheme = (
+  const { style, theme, scheme } = params;
+  const baseTheme = (
     !theme || Object.keys(theme).length === 0
       ? JSON.parse(JSON.stringify(defaultTheme))
       : JSON.parse(JSON.stringify(theme))
   ) as Theme;
 
+  const semantics = resolveTokensTopologically(scheme === 'dark' ? darkSemantics : lightSemantics);
+
+  const finalTheme = { ...baseTheme, semantics };
+
   if (style) {
     merge(finalTheme, style);
   }
 
-  const semantics = resolveTokensTopologically(finalTheme.semantics);
-
-  return { ...finalTheme, semantics };
+  return finalTheme;
 };
 
 export const ThemeContext = React.createContext(DEFAULT_BASE_CONTEXT_VALUE as Theme);
@@ -50,13 +57,15 @@ export const ThemeProvider = (
 ) => {
   const { children, mergedStyle, style, theme } = props;
 
+  const scheme = useColorScheme();
+
   const modifiedTheme = useMemo(() => {
     if (mergedStyle) {
       return mergedStyle;
     }
 
-    return mergeThemes({ style, theme });
-  }, [mergedStyle, style, theme]);
+    return mergeThemes({ style, theme, scheme });
+  }, [mergedStyle, style, theme, scheme]);
 
   return <ThemeContext.Provider value={modifiedTheme}>{children}</ThemeContext.Provider>;
 };

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -596,8 +596,6 @@ export type Theme = {
         onlyEmojiMarkdown: MarkdownStyle;
       };
       wrapper: ViewStyle;
-      receiverMessageBackgroundColor?: ColorValue;
-      senderMessageBackgroundColor?: ColorValue;
       timestampText?: TextStyle;
     };
     deleted: {

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -1,8 +1,14 @@
-import { type ColorValue, type ImageStyle, type TextStyle, type ViewStyle } from 'react-native';
+import {
+  Appearance,
+  type ColorValue,
+  type ImageStyle,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native';
 import type { CircleProps } from 'react-native-svg';
 
 import type { IconProps } from '../../../icons/utils/base';
-import { primitives, semantics } from '../../../theme';
+import { primitives, lightSemantics, darkSemantics } from '../../../theme';
 
 export const DEFAULT_STATUS_ICON_SIZE = 16;
 // TODO: Handle this better later depending on the size of the avatar used
@@ -919,11 +925,11 @@ export type Theme = {
     thumb: ViewStyle;
     waveform: ViewStyle;
   };
-  semantics: typeof semantics;
+  semantics: typeof lightSemantics; // themed semantics have the same type
 };
 
 export const defaultTheme: Theme = {
-  semantics,
+  semantics: Appearance.getColorScheme() === 'light' ? lightSemantics : darkSemantics,
   aiTypingIndicatorView: {
     container: {},
     text: {},

--- a/package/src/theme/index.ts
+++ b/package/src/theme/index.ts
@@ -1,2 +1,8 @@
-// TODO: Handle color scheme here.
-export * from './generated/light/StreamTokens';
+import { semantics as darkSemantics } from './generated/dark/StreamTokens';
+import { semantics as lightSemantics } from './generated/light/StreamTokens';
+// TODO: As these never change across different themes (only per platform),
+//       it's safe to do this. It should be handled in the generation phase,
+//       though.
+export { primitives, foundations, components } from './generated/light/StreamTokens';
+
+export { lightSemantics, darkSemantics };


### PR DESCRIPTION
## 🎯 Goal

This PR addresses some issues we had with `scheme` changes with the redesign of the SDK, namely some components not using the new adequate colors from `semantics` in order to adjust to the scheme. It also fixes an issue with scheme reactivity of messages.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


