### PR TITLE
feat: long message ctx menu

### DIFF
--- a/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.js.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.js.snap
@@ -787,19 +787,15 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
     }
   >
     <View
+      pointerEvents="box-none"
       style={
-        [
-          {
-            "height": 0,
-          },
-          {
-            "transform": [
-              {
-                "translateY": 0,
-              },
-            ],
-          },
-        ]
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
       }
     >
       <View
@@ -1708,19 +1704,15 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
     }
   >
     <View
+      pointerEvents="box-none"
       style={
-        [
-          {
-            "height": 0,
-          },
-          {
-            "transform": [
-              {
-                "translateY": 0,
-              },
-            ],
-          },
-        ]
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
       }
     >
       <View
@@ -2629,19 +2621,15 @@ exports[`AttachButton should render an disabled AttachButton 1`] = `
     }
   >
     <View
+      pointerEvents="box-none"
       style={
-        [
-          {
-            "height": 0,
-          },
-          {
-            "transform": [
-              {
-                "translateY": 0,
-              },
-            ],
-          },
-        ]
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
       }
     >
       <View

--- a/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.js.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.js.snap
@@ -785,19 +785,15 @@ exports[`SendButton should render a SendButton 1`] = `
     }
   >
     <View
+      pointerEvents="box-none"
       style={
-        [
-          {
-            "height": 0,
-          },
-          {
-            "transform": [
-              {
-                "translateY": 0,
-              },
-            ],
-          },
-        ]
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
       }
     >
       <View
@@ -1704,19 +1700,15 @@ exports[`SendButton should render a disabled SendButton 1`] = `
     }
   >
     <View
+      pointerEvents="box-none"
       style={
-        [
-          {
-            "height": 0,
-          },
-          {
-            "transform": [
-              {
-                "translateY": 0,
-              },
-            ],
-          },
-        ]
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
       }
     >
       <View

--- a/package/src/components/MessageMenu/MessageActionListItem.tsx
+++ b/package/src/components/MessageMenu/MessageActionListItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { StyleProp, StyleSheet, Text, TextStyle, View } from 'react-native';
 
 import { Pressable } from 'react-native-gesture-handler';
@@ -63,12 +63,12 @@ export const MessageActionListItem = (props: MessageActionListItemProps) => {
   const {
     theme: {
       semantics,
-      colors: { black },
       messageMenu: {
         actionListItem: { container, icon: iconTheme, title: titleTheme },
       },
     },
   } = useTheme();
+  const styles = useStyles();
 
   const onActionPress = useStableCallback(() => {
     closeOverlay();
@@ -88,23 +88,36 @@ export const MessageActionListItem = (props: MessageActionListItemProps) => {
         style={[styles.container, container]}
       >
         <View style={iconTheme}>{icon}</View>
-        <Text style={[styles.titleStyle, { color: black }, titleStyle, titleTheme]}>{title}</Text>
+        <Text style={[styles.titleStyle, titleStyle, titleTheme]}>{title}</Text>
       </View>
     </Pressable>
   );
 };
 
-const styles = StyleSheet.create({
-  buttonContainer: {
-    borderRadius: primitives.radiusLg,
-  },
-  container: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    justifyContent: 'flex-start',
-    padding: primitives.spacingXs,
-  },
-  titleStyle: {
-    paddingLeft: primitives.spacingXs,
-  },
-});
+const useStyles = () => {
+  const {
+    theme: { semantics },
+  } = useTheme();
+  return useMemo(
+    () =>
+      StyleSheet.create({
+        buttonContainer: {
+          borderRadius: primitives.radiusLg,
+        },
+        container: {
+          alignItems: 'center',
+          flexDirection: 'row',
+          justifyContent: 'flex-start',
+          padding: primitives.spacingXs,
+        },
+        titleStyle: {
+          paddingLeft: primitives.spacingXs,
+          fontWeight: primitives.typographyFontWeightMedium,
+          fontSize: primitives.typographyFontSizeMd,
+          lineHeight: primitives.typographyLineHeightNormal,
+          color: semantics.textPrimary,
+        },
+      }),
+    [semantics.textPrimary],
+  );
+};

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -23,7 +23,6 @@ import {
 } from '../../state-store';
 
 const DURATION = 300;
-
 export const MessageOverlayHostLayer = () => {
   const { id, closing } = useOverlayController();
   const insets = useSafeAreaInsets();
@@ -89,17 +88,40 @@ export const MessageOverlayHostLayer = () => {
     opacity: backdrop.value,
   }));
 
-  const shiftY = useDerivedValue(() => {
+  const messageShiftY = useDerivedValue(() => {
     if (!messageH.value || !topH.value || !bottomH.value) return 0;
 
     const anchorY = messageH.value.y;
     const msgH = messageH.value.h;
-
     const minTop = minY + topH.value.h;
-    const maxTop = maxY - (msgH + bottomH.value.h);
+    const maxTopWithBottom = maxY - (msgH + bottomH.value.h);
+    const maxTopWithoutBottom = maxY - msgH;
+    const maxTop = minTop <= maxTopWithBottom ? maxTopWithBottom : maxTopWithoutBottom;
+    const solvedTop = clamp(anchorY, minTop, Math.max(minTop, maxTop));
 
-    const solvedTop = clamp(anchorY, minTop, maxTop);
     return solvedTop - anchorY;
+  });
+
+  const bottomShiftY = useDerivedValue(() => {
+    if (!messageH.value || !topH.value || !bottomH.value) return 0;
+
+    const anchorMessageTop = messageH.value.y;
+    const msgH = messageH.value.h;
+    const minMessageTop = minY + topH.value.h;
+    const maxMessageTopWithBottom = maxY - (msgH + bottomH.value.h);
+    const maxMessageTopWithoutBottom = maxY - msgH;
+    const maxMessageTop =
+      minMessageTop <= maxMessageTopWithBottom
+        ? maxMessageTopWithBottom
+        : maxMessageTopWithoutBottom;
+    const solvedMessageTop = clamp(
+      anchorMessageTop,
+      minMessageTop,
+      Math.max(minMessageTop, maxMessageTop),
+    );
+
+    const solvedBottomTop = Math.min(solvedMessageTop + msgH, maxY - bottomH.value.h);
+    return solvedBottomTop - bottomH.value.y;
   });
 
   const viewportH = useSharedValue(screenH);
@@ -171,7 +193,7 @@ export const MessageOverlayHostLayer = () => {
   });
 
   const topItemTranslateStyle = useAnimatedStyle(() => {
-    const target = isActive ? (closing ? closeCorrectionY.value : shiftY.value) : 0;
+    const target = isActive ? (closing ? closeCorrectionY.value : messageShiftY.value) : 0;
     return {
       transform: [
         { scale: backdrop.value },
@@ -192,7 +214,7 @@ export const MessageOverlayHostLayer = () => {
   });
 
   const bottomItemTranslateStyle = useAnimatedStyle(() => {
-    const target = isActive ? (closing ? closeCorrectionY.value : shiftY.value) : 0;
+    const target = isActive ? (closing ? closeCorrectionY.value : bottomShiftY.value) : 0;
     return {
       transform: [
         { scale: backdrop.value },
@@ -213,7 +235,7 @@ export const MessageOverlayHostLayer = () => {
   });
 
   const hostTranslateStyle = useAnimatedStyle(() => {
-    const target = isActive ? (closing ? closeCorrectionY.value : shiftY.value) : 0;
+    const target = isActive ? (closing ? closeCorrectionY.value : messageShiftY.value) : 0;
 
     return {
       transform: [
@@ -236,14 +258,15 @@ export const MessageOverlayHostLayer = () => {
       const x = t.x;
       const y = t.y;
 
-      const yShift = shiftY.value; // overlay shift
+      const messageYShift = messageShiftY.value; // overlay shift for top + message
+      const bottomYShift = bottomShiftY.value; // overlay shift for bottom
       const yParent = scrollY.value; // parent content
 
       const top = topH.value;
       if (top) {
         // top rectangle's final screen Y
-        // base layout Y + overlay shift (shiftY) + parent scroll transform (scrollY)
-        const topY = top.y + yParent + yShift;
+        // base layout Y + overlay shift + parent scroll transform
+        const topY = top.y + yParent + messageYShift;
         if (x >= top.x && x <= top.x + top.w && y >= topY && y <= topY + top.h) {
           state.fail();
           return;
@@ -253,8 +276,8 @@ export const MessageOverlayHostLayer = () => {
       const bot = bottomH.value;
       if (bot) {
         // bottom rectangle's final screen Y
-        // base layout Y + overlay shift (shiftY) + parent scroll transform (scrollY)
-        const botY = bot.y + yParent + yShift;
+        // base layout Y + overlay shift + parent scroll transform
+        const botY = bot.y + yParent + bottomYShift;
         if (x >= bot.x && x <= bot.x + bot.w && y >= botY && y <= botY + bot.h) {
           state.fail();
           return;

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -1,14 +1,12 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { Platform, Pressable, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
-  cancelAnimation,
   clamp,
   runOnJS,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
-  withDecay,
   withSpring,
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -124,70 +122,13 @@ export const MessageOverlayHostLayer = () => {
     return solvedBottomTop - bottomH.value.y;
   });
 
-  const viewportH = useSharedValue(screenH);
-  useEffect(() => {
-    viewportH.value = screenH;
-  }, [screenH, viewportH]);
-
-  const scrollY = useSharedValue(0);
-  const initialScrollOffset = useSharedValue(0);
-
-  useEffect(() => {
-    if (isActive) scrollY.value = 0;
-  }, [isActive, scrollY]);
-
-  const contentH = useDerivedValue(() =>
-    topH.value && bottomH.value && messageH.value
-      ? Math.max(
-          screenH,
-          topH.value.h + messageH.value.h + bottomH.value.h + topInset + bottomInset + 20,
-        )
-      : 0,
-  );
-
-  const maxScroll = useDerivedValue(() => Math.max(0, contentH.value - viewportH.value));
-
-  const pan = useMemo(
-    () =>
-      Gesture.Pan()
-        .activeOffsetY([-8, 8])
-        .failOffsetX([-12, 12])
-        .onBegin(() => {
-          cancelAnimation(scrollY);
-          initialScrollOffset.value = scrollY.value;
-        })
-        .onUpdate((e) => {
-          scrollY.value = clamp(initialScrollOffset.value + e.translationY, 0, maxScroll.value);
-        })
-        .onEnd((e) => {
-          scrollY.value = withDecay({ clamp: [0, maxScroll.value], velocity: e.velocityY });
-        }),
-    [initialScrollOffset, maxScroll, scrollY],
-  );
-
-  const scrollAtClose = useSharedValue(0);
-
-  useDerivedValue(() => {
-    if (closing) {
-      scrollAtClose.value = scrollY.value;
-      cancelAnimation(scrollY);
-    }
-  }, [closing]);
-
-  const closeCompStyle = useAnimatedStyle(() => {
-    const target = closing ? -scrollAtClose.value : 0;
-    return {
-      transform: [{ translateY: withSpring(target, { duration: DURATION }) }],
-    };
-  }, [closing]);
-
   const topItemStyle = useAnimatedStyle(() => {
     if (!topH.value) return { height: 0 };
     return {
       height: topH.value.h,
       left: topH.value.x,
       position: 'absolute',
-      top: topH.value.y + scrollY.value,
+      top: topH.value.y,
       width: topH.value.w,
     };
   });
@@ -208,7 +149,7 @@ export const MessageOverlayHostLayer = () => {
       height: bottomH.value.h,
       left: bottomH.value.x,
       position: 'absolute',
-      top: bottomH.value.y + scrollY.value,
+      top: bottomH.value.y,
       width: bottomH.value.w,
     };
   });
@@ -229,7 +170,7 @@ export const MessageOverlayHostLayer = () => {
       height: messageH.value.h,
       left: messageH.value.x,
       position: 'absolute',
-      top: messageH.value.y + scrollY.value, // layout scroll (no special msg-only compensation)
+      top: messageH.value.y,
       width: messageH.value.w,
     };
   });
@@ -246,10 +187,6 @@ export const MessageOverlayHostLayer = () => {
     };
   }, [isActive, closing]);
 
-  const contentStyle = useAnimatedStyle(() => ({
-    height: contentH.value,
-  }));
-
   const tap = Gesture.Tap()
     .onTouchesDown((e, state) => {
       const t = e.allTouches[0];
@@ -260,13 +197,9 @@ export const MessageOverlayHostLayer = () => {
 
       const messageYShift = messageShiftY.value; // overlay shift for top + message
       const bottomYShift = bottomShiftY.value; // overlay shift for bottom
-      const yParent = scrollY.value; // parent content
-
       const top = topH.value;
       if (top) {
-        // top rectangle's final screen Y
-        // base layout Y + overlay shift + parent scroll transform
-        const topY = top.y + yParent + messageYShift;
+        const topY = top.y + messageYShift;
         if (x >= top.x && x <= top.x + top.w && y >= topY && y <= topY + top.h) {
           state.fail();
           return;
@@ -275,9 +208,7 @@ export const MessageOverlayHostLayer = () => {
 
       const bot = bottomH.value;
       if (bot) {
-        // bottom rectangle's final screen Y
-        // base layout Y + overlay shift + parent scroll transform
-        const botY = bot.y + yParent + bottomYShift;
+        const botY = bot.y + bottomYShift;
         if (x >= bot.x && x <= bot.x + bot.w && y >= botY && y <= botY + bot.h) {
           state.fail();
           return;
@@ -289,7 +220,7 @@ export const MessageOverlayHostLayer = () => {
     });
 
   return (
-    <GestureDetector gesture={Gesture.Exclusive(pan, tap)}>
+    <GestureDetector gesture={tap}>
       <View pointerEvents='box-none' style={StyleSheet.absoluteFill}>
         {isActive ? (
           <Animated.View
@@ -298,7 +229,7 @@ export const MessageOverlayHostLayer = () => {
           />
         ) : null}
 
-        <Animated.View style={[contentStyle, closeCompStyle]}>
+        <View pointerEvents='box-none' style={StyleSheet.absoluteFill}>
           {isActive ? (
             <Pressable onPress={closeOverlay} style={StyleSheet.absoluteFillObject} />
           ) : null}
@@ -314,7 +245,7 @@ export const MessageOverlayHostLayer = () => {
           <Animated.View style={[bottomItemStyle, bottomItemTranslateStyle, styles.shadow3]}>
             <PortalHost name='bottom-item' style={StyleSheet.absoluteFillObject} />
           </Animated.View>
-        </Animated.View>
+        </View>
       </View>
     </GestureDetector>
   );

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Platform, Pressable, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
@@ -187,37 +187,41 @@ export const MessageOverlayHostLayer = () => {
     };
   }, [isActive, closing]);
 
-  const tap = Gesture.Tap()
-    .onTouchesDown((e, state) => {
-      const t = e.allTouches[0];
-      if (!t) return;
+  const tap = useMemo(
+    () =>
+      Gesture.Tap()
+        .onTouchesDown((e, state) => {
+          const t = e.allTouches[0];
+          if (!t || !topH || !bottomH) return;
 
-      const x = t.x;
-      const y = t.y;
+          const x = t.x;
+          const y = t.y;
 
-      const messageYShift = messageShiftY.value; // overlay shift for top + message
-      const bottomYShift = bottomShiftY.value; // overlay shift for bottom
-      const top = topH.value;
-      if (top) {
-        const topY = top.y + messageYShift;
-        if (x >= top.x && x <= top.x + top.w && y >= topY && y <= topY + top.h) {
-          state.fail();
-          return;
-        }
-      }
+          const messageYShift = messageShiftY.value; // overlay shift for top + message
+          const bottomYShift = bottomShiftY.value; // overlay shift for bottom
+          const top = topH.value;
+          if (top) {
+            const topY = top.y + messageYShift;
+            if (x >= top.x && x <= top.x + top.w && y >= topY && y <= topY + top.h) {
+              state.fail();
+              return;
+            }
+          }
 
-      const bot = bottomH.value;
-      if (bot) {
-        const botY = bot.y + bottomYShift;
-        if (x >= bot.x && x <= bot.x + bot.w && y >= botY && y <= botY + bot.h) {
-          state.fail();
-          return;
-        }
-      }
-    })
-    .onEnd(() => {
-      runOnJS(closeOverlay)();
-    });
+          const bot = bottomH.value;
+          if (bot) {
+            const botY = bot.y + bottomYShift;
+            if (x >= bot.x && x <= bot.x + bot.w && y >= botY && y <= botY + bot.h) {
+              state.fail();
+              return;
+            }
+          }
+        })
+        .onEnd(() => {
+          runOnJS(closeOverlay)();
+        }),
+    [bottomH, bottomShiftY, messageShiftY, topH],
+  );
 
   return (
     <GestureDetector gesture={tap}>


### PR DESCRIPTION
## 🎯 Goal

This PR implements the new design for very long messages in the context menu. 

Short summary:

- Scrollability is removed
- Layout is changed to always visible top/bottom items
- Layout calculations have been adjusted to fit the frame here

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


