### PR TITLE
fix: exclude RCT-Folly from prebuilt RN

### DIFF
--- a/package/native-package/stream-chat-react-native.podspec
+++ b/package/native-package/stream-chat-react-native.podspec
@@ -28,11 +28,15 @@ Pod::Spec.new do |s|
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
     s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
+    # Prebuilt RN modes already handle Folly (or don't expose RCT-Folly podspec).
+    use_prebuilt_core = ENV['RCT_USE_PREBUILT_RNCORE'] == '1'
+    use_prebuilt_deps = ENV['RCT_USE_RN_DEP'] == '1'
+    unless use_prebuilt_core || use_prebuilt_deps
+      s.dependency "RCT-Folly"
+    end
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
     install_modules_dependencies(s)
   end
 end
-


### PR DESCRIPTION
## 🎯 Goal

This PR fixes iOS Pod install failures when using prebuilt React Native dependencies/core by conditionally excluding RCT-Folly from `stream-chat-react-native.podspec`.

In New Architecture builds when prebuilt React Native modes are enabled, the SDK still declared a direct dependency on `RCT-Folly`. In certain configurations (for example RN 0.80 with `RCT_USE_RN_DEP=1`), this can cause `pod` installation to fail with:
```
  - [!] Unable to find a specification for 'RCT-Folly' depended upon by 'stream-chat-react-native'
```

This fails in prebuilt mode because React Native no longer relies on resolving `RCT-Folly` as a standalone pod from the specs repo. Instead, `Folly` is handled through RN’s prebuilt dependency/core packaging. As a result, an explicit `s.dependency "RCT-Folly"` in our `podspec` can force cocoapods to resolve a podspec that is not available in that installation path, causing the failure.

Should resolve [this github issue](https://github.com/GetStream/stream-chat-react-native/issues/3369).

For reference, see:

https://github.com/facebook/react-native/blob/v0.80.2/packages/react-native/scripts/cocoapods/rndependencies.rb#L12-L15

https://github.com/facebook/react-native/blob/v0.80.2/packages/react-native/scripts/react_native_pods.rb#L172-L182

https://github.com/facebook/react-native/blob/v0.80.2/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec#L39-L43

https://github.com/facebook/react-native/blob/v0.80.2/packages/react-native/third-party-podspecs/RCT-Folly.podspec#L11-L13

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


