### PR TITLE
feat: typing indicator

### DIFF
--- a/examples/SampleApp/src/screens/ChannelScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelScreen.tsx
@@ -11,7 +11,6 @@ import {
   useChannelPreviewDisplayName,
   useChatContext,
   useTheme,
-  useTypingString,
   AITypingIndicatorView,
   useTranslationContext,
   MessageActionsParams,
@@ -56,7 +55,6 @@ const ChannelHeader: React.FC<ChannelHeaderProps> = ({ channel }) => {
   const { isOnline } = useChatContext();
   const { chatClient } = useAppContext();
   const navigation = useNavigation<ChannelScreenNavigationProp>();
-  const typing = useTypingString();
 
   const isOneOnOneConversation =
     channel &&
@@ -108,7 +106,7 @@ const ChannelHeader: React.FC<ChannelHeaderProps> = ({ channel }) => {
       )}
       showUnreadCountBadge
       Subtitle={isOnline ? undefined : NetworkDownIndicator}
-      subtitleText={typing ? typing : membersStatus}
+      subtitleText={membersStatus}
       titleText={displayName}
     />
   );
@@ -229,7 +227,6 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
         channel={channel}
         messageInputFloating={messageInputFloating}
         onPressMessage={onPressMessage}
-        disableTypingIndicator
         initialScrollToFirstUnreadMessage
         keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : -300}
         messageActions={messageActions}

--- a/package/src/components/MessageInput/MessageInput.tsx
+++ b/package/src/components/MessageInput/MessageInput.tsx
@@ -69,6 +69,11 @@ const useStyles = () => {
   } = useTheme();
   return useMemo(() => {
     return StyleSheet.create({
+      autocompleteInputContainer: {
+        flex: 1,
+        flexShrink: 1,
+        minWidth: 0,
+      },
       pollModalWrapper: {
         alignItems: 'center',
         flex: 1,
@@ -418,7 +423,10 @@ const MessageInputWithContext = (props: MessageInputPropsWithContext) => {
                     <>
                       <MessageInputLeadingView />
 
-                      <Animated.View layout={LinearTransition.duration(200)}>
+                      <Animated.View
+                        style={styles.autocompleteInputContainer}
+                        layout={LinearTransition.duration(200)}
+                      >
                         <AutoCompleteInput
                           TextInputComponent={TextInputComponent}
                           {...additionalTextInputProps}

--- a/package/src/components/MessageList/MessageFlashList.tsx
+++ b/package/src/components/MessageList/MessageFlashList.tsx
@@ -1107,6 +1107,12 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
   );
 };
 
+/**
+ * Unfortunately, FlashList does not handle autoscrolling if the footer changes properly. Because
+ * of that, we calculate this manually and autoscroll to the bottom if we're near the end. We only
+ * do this if the typing indicator is about to be rendered for now. Later on we can rely on proper
+ * layout calculations.
+ */
 const FlashListFooterTypingAdapter = ({
   enabled,
   children,

--- a/package/src/components/MessageList/MessageFlashList.tsx
+++ b/package/src/components/MessageList/MessageFlashList.tsx
@@ -1143,6 +1143,8 @@ const FlashListFooterTypingAdapter = ({
     if (listApi && typingUsersLengthRef.current === 0 && typingUsers.length > 0 && isNearEnd) {
       listApi.scrollToEnd({ animated: true });
     }
+
+    typingUsersLengthRef.current = typingUsers.length;
   }, [enabled, api, typingUsers.length]);
 
   return children;

--- a/package/src/components/MessageList/MessageFlashList.tsx
+++ b/package/src/components/MessageList/MessageFlashList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   LayoutChangeEvent,
   ScrollViewProps,
@@ -10,11 +10,12 @@ import {
 
 import Animated, { LinearTransition } from 'react-native-reanimated';
 
-import type { FlashListProps, FlashListRef } from '@shopify/flash-list';
+import { FlashListProps, FlashListRef, useFlashListContext } from '@shopify/flash-list';
 import type { Channel, Event, LocalMessage, MessageResponse } from 'stream-chat';
 
 import { useMessageList } from './hooks/useMessageList';
 import { useShouldScrollToRecentOnNewOwnMessage } from './hooks/useShouldScrollToRecentOnNewOwnMessage';
+import { useTypingUsers } from './hooks/useTypingUsers';
 import { InlineLoadingMoreIndicator } from './InlineLoadingMoreIndicator';
 import { InlineLoadingMoreRecentIndicator } from './InlineLoadingMoreRecentIndicator';
 import { InlineLoadingMoreRecentThreadIndicator } from './InlineLoadingMoreRecentThreadIndicator';
@@ -274,7 +275,7 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
     disableTypingIndicator,
     EmptyStateIndicator,
     // FlatList,
-    FooterComponent = LoadingMoreRecentIndicator,
+    FooterComponent,
     HeaderComponent = InlineLoadingMoreIndicator,
     hideStickyDateHeader,
     isLiveStreaming = false,
@@ -1002,6 +1003,29 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
     currentListHeightRef.current = height;
   });
 
+  const ListFooterComponent = useCallback(() => {
+    if (FooterComponent) {
+      return <FooterComponent />;
+    }
+
+    return (
+      <FlashListFooterTypingAdapter enabled={!disableTypingIndicator && !!TypingIndicator}>
+        <LoadingMoreRecentIndicator />
+        {!disableTypingIndicator && TypingIndicator && (
+          <TypingIndicatorContainer>
+            <TypingIndicator />
+          </TypingIndicatorContainer>
+        )}
+      </FlashListFooterTypingAdapter>
+    );
+  }, [
+    FooterComponent,
+    LoadingMoreRecentIndicator,
+    TypingIndicator,
+    TypingIndicatorContainer,
+    disableTypingIndicator,
+  ]);
+
   if (loading) {
     return (
       <View style={styles.container}>
@@ -1034,7 +1058,7 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
             }
             keyboardShouldPersistTaps='handled'
             keyExtractor={keyExtractor}
-            ListFooterComponent={FooterComponent}
+            ListFooterComponent={ListFooterComponent}
             ListHeaderComponent={HeaderComponent}
             maintainVisibleContentPosition={maintainVisibleContentPosition}
             onMomentumScrollEnd={onUserScrollEvent}
@@ -1060,11 +1084,6 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
           <StickyHeader date={stickyHeaderDate} DateHeader={DateHeader} />
         ) : null}
       </View>
-      {!disableTypingIndicator && TypingIndicator && (
-        <TypingIndicatorContainer>
-          <TypingIndicator />
-        </TypingIndicatorContainer>
-      )}
       <Animated.View
         layout={LinearTransition.duration(200)}
         style={[
@@ -1086,6 +1105,41 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
       ) : null}
     </View>
   );
+};
+
+const FlashListFooterTypingAdapter = ({
+  enabled,
+  children,
+}: PropsWithChildren<{
+  enabled: boolean;
+}>) => {
+  const api = useFlashListContext();
+  const typingUsers = useTypingUsers();
+
+  const typingUsersLengthRef = useRef<number>(typingUsers.length);
+
+  useEffect(() => {
+    const listApi = api?.getRef();
+
+    if (!enabled || !listApi) {
+      return;
+    }
+
+    const lastScrollOffset = listApi.getAbsoluteLastScrollOffset();
+    const contentSize = listApi.getChildContainerDimensions();
+    const windowSize = listApi.getWindowSize();
+
+    const visibleLength = windowSize.height;
+    const contentLength = contentSize.height + listApi.getFirstItemOffset();
+
+    const isNearEnd = Math.ceil(lastScrollOffset + visibleLength) >= contentLength;
+
+    if (listApi && typingUsersLengthRef.current === 0 && typingUsers.length > 0 && isNearEnd) {
+      listApi.scrollToEnd({ animated: true });
+    }
+  }, [enabled, api, typingUsers.length]);
+
+  return children;
 };
 
 export type MessageFlashListProps = Partial<MessageFlashListPropsWithContext>;

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -1229,7 +1229,13 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
         )}
       </>
     );
-  }, [HeaderComponent, LoadingMoreRecentIndicator]);
+  }, [
+    HeaderComponent,
+    LoadingMoreRecentIndicator,
+    TypingIndicator,
+    TypingIndicatorContainer,
+    disableTypingIndicator,
+  ]);
 
   if (!ListComponent) {
     return null;

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -329,7 +329,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
     EmptyStateIndicator,
     FlatList,
     FooterComponent = InlineLoadingMoreIndicator,
-    HeaderComponent = LoadingMoreRecentIndicator,
+    HeaderComponent,
     hideStickyDateHeader,
     inverted = true,
     isLiveStreaming = false,
@@ -1214,6 +1214,23 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
     viewportHeightRef.current = nextViewportHeight;
   });
 
+  const ListHeaderComponent = useCallback(() => {
+    if (HeaderComponent) {
+      return <HeaderComponent />;
+    }
+
+    return (
+      <>
+        <LoadingMoreRecentIndicator />
+        {!disableTypingIndicator && TypingIndicator && (
+          <TypingIndicatorContainer>
+            <TypingIndicator />
+          </TypingIndicatorContainer>
+        )}
+      </>
+    );
+  }, [HeaderComponent, LoadingMoreRecentIndicator]);
+
   if (!ListComponent) {
     return null;
   }
@@ -1247,7 +1264,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
             keyboardShouldPersistTaps='handled'
             keyExtractor={keyExtractor}
             ListFooterComponent={FooterComponent}
-            ListHeaderComponent={HeaderComponent}
+            ListHeaderComponent={ListHeaderComponent}
             /**
             If autoscrollToTopThreshold is 10, we scroll to recent only if before the update, the list was already at the
             bottom (10 offset or below).
@@ -1283,11 +1300,6 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
           <StickyHeader date={stickyHeaderDate} DateHeader={DateHeader} />
         ) : null}
       </View>
-      {!disableTypingIndicator && TypingIndicator && (
-        <TypingIndicatorContainer>
-          <TypingIndicator />
-        </TypingIndicatorContainer>
-      )}
       {scrollToBottomButtonVisible ? (
         <Animated.View
           layout={LinearTransition.duration(200)}

--- a/package/src/components/MessageList/TypingIndicator.tsx
+++ b/package/src/components/MessageList/TypingIndicator.tsx
@@ -1,43 +1,63 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
 
-import { useTypingString } from './hooks/useTypingString';
+import { useTypingUsers } from './hooks/useTypingUsers';
 
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 
+import { components, primitives } from '../../theme';
 import { LoadingDots } from '../Indicators/LoadingDots';
+import { UserAvatarStack } from '../ui';
 
-const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    height: 24,
-    justifyContent: 'flex-start',
-  },
-  loadingDots: {
-    marginLeft: 8,
-  },
-  typingText: {
-    marginLeft: 8,
-  },
-});
+const useStyles = () => {
+  const {
+    theme: { semantics },
+  } = useTheme();
+  return useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          alignItems: 'center',
+          flexDirection: 'row',
+          justifyContent: 'flex-start',
+          gap: primitives.spacingXs,
+        },
+        loadingDots: {},
+        loadingDotsBubble: {
+          borderTopLeftRadius: components.messageBubbleRadiusGroupBottom,
+          borderTopRightRadius: components.messageBubbleRadiusGroupBottom,
+          borderBottomRightRadius: components.messageBubbleRadiusGroupBottom,
+          borderBottomLeftRadius: components.messageBubbleRadiusTail,
+          backgroundColor: semantics.chatBgIncoming,
+          paddingVertical: primitives.spacingMd,
+          paddingHorizontal: primitives.spacingSm,
+        },
+        avatarStackContainer: {
+          paddingTop: primitives.spacingXxs,
+        },
+      }),
+    [semantics],
+  );
+};
 
 export const TypingIndicator = () => {
   const {
     theme: {
-      colors: { grey, white_snow },
-      typingIndicator: { container, text },
+      typingIndicator: { container, loadingDotsBubble, avatarStackContainer },
     },
   } = useTheme();
-  const typingString = useTypingString();
+  const styles = useStyles();
+
+  const typingUsers = useTypingUsers();
 
   return (
-    <View
-      style={[styles.container, { backgroundColor: `${white_snow}E6` }, container]}
-      testID='typing-indicator'
-    >
-      <LoadingDots style={styles.loadingDots} />
-      <Text style={[styles.typingText, { color: grey }, text]}>{typingString}</Text>
+    <View style={[styles.container, container]} testID='typing-indicator'>
+      <View style={[styles.avatarStackContainer, avatarStackContainer]}>
+        <UserAvatarStack users={typingUsers} avatarSize='md' maxVisible={3} overlap={0.4} />
+      </View>
+      <View style={[styles.loadingDotsBubble, loadingDotsBubble]}>
+        <LoadingDots style={styles.loadingDots} />
+      </View>
     </View>
   );
 };

--- a/package/src/components/MessageList/TypingIndicatorContainer.tsx
+++ b/package/src/components/MessageList/TypingIndicatorContainer.tsx
@@ -7,11 +7,12 @@ import { ChatContextValue, useChatContext } from '../../contexts/chatContext/Cha
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { ThreadContextValue, useThreadContext } from '../../contexts/threadContext/ThreadContext';
 import { TypingContextValue, useTypingContext } from '../../contexts/typingContext/TypingContext';
+import { primitives } from '../../theme';
 
 const styles = StyleSheet.create({
   container: {
-    bottom: 0,
-    position: 'absolute',
+    paddingVertical: primitives.spacingXs,
+    paddingHorizontal: primitives.spacingMd,
     width: '100%',
   },
 });

--- a/package/src/components/MessageList/__tests__/TypingIndicator.test.js
+++ b/package/src/components/MessageList/__tests__/TypingIndicator.test.js
@@ -2,12 +2,10 @@ import React from 'react';
 
 import { cleanup, render, waitFor } from '@testing-library/react-native';
 
-import { TranslationProvider } from '../../../contexts/translationContext/TranslationContext';
 import { TypingProvider } from '../../../contexts/typingContext/TypingContext';
 
 import { generateStaticUser, generateUser } from '../../../mock-builders/generator/user';
 import { getTestClientWithUser } from '../../../mock-builders/mock';
-import { Streami18n } from '../../../utils/i18n/Streami18n';
 import { Chat } from '../../Chat/Chat';
 import { TypingIndicator } from '../TypingIndicator';
 
@@ -17,7 +15,6 @@ describe('TypingIndicator', () => {
   let chatClient;
 
   it('should render typing indicator for two users', async () => {
-    const t = jest.fn((key) => key);
     const user0 = generateUser();
     const user1 = generateUser();
     const user2 = generateUser();
@@ -26,26 +23,20 @@ describe('TypingIndicator', () => {
     await chatClient.setUser(user0, 'testToken');
     const typing = { user1: { user: user1 }, user2: { user: user2 } };
 
-    const { getByTestId } = render(
+    const { getAllByTestId, getByTestId } = render(
       <Chat client={chatClient}>
-        <TranslationProvider value={{ t }}>
-          <TypingProvider value={{ typing }}>
-            <TypingIndicator />
-          </TypingProvider>
-        </TranslationProvider>
+        <TypingProvider value={{ typing }}>
+          <TypingIndicator />
+        </TypingProvider>
       </Chat>,
     );
-    expect(t).toHaveBeenCalledWith('{{ firstUser }} and {{ nonSelfUserLength }} more are typing', {
-      firstUser: user1.name,
-      nonSelfUserLength: 1,
-    });
     await waitFor(() => {
       expect(getByTestId('typing-indicator')).toBeTruthy();
+      expect(getAllByTestId('user-avatar')).toHaveLength(2);
     });
   });
 
   it('should render typing indicator for one user', async () => {
-    const t = jest.fn((key) => key);
     const user0 = generateUser();
     const user1 = generateUser();
 
@@ -53,26 +44,20 @@ describe('TypingIndicator', () => {
     await chatClient.setUser(user0, 'testToken');
     const typing = { user1: { user: user1 } };
 
-    const { getByTestId } = render(
+    const { getAllByTestId, getByTestId } = render(
       <Chat client={chatClient}>
-        <TranslationProvider value={{ t }}>
-          <TypingProvider value={{ typing }}>
-            <TypingIndicator />
-          </TypingProvider>
-        </TranslationProvider>
+        <TypingProvider value={{ typing }}>
+          <TypingIndicator />
+        </TypingProvider>
       </Chat>,
     );
-    expect(t).toHaveBeenCalledWith('{{ user }} is typing', {
-      user: user1.name,
-    });
     await waitFor(() => {
       expect(getByTestId('typing-indicator')).toBeTruthy();
+      expect(getAllByTestId('user-avatar')).toHaveLength(1);
     });
   });
 
   it('should match typing indicator snapshot', async () => {
-    const i18nInstance = new Streami18n();
-    const { t } = await i18nInstance.getTranslators();
     const user0 = generateStaticUser(0);
     const user1 = generateStaticUser(1);
     const user2 = generateStaticUser(3);
@@ -83,11 +68,9 @@ describe('TypingIndicator', () => {
 
     const { toJSON } = render(
       <Chat client={chatClient}>
-        <TranslationProvider value={{ t }}>
-          <TypingProvider value={{ typing }}>
-            <TypingIndicator />
-          </TypingProvider>
-        </TranslationProvider>
+        <TypingProvider value={{ typing }}>
+          <TypingIndicator />
+        </TypingProvider>
       </Chat>,
     );
     await waitFor(() => {

--- a/package/src/components/MessageList/__tests__/__snapshots__/TypingIndicator.test.js.snap
+++ b/package/src/components/MessageList/__tests__/__snapshots__/TypingIndicator.test.js.snap
@@ -7,11 +7,8 @@ exports[`TypingIndicator should match typing indicator snapshot 1`] = `
       {
         "alignItems": "center",
         "flexDirection": "row",
-        "height": 24,
+        "gap": 8,
         "justifyContent": "flex-start",
-      },
-      {
-        "backgroundColor": "#FCFCFCE6",
       },
       {},
     ]
@@ -22,12 +19,9 @@ exports[`TypingIndicator should match typing indicator snapshot 1`] = `
     style={
       [
         {
-          "flexDirection": "row",
+          "paddingTop": 4,
         },
         {},
-        {
-          "marginLeft": 8,
-        },
       ]
     }
   >
@@ -35,76 +29,222 @@ exports[`TypingIndicator should match typing indicator snapshot 1`] = `
       style={
         [
           {
-            "backgroundColor": "#687385",
-            "borderRadius": 2.5,
-            "height": 5,
-            "width": 5,
+            "alignItems": "center",
+            "flexDirection": "row",
           },
           {
-            "marginRight": 2,
+            "width": 51.2,
           },
-          {
-            "opacity": -0.3333333333333333,
-          },
-          {},
         ]
       }
-    />
-    <View
-      style={
-        [
-          {
-            "backgroundColor": "#687385",
-            "borderRadius": 2.5,
-            "height": 5,
-            "width": 5,
-          },
-          {
-            "marginHorizontal": 2,
-          },
-          {
-            "opacity": 0.3333333333333333,
-          },
-          {},
-        ]
-      }
-    />
-    <View
-      style={
-        [
-          {
-            "backgroundColor": "#687385",
-            "borderRadius": 2.5,
-            "height": 5,
-            "width": 5,
-          },
-          {
-            "marginLeft": 2,
-          },
-          {
-            "opacity": 1,
-          },
-          {},
-        ]
-      }
-    />
+    >
+      <View
+        style={
+          [
+            {
+              "position": "absolute",
+            },
+            {
+              "left": 0,
+            },
+          ]
+        }
+      >
+        <View
+          testID="user-avatar"
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 9999,
+                  "justifyContent": "center",
+                  "overflow": "hidden",
+                },
+                {
+                  "height": 32,
+                  "width": 32,
+                },
+                {
+                  "backgroundColor": "#fcd579",
+                },
+                {
+                  "borderColor": "rgba(0, 0, 0, 0.1)",
+                  "borderWidth": 1,
+                },
+                undefined,
+              ]
+            }
+            testID="avatar-image"
+          >
+            <Image
+              onError={[Function]}
+              source={
+                {
+                  "uri": "https://i.imgur.com/LuuGvh0.png",
+                }
+              }
+              style={
+                [
+                  {},
+                  {
+                    "height": 32,
+                    "width": 32,
+                  },
+                ]
+              }
+            />
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          [
+            {
+              "position": "absolute",
+            },
+            {
+              "left": 19.2,
+            },
+          ]
+        }
+      >
+        <View
+          testID="user-avatar"
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 9999,
+                  "justifyContent": "center",
+                  "overflow": "hidden",
+                },
+                {
+                  "height": 32,
+                  "width": 32,
+                },
+                {
+                  "backgroundColor": "#8febbd",
+                },
+                {
+                  "borderColor": "rgba(0, 0, 0, 0.1)",
+                  "borderWidth": 1,
+                },
+                undefined,
+              ]
+            }
+            testID="avatar-image"
+          >
+            <Image
+              onError={[Function]}
+              source={
+                {
+                  "uri": "https://i.imgur.com/spueyAP.png",
+                }
+              }
+              style={
+                [
+                  {},
+                  {
+                    "height": 32,
+                    "width": 32,
+                  },
+                ]
+              }
+            />
+          </View>
+        </View>
+      </View>
+    </View>
   </View>
-  <Text
+  <View
     style={
       [
         {
-          "marginLeft": 8,
+          "backgroundColor": "#ebeef1",
+          "borderBottomLeftRadius": 0,
+          "borderBottomRightRadius": 20,
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
+          "paddingHorizontal": 12,
+          "paddingVertical": 16,
         },
-        {
-          "color": "#7A7A7A",
-        },
-        {
-          "fontSize": 14,
-        },
+        {},
       ]
     }
   >
-    Arthur and 1 more are typing
-  </Text>
+    <View
+      style={
+        [
+          {
+            "flexDirection": "row",
+          },
+          {},
+          {},
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "backgroundColor": "#687385",
+              "borderRadius": 2.5,
+              "height": 5,
+              "width": 5,
+            },
+            {
+              "marginRight": 2,
+            },
+            {
+              "opacity": -0.3333333333333333,
+            },
+            {},
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "backgroundColor": "#687385",
+              "borderRadius": 2.5,
+              "height": 5,
+              "width": 5,
+            },
+            {
+              "marginHorizontal": 2,
+            },
+            {
+              "opacity": 0.3333333333333333,
+            },
+            {},
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "backgroundColor": "#687385",
+              "borderRadius": 2.5,
+              "height": 5,
+              "width": 5,
+            },
+            {
+              "marginLeft": 2,
+            },
+            {
+              "opacity": 1,
+            },
+            {},
+          ]
+        }
+      />
+    </View>
+  </View>
 </View>
 `;

--- a/package/src/components/MessageList/hooks/useTypingString.ts
+++ b/package/src/components/MessageList/hooks/useTypingString.ts
@@ -1,30 +1,31 @@
-import { useChatContext } from '../../../contexts/chatContext/ChatContext';
-import { useThreadContext } from '../../../contexts/threadContext/ThreadContext';
-import { useTranslationContext } from '../../../contexts/translationContext/TranslationContext';
-import { useTypingContext } from '../../../contexts/typingContext/TypingContext';
+import { useMemo } from 'react';
 
-import { filterTypingUsers } from '../utils/filterTypingUsers';
+import { useTypingUsers } from './useTypingUsers';
+
+import { useTranslationContext } from '../../../contexts/translationContext/TranslationContext';
 
 export const useTypingString = () => {
-  const { client } = useChatContext();
-  const { thread } = useThreadContext();
   const { t } = useTranslationContext();
-  const { typing } = useTypingContext();
 
-  const filteredTypingUsers = filterTypingUsers({ client, thread, typing });
+  const typingUsers = useTypingUsers();
 
-  if (filteredTypingUsers.length === 1) {
-    return t('{{ user }} is typing', { user: filteredTypingUsers[0] });
+  const typingUsernames = useMemo(
+    () => typingUsers.map((typingUser) => typingUser.name || typingUser.id),
+    [typingUsers],
+  );
+
+  if (typingUsernames.length === 1) {
+    return t('{{ user }} is typing', { user: typingUsernames[0] });
   }
 
-  if (filteredTypingUsers.length > 1) {
+  if (typingUsernames.length > 1) {
     /**
      * Joins the multiple names with number after first name
      * example: "Dan and Neil"
      */
     return t('{{ firstUser }} and {{ nonSelfUserLength }} more are typing', {
-      firstUser: filteredTypingUsers[0],
-      nonSelfUserLength: filteredTypingUsers.length - 1,
+      firstUser: typingUsernames[0],
+      nonSelfUserLength: typingUsernames.length - 1,
     });
   }
 

--- a/package/src/components/MessageList/hooks/useTypingUsers.ts
+++ b/package/src/components/MessageList/hooks/useTypingUsers.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react';
+
+import { useChatContext, useThreadContext, useTypingContext } from '../../../contexts';
+import { filterTypingUsers } from '../utils/filterTypingUsers';
+
+export const useTypingUsers = () => {
+  const { client } = useChatContext();
+  const { thread } = useThreadContext();
+  const { typing } = useTypingContext();
+
+  return useMemo(() => filterTypingUsers({ client, thread, typing }), [client, thread, typing]);
+};

--- a/package/src/components/MessageList/utils/filterTypingUsers.ts
+++ b/package/src/components/MessageList/utils/filterTypingUsers.ts
@@ -1,3 +1,5 @@
+import { UserResponse } from 'stream-chat';
+
 import type { ChatContextValue } from '../../../contexts/chatContext/ChatContext';
 import type { ThreadContextValue } from '../../../contexts/threadContext/ThreadContext';
 import type { TypingContextValue } from '../../../contexts/typingContext/TypingContext';
@@ -7,7 +9,7 @@ type FilterTypingUsersParams = Pick<TypingContextValue, 'typing'> &
   Pick<ThreadContextValue, 'thread'>;
 
 export const filterTypingUsers = ({ client, thread, typing }: FilterTypingUsersParams) => {
-  const nonSelfUsers: string[] = [];
+  const nonSelfUsers: UserResponse[] = [];
 
   if (!client || !client.user || !typing) {
     return nonSelfUsers;
@@ -33,7 +35,7 @@ export const filterTypingUsers = ({ client, thread, typing }: FilterTypingUsersP
       return;
     }
 
-    const user = typing[typingKey].user?.name || typing[typingKey].user?.id;
+    const user = typing[typingKey].user;
     if (user) {
       nonSelfUsers.push(user);
     }

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -2209,6 +2209,13 @@ exports[`Thread should match thread snapshot 1`] = `
             >
               <View
                 layout={BaseAnimationMock {}}
+                style={
+                  {
+                    "flex": 1,
+                    "flexShrink": 1,
+                    "minWidth": 0,
+                  }
+                }
               >
                 <TextInput
                   autoFocus={true}

--- a/package/src/components/ui/Avatar/AvatarStack.tsx
+++ b/package/src/components/ui/Avatar/AvatarStack.tsx
@@ -10,7 +10,7 @@ import { UserAvatar } from './UserAvatar';
 import { BadgeCount } from '../Badge';
 
 export type AvatarStackProps = {
-  avatarSize?: 'sm' | 'xs';
+  avatarSize?: 'sm' | 'md' | 'xs';
   maxVisible?: number;
   items: React.ReactNode[];
   overlap?: number;
@@ -25,7 +25,12 @@ export const AvatarStack = (props: AvatarStackProps) => {
   const extraCount = items.length - visibleItems.length;
 
   if (extraCount > 0) {
-    visibleItems.push(<BadgeCount count={extraCount} size={avatarSize === 'sm' ? 'md' : 'sm'} />);
+    visibleItems.push(
+      <BadgeCount
+        count={extraCount}
+        size={avatarSize === 'sm' || avatarSize === 'md' ? 'md' : 'sm'}
+      />,
+    );
   }
 
   const totalWidth = diameter + (visibleItems.length - 1) * visiblePortion;
@@ -66,14 +71,18 @@ export type UserAvatarStackProps = Pick<
 };
 
 export const UserAvatarStack = ({
-  avatarSize,
+  avatarSize = 'sm',
   maxVisible,
   overlap,
   users,
 }: UserAvatarStackProps) => {
-  const items = users.map((user) => {
-    return <UserAvatar key={user.id} user={user} size='sm' showBorder />;
-  });
+  const items = useMemo(
+    () =>
+      users.map((user) => {
+        return <UserAvatar key={user.id} user={user} size={avatarSize} showBorder />;
+      }),
+    [avatarSize, users],
+  );
 
   return (
     <AvatarStack avatarSize={avatarSize} maxVisible={maxVisible} overlap={overlap} items={items} />

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -938,6 +938,8 @@ export type Theme = {
   };
   typingIndicator: {
     container: ViewStyle;
+    loadingDotsBubble: ViewStyle;
+    avatarStackContainer: ViewStyle;
     text: TextStyle & {
       fontSize: TextStyle['fontSize'];
     };
@@ -1774,6 +1776,8 @@ export const defaultTheme: Theme = {
   },
   typingIndicator: {
     container: {},
+    loadingDotsBubble: {},
+    avatarStackContainer: {},
     text: {
       fontSize: 14,
     },


### PR DESCRIPTION
## 🎯 Goal

This PR implements the new designs for the typing indicator in both `MessageList` and `MessageFlashList`.

While it was relatively trivial for `MessageList`, on `MessageFlashList` there is no automatic autoscroll if footer layout changes. Hence, we have to write an adapter to do this manually.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


