### PR TITLE
fix: audio recording race condition

### DIFF
--- a/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingButton.tsx
+++ b/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingButton.tsx
@@ -151,12 +151,12 @@ export const AudioRecordingButtonWithContext = (props: AudioRecordingButtonProps
   });
 
   const onTouchGestureEnd = useStableCallback(() => {
+    if (cancellableDuration) {
+      onEarlyReleaseHandler();
+      return;
+    }
     if (status === 'recording') {
-      if (cancellableDuration) {
-        onEarlyReleaseHandler();
-      } else {
-        uploadVoiceRecording(asyncMessagesMultiSendEnabled);
-      }
+      uploadVoiceRecording(asyncMessagesMultiSendEnabled);
     }
   });
 

--- a/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingButton.tsx
+++ b/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingButton.tsx
@@ -157,6 +157,8 @@ export const AudioRecordingButtonWithContext = (props: AudioRecordingButtonProps
     }
     if (status === 'recording') {
       uploadVoiceRecording(asyncMessagesMultiSendEnabled);
+    } else {
+      resetAudioRecording();
     }
   });
 

--- a/package/src/components/MessageInput/hooks/useAudioRecorder.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioRecorder.tsx
@@ -28,8 +28,6 @@ export const useAudioRecorder = ({
    * hence this approach.
    */
   const stopVoiceRecording = useCallback(async () => {
-    const { status } = audioRecorderManager.state.getLatestValue();
-    if (status !== 'recording') return;
     await audioRecorderManager.stopRecording();
   }, [audioRecorderManager]);
 

--- a/package/src/components/MessageInput/hooks/useAudioRecorder.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioRecorder.tsx
@@ -27,9 +27,12 @@ export const useAudioRecorder = ({
    * side only. Meant to be used as a pure function (during unmounting for instance)
    * hence this approach.
    */
-  const stopVoiceRecording = useCallback(async () => {
-    await audioRecorderManager.stopRecording();
-  }, [audioRecorderManager]);
+  const stopVoiceRecording = useCallback(
+    async (withDelete?: boolean) => {
+      await audioRecorderManager.stopRecording(withDelete);
+    },
+    [audioRecorderManager],
+  );
 
   // This effect stop the player from playing and stops audio recording on
   // the audio SDK side on unmount.
@@ -60,9 +63,8 @@ export const useAudioRecorder = ({
    * Function to delete voice recording.
    */
   const deleteVoiceRecording = useCallback(async () => {
-    await stopVoiceRecording();
-    audioRecorderManager.reset();
-  }, [audioRecorderManager, stopVoiceRecording]);
+    await stopVoiceRecording(true);
+  }, [stopVoiceRecording]);
 
   /**
    * Function to upload or send voice recording.

--- a/package/src/state-store/__tests__/audio-recorder-manager.test.ts
+++ b/package/src/state-store/__tests__/audio-recorder-manager.test.ts
@@ -1,0 +1,219 @@
+import { AudioReturnType, NativeHandlers } from '../../native';
+import { AudioRecorderManager } from '../audio-recorder-manager';
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+};
+
+const getMockRecording = () =>
+  ({
+    getStatusAsync: jest.fn(),
+    getURI: jest.fn(),
+    pauseAsync: jest.fn(),
+    recording: 'recording-id',
+    setProgressUpdateInterval: jest.fn(),
+    stopAndUnloadAsync: jest.fn(),
+  }) as const;
+
+describe('AudioRecorderManager race conditions', () => {
+  const originalAudioHandler = NativeHandlers.Audio;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    NativeHandlers.Audio = originalAudioHandler;
+  });
+
+  it('keeps initial recorder state', () => {
+    const manager = new AudioRecorderManager();
+    expect(manager.state.getLatestValue()).toEqual({
+      duration: 0,
+      isStarting: false,
+      micLocked: false,
+      recording: undefined,
+      status: 'idle',
+      waveformData: [],
+    });
+  });
+
+  it('starts successfully and transitions to recording only after native start resolves', async () => {
+    const recording = getMockRecording();
+    const startRecording = jest.fn().mockResolvedValue({
+      accessGranted: true,
+      recording,
+    } satisfies AudioReturnType);
+    const stopRecording = jest.fn().mockResolvedValue(undefined);
+
+    NativeHandlers.Audio = {
+      audioRecordingConfiguration: {},
+      startRecording,
+      stopRecording,
+    };
+
+    const manager = new AudioRecorderManager();
+    const startPromise = manager.startRecording();
+
+    expect(manager.state.getLatestValue().isStarting).toBe(true);
+    await startPromise;
+
+    const latest = manager.state.getLatestValue();
+    expect(latest.isStarting).toBe(false);
+    expect(latest.status).toBe('recording');
+    expect(latest.recording).toBe(recording);
+    expect(recording.setProgressUpdateInterval).toHaveBeenCalledWith(expect.any(Number));
+  });
+
+  it('stops during in-flight start and does not enter recording when start resolves', async () => {
+    const recording = getMockRecording();
+    const deferred = createDeferred<AudioReturnType>();
+    const startRecording = jest.fn().mockImplementation(() => deferred.promise);
+    const stopRecording = jest.fn().mockResolvedValue(undefined);
+
+    NativeHandlers.Audio = {
+      audioRecordingConfiguration: {},
+      startRecording,
+      stopRecording,
+    };
+
+    const manager = new AudioRecorderManager();
+    const startPromise = manager.startRecording();
+
+    expect(manager.state.getLatestValue().isStarting).toBe(true);
+
+    await manager.stopRecording();
+    expect(manager.state.getLatestValue()).toEqual({
+      duration: 0,
+      isStarting: false,
+      micLocked: false,
+      recording: undefined,
+      status: 'idle',
+      waveformData: [],
+    });
+
+    deferred.resolve({ accessGranted: true, recording });
+    await startPromise;
+
+    expect(stopRecording).toHaveBeenCalledTimes(1);
+    expect(manager.state.getLatestValue().status).toBe('idle');
+    expect(manager.state.getLatestValue().recording).toBeUndefined();
+  });
+
+  it('does not call native stop after pending stop if start resolves without access', async () => {
+    const deferred = createDeferred<AudioReturnType>();
+    const startRecording = jest.fn().mockImplementation(() => deferred.promise);
+    const stopRecording = jest.fn().mockResolvedValue(undefined);
+
+    NativeHandlers.Audio = {
+      audioRecordingConfiguration: {},
+      startRecording,
+      stopRecording,
+    };
+
+    const manager = new AudioRecorderManager();
+    const startPromise = manager.startRecording();
+    await manager.stopRecording();
+
+    deferred.resolve({ accessGranted: false, recording: undefined });
+    await startPromise;
+
+    expect(stopRecording).not.toHaveBeenCalled();
+    expect(manager.state.getLatestValue().status).toBe('idle');
+  });
+
+  it('resets state when native start throws', async () => {
+    const startRecording = jest.fn().mockRejectedValue(new Error('start failed'));
+    const stopRecording = jest.fn().mockResolvedValue(undefined);
+
+    NativeHandlers.Audio = {
+      audioRecordingConfiguration: {},
+      startRecording,
+      stopRecording,
+    };
+
+    const manager = new AudioRecorderManager();
+    const result = await manager.startRecording();
+
+    expect(result).toBe(false);
+    expect(manager.state.getLatestValue()).toEqual({
+      duration: 0,
+      isStarting: false,
+      micLocked: false,
+      recording: undefined,
+      status: 'idle',
+      waveformData: [],
+    });
+  });
+
+  it('does not let stale start completion overwrite newer recording session', async () => {
+    const recording1 = getMockRecording();
+    const recording2 = getMockRecording();
+    const deferred1 = createDeferred<AudioReturnType>();
+    const deferred2 = createDeferred<AudioReturnType>();
+
+    const startRecording = jest
+      .fn()
+      .mockImplementationOnce(() => deferred1.promise)
+      .mockImplementationOnce(() => deferred2.promise);
+    const stopRecording = jest.fn().mockResolvedValue(undefined);
+
+    NativeHandlers.Audio = {
+      audioRecordingConfiguration: {},
+      startRecording,
+      stopRecording,
+    };
+
+    const manager = new AudioRecorderManager();
+    const firstStart = manager.startRecording();
+    await manager.stopRecording();
+    const secondStart = manager.startRecording();
+
+    deferred1.resolve({ accessGranted: true, recording: recording1 });
+    await firstStart;
+
+    // First (stale) completion should not put stale recording into state.
+    expect(manager.state.getLatestValue().recording).toBeUndefined();
+    expect(manager.state.getLatestValue().status).toBe('idle');
+
+    deferred2.resolve({ accessGranted: true, recording: recording2 });
+    await secondStart;
+
+    expect(manager.state.getLatestValue().recording).toBe(recording2);
+    expect(manager.state.getLatestValue().status).toBe('recording');
+  });
+
+  it('stopRecording with delete clears state instead of setting stopped', async () => {
+    const recording = getMockRecording();
+    const startRecording = jest.fn().mockResolvedValue({
+      accessGranted: true,
+      recording,
+    } satisfies AudioReturnType);
+    const stopRecording = jest.fn().mockResolvedValue(undefined);
+
+    NativeHandlers.Audio = {
+      audioRecordingConfiguration: {},
+      startRecording,
+      stopRecording,
+    };
+
+    const manager = new AudioRecorderManager();
+    await manager.startRecording();
+    await manager.stopRecording(true);
+
+    expect(manager.state.getLatestValue()).toEqual({
+      duration: 0,
+      isStarting: false,
+      micLocked: false,
+      recording: undefined,
+      status: 'idle',
+      waveformData: [],
+    });
+  });
+});

--- a/package/src/state-store/audio-recorder-manager.ts
+++ b/package/src/state-store/audio-recorder-manager.ts
@@ -3,11 +3,17 @@ import { Platform } from 'react-native';
 import { StateStore } from 'stream-chat';
 
 import { normalizeAudioLevel } from '../components/MessageInput/utils/normalizeAudioLevel';
-import { AudioRecordingReturnType, NativeHandlers, RecordingStatus } from '../native';
+import {
+  AudioRecordingReturnType,
+  AudioReturnType,
+  NativeHandlers,
+  RecordingStatus,
+} from '../native';
 
 export type RecordingStatusStates = 'idle' | 'recording' | 'stopped';
 
 export type AudioRecorderManagerState = {
+  isStarting: boolean;
   micLocked: boolean;
   recording: AudioRecordingReturnType;
   waveformData: number[];
@@ -16,6 +22,7 @@ export type AudioRecorderManagerState = {
 };
 
 const INITIAL_STATE: AudioRecorderManagerState = {
+  isStarting: false,
   micLocked: false,
   waveformData: [],
   recording: undefined,
@@ -25,12 +32,29 @@ const INITIAL_STATE: AudioRecorderManagerState = {
 
 export class AudioRecorderManager {
   state: StateStore<AudioRecorderManagerState>;
+  /**
+   * A boolean signifying whether we've tried to stop a recording while the
+   * startRecording method is still executing. It is useful to identify race
+   * conditions where we try to cancel the recording altogether while setting
+   * up the recording session finishes (which can take up to 700ms on some
+   * slower devices).
+   * @private
+   */
+  private hasPendingStopWhileStarting = false;
+  /**
+   * A request ID for this recording session. Used to identify stale recording
+   * sessions and respond adequately, avoiding race conditions.
+   * @private
+   */
+  private startRequestId = 0;
 
   constructor() {
     this.state = new StateStore<AudioRecorderManagerState>(INITIAL_STATE);
   }
 
   reset() {
+    this.startRequestId += 1;
+    this.hasPendingStopWhileStarting = false;
     this.state.next(INITIAL_STATE);
   }
 
@@ -54,18 +78,52 @@ export class AudioRecorderManager {
     if (!NativeHandlers.Audio) {
       return;
     }
-    const recordingInfo = await NativeHandlers.Audio.startRecording(
-      {
-        isMeteringEnabled: true,
-      },
-      this.onRecordingStatusUpdate,
-    );
+    const { isStarting, status } = this.state.getLatestValue();
+    if (isStarting || status === 'recording') {
+      return true;
+    }
+    this.hasPendingStopWhileStarting = false;
+    const requestId = ++this.startRequestId;
+    this.state.partialNext({
+      duration: 0,
+      isStarting: true,
+      micLocked: false,
+      recording: undefined,
+      status: 'idle',
+      waveformData: [],
+    });
+    let recordingInfo: AudioReturnType;
+    try {
+      recordingInfo = await NativeHandlers.Audio.startRecording(
+        {
+          isMeteringEnabled: true,
+        },
+        this.onRecordingStatusUpdate,
+      );
+    } catch {
+      if (requestId === this.startRequestId) {
+        this.reset();
+      }
+      return false;
+    }
+
     const { accessGranted, recording } = recordingInfo;
+    if (this.hasPendingStopWhileStarting || requestId !== this.startRequestId) {
+      try {
+        await NativeHandlers.Audio.stopRecording();
+      } catch {
+        // If stopRecording fails, the native implementation has already stopped the
+        // recorder and so we do nothing.
+      }
+      this.reset();
+      return accessGranted;
+    }
+
     if (accessGranted && recording) {
       if (recording && typeof recording !== 'string' && recording.setProgressUpdateInterval) {
         recording.setProgressUpdateInterval(Platform.OS === 'android' ? 100 : 60);
       }
-      this.state.partialNext({ recording, status: 'recording' });
+      this.state.partialNext({ isStarting: false, recording, status: 'recording' });
     } else {
       this.reset();
     }
@@ -77,8 +135,21 @@ export class AudioRecorderManager {
     if (!NativeHandlers.Audio) {
       return;
     }
-    await NativeHandlers.Audio.stopRecording();
-    this.state.partialNext({ status: 'stopped' });
+    const { isStarting, status } = this.state.getLatestValue();
+    if (isStarting) {
+      this.hasPendingStopWhileStarting = true;
+      this.reset();
+      return;
+    }
+    if (status !== 'recording') {
+      return;
+    }
+    try {
+      await NativeHandlers.Audio.stopRecording();
+    } catch {
+      // Best effort cleanup, native implementation may already be stopped.
+    }
+    this.state.partialNext({ isStarting: false, status: 'stopped' });
   }
 
   set micLocked(value: boolean) {

--- a/package/src/state-store/audio-recorder-manager.ts
+++ b/package/src/state-store/audio-recorder-manager.ts
@@ -33,14 +33,14 @@ const INITIAL_STATE: AudioRecorderManagerState = {
 export class AudioRecorderManager {
   state: StateStore<AudioRecorderManagerState>;
   /**
-   * A boolean signifying whether we've tried to stop a recording while the
+   * A Set signifying whether we've tried to stop a recording session while the
    * startRecording method is still executing. It is useful to identify race
    * conditions where we try to cancel the recording altogether while setting
    * up the recording session finishes (which can take up to 700ms on some
    * slower devices).
    * @private
    */
-  private hasPendingStopWhileStarting = false;
+  private pendingStopRequestIds = new Set<number>();
   /**
    * A request ID for this recording session. Used to identify stale recording
    * sessions and respond adequately, avoiding race conditions.
@@ -53,8 +53,6 @@ export class AudioRecorderManager {
   }
 
   reset() {
-    this.startRequestId += 1;
-    this.hasPendingStopWhileStarting = false;
     this.state.next(INITIAL_STATE);
   }
 
@@ -82,7 +80,6 @@ export class AudioRecorderManager {
     if (isStarting || status === 'recording') {
       return true;
     }
-    this.hasPendingStopWhileStarting = false;
     const requestId = ++this.startRequestId;
     this.state.partialNext({
       duration: 0,
@@ -101,6 +98,7 @@ export class AudioRecorderManager {
         this.onRecordingStatusUpdate,
       );
     } catch {
+      this.pendingStopRequestIds.delete(requestId);
       if (requestId === this.startRequestId) {
         this.reset();
       }
@@ -108,14 +106,24 @@ export class AudioRecorderManager {
     }
 
     const { accessGranted, recording } = recordingInfo;
-    if (this.hasPendingStopWhileStarting || requestId !== this.startRequestId) {
-      try {
-        await NativeHandlers.Audio.stopRecording();
-      } catch {
-        // If stopRecording fails, the native implementation has already stopped the
-        // recorder and so we do nothing.
+    if (this.pendingStopRequestIds.has(requestId)) {
+      if (accessGranted) {
+        try {
+          await NativeHandlers.Audio.stopRecording();
+        } catch {
+          // If stopRecording fails, the native implementation has already stopped the
+          // recorder and so we do nothing.
+        }
       }
-      this.reset();
+      this.pendingStopRequestIds.delete(requestId);
+      if (requestId === this.startRequestId) {
+        this.reset();
+      }
+      return accessGranted;
+    }
+
+    if (requestId !== this.startRequestId) {
+      // Stale start completion, ignore to avoid affecting newer attempts
       return accessGranted;
     }
 
@@ -137,7 +145,8 @@ export class AudioRecorderManager {
     }
     const { isStarting, status } = this.state.getLatestValue();
     if (isStarting) {
-      this.hasPendingStopWhileStarting = true;
+      this.pendingStopRequestIds.add(this.startRequestId);
+      this.reset();
       return;
     }
     if (status !== 'recording') {

--- a/package/src/state-store/audio-recorder-manager.ts
+++ b/package/src/state-store/audio-recorder-manager.ts
@@ -139,7 +139,7 @@ export class AudioRecorderManager {
     return accessGranted;
   }
 
-  async stopRecording() {
+  async stopRecording(withDelete: boolean = false) {
     if (!NativeHandlers.Audio) {
       return;
     }
@@ -157,7 +157,12 @@ export class AudioRecorderManager {
     } catch {
       // Best effort cleanup, native implementation may already be stopped.
     }
-    this.state.partialNext({ isStarting: false, status: 'stopped' });
+
+    if (withDelete) {
+      this.reset();
+    } else {
+      this.state.partialNext({ isStarting: false, status: 'stopped' });
+    }
   }
 
   set micLocked(value: boolean) {

--- a/package/src/state-store/audio-recorder-manager.ts
+++ b/package/src/state-store/audio-recorder-manager.ts
@@ -138,7 +138,6 @@ export class AudioRecorderManager {
     const { isStarting, status } = this.state.getLatestValue();
     if (isStarting) {
       this.hasPendingStopWhileStarting = true;
-      this.reset();
       return;
     }
     if (status !== 'recording') {


### PR DESCRIPTION
## 🎯 Goal

This PR addresses an issue with voice recording, where if we let go of the long press gesture just after `onLongPress` has fired, but before `startRecording` has actually been invoked, we would get the player stuck in a bad state where we would neither be able to cancel nor lock the microphone in unless we long press again (which is not really intuitive). 

We implement a simple locking/semaphore mechanism to make sure this does not happen.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


