### PR TITLE
fix: thread and channel mirror navigation

### DIFF
--- a/examples/SampleApp/src/screens/ChannelScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelScreen.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import type { LocalMessage, Channel as StreamChatChannel } from 'stream-chat';
 import { RouteProp, useFocusEffect, useNavigation } from '@react-navigation/native';
 import {
+  AlsoSentToChannelHeaderPressPayload,
   Channel,
   MessageInput,
   MessageList,
@@ -188,13 +189,7 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
   );
 
   const onAlsoSentToChannelHeaderPress = useCallback(
-    async ({
-      parentMessage,
-      targetedMessageId,
-    }: {
-      parentMessage?: LocalMessage;
-      targetedMessageId: string;
-    }) => {
+    async ({ parentMessage, targetedMessageId }: AlsoSentToChannelHeaderPressPayload) => {
       if (!channel || !parentMessage) {
         return;
       }

--- a/examples/SampleApp/src/screens/ChannelScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelScreen.tsx
@@ -173,7 +173,7 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
   };
 
   const onThreadSelect = useCallback(
-    (thread: LocalMessage | null, targetedMessageId?: string) => {
+    (thread: LocalMessage | null) => {
       if (!thread || !channel) {
         return;
       }
@@ -182,8 +182,25 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
       navigation.navigate('ThreadScreen', {
         channel,
         thread,
-        targetedMessageId,
       });
+    },
+    [channel, navigation, setThread],
+  );
+
+  const onAlsoSentToChannelHeaderPress = useCallback(
+    async ({
+      parentMessage,
+      targetedMessageId,
+    }: {
+      parentMessage?: LocalMessage;
+      targetedMessageId: string;
+    }) => {
+      if (!channel || !parentMessage) {
+        return;
+      }
+      setSelectedThread(parentMessage);
+      setThread(parentMessage);
+      navigation.navigate('ThreadScreen', { channel, thread: parentMessage, targetedMessageId });
     },
     [channel, navigation, setThread],
   );
@@ -233,6 +250,7 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
         MessageLocation={MessageLocation}
         messageId={messageId}
         NetworkDownIndicator={() => null}
+        onAlsoSentToChannelHeaderPress={onAlsoSentToChannelHeaderPress}
         thread={selectedThread}
         maximumMessageLimit={messageListPruning}
       >

--- a/examples/SampleApp/src/screens/ChannelScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelScreen.tsx
@@ -33,6 +33,7 @@ import { useStreamChatContext } from '../context/StreamChatContext.tsx';
 import { CustomAttachmentPickerSelectionBar } from '../components/AttachmentPickerSelectionBar.tsx';
 import { MessageInfoBottomSheet } from '../components/MessageInfoBottomSheet.tsx';
 import { CustomAttachmentPickerContent } from '../components/AttachmentPickerContent.tsx';
+import { ThreadType } from 'stream-chat-react-native-core';
 
 export type ChannelScreenNavigationProp = NativeStackNavigationProp<
   StackNavigatorParamList,
@@ -195,7 +196,29 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({
       }
       setSelectedThread(parentMessage);
       setThread(parentMessage);
-      navigation.navigate('ThreadScreen', { channel, thread: parentMessage, targetedMessageId });
+      const params: StackNavigatorParamList['ThreadScreen'] = {
+        channel,
+        targetedMessageId,
+        thread: parentMessage,
+      };
+      const hasThreadInStack = navigation.getState().routes.some((route) => {
+        if (route.name !== 'ThreadScreen') {
+          return false;
+        }
+        const routeParams = route.params as StackNavigatorParamList['ThreadScreen'] | undefined;
+        const routeThreadId =
+          (routeParams?.thread as LocalMessage)?.id ??
+          (routeParams?.thread as ThreadType)?.thread?.id;
+        const routeChannelId = routeParams?.channel?.id;
+        return routeThreadId === parentMessage.id && routeChannelId === channel.id;
+      });
+
+      if (hasThreadInStack) {
+        navigation.popTo('ThreadScreen', params);
+        return;
+      }
+
+      navigation.navigate('ThreadScreen', params);
     },
     [channel, navigation, setThread],
   );

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 
 import {
+  AlsoSentToChannelHeaderPressPayload,
   Channel,
   MessageActionsParams,
   Thread,
@@ -73,7 +74,7 @@ const ThreadHeader: React.FC<ThreadHeaderProps> = ({ thread }) => {
 export const ThreadScreen: React.FC<ThreadScreenProps> = ({
   navigation,
   route: {
-    params: { channel, thread, targetedMessageId },
+    params: { channel, thread, targetedMessageId: targetedMessageIdFromParams },
   },
 }) => {
   const {
@@ -117,7 +118,7 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
   }, [setThread]);
 
   const onAlsoSentToChannelHeaderPress = useCallback(
-    ({ targetedMessageId }: { targetedMessageId: string }) => {
+    ({ targetedMessageId }: AlsoSentToChannelHeaderPressPayload) => {
       navigation.navigate('ChannelScreen', { channel, messageId: targetedMessageId });
     },
     [channel, navigation],
@@ -138,7 +139,7 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
         thread={thread}
         threadList
         onAlsoSentToChannelHeaderPress={onAlsoSentToChannelHeaderPress}
-        messageId={targetedMessageId}
+        messageId={targetedMessageIdFromParams}
       >
         <ThreadHeader thread={thread} />
         <Thread

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -116,7 +116,7 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
     setThread(null);
   }, [setThread]);
 
-  const onBackPressThread = useCallback(
+  const onAlsoSentToChannelHeaderPress = useCallback(
     (messageId?: string) => {
       navigation.popTo('ChannelScreen', { messageId: messageId });
     },
@@ -137,7 +137,7 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
         onPressMessage={onPressMessage}
         thread={thread}
         threadList
-        onBackPressThread={onBackPressThread}
+        onAlsoSentToChannelHeaderPress={onAlsoSentToChannelHeaderPress}
         messageId={targetedMessageId}
       >
         <ThreadHeader thread={thread} />

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -117,10 +117,10 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
   }, [setThread]);
 
   const onAlsoSentToChannelHeaderPress = useCallback(
-    (messageId?: string) => {
-      navigation.popTo('ChannelScreen', { messageId: messageId });
+    ({ targetedMessageId }: { targetedMessageId: string }) => {
+      navigation.navigate('ChannelScreen', { channel, messageId: targetedMessageId });
     },
-    [navigation],
+    [channel, navigation],
   );
 
   return (

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -119,7 +119,27 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
 
   const onAlsoSentToChannelHeaderPress = useCallback(
     ({ targetedMessageId }: AlsoSentToChannelHeaderPressPayload) => {
-      navigation.navigate('ChannelScreen', { channel, messageId: targetedMessageId });
+      const params: StackNavigatorParamList['ChannelScreen'] = {
+        channel,
+        messageId: targetedMessageId,
+      };
+      const hasChannelInStack = navigation
+        .getState()
+        .routes.some((route) => {
+          if (route.name !== 'ChannelScreen') {
+            return false;
+          }
+          const routeParams = route.params as StackNavigatorParamList['ChannelScreen'] | undefined;
+          const routeChannelId = routeParams?.channel?.id ?? routeParams?.channelId;
+          return routeChannelId === channel.id;
+        });
+
+      if (hasChannelInStack) {
+        navigation.popTo('ChannelScreen', params);
+        return;
+      }
+
+      navigation.navigate('ChannelScreen', params);
     },
     [channel, navigation],
   );

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -410,7 +410,12 @@ export type ChannelPropsWithContext = Pick<ChannelContextValue, 'channel'> &
     >
   > &
   Partial<Pick<MessageContextValue, 'isMessageAIGenerated'>> &
-  Partial<Pick<ThreadContextValue, 'allowThreadMessagesInChannel' | 'onBackPressThread'>> & {
+  Partial<
+    Pick<
+      ThreadContextValue,
+      'allowThreadMessagesInChannel' | 'onAlsoSentToChannelHeaderPress'
+    >
+  > & {
     shouldSyncChannel: boolean;
     thread: ThreadType;
     /**
@@ -713,7 +718,7 @@ const ChannelWithContext = (props: PropsWithChildren<ChannelPropsWithContext>) =
     onLongPressMessage,
     onPressInMessage,
     onPressMessage,
-    onBackPressThread,
+    onAlsoSentToChannelHeaderPress,
     openPollCreationDialog,
     overrideOwnCapabilities,
     PollContent,
@@ -1997,7 +2002,7 @@ const ChannelWithContext = (props: PropsWithChildren<ChannelPropsWithContext>) =
 
   const threadContext = useCreateThreadContext({
     allowThreadMessagesInChannel,
-    onBackPressThread,
+    onAlsoSentToChannelHeaderPress,
     closeThread,
     loadMoreThread,
     openThread,

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -411,10 +411,7 @@ export type ChannelPropsWithContext = Pick<ChannelContextValue, 'channel'> &
   > &
   Partial<Pick<MessageContextValue, 'isMessageAIGenerated'>> &
   Partial<
-    Pick<
-      ThreadContextValue,
-      'allowThreadMessagesInChannel' | 'onAlsoSentToChannelHeaderPress'
-    >
+    Pick<ThreadContextValue, 'allowThreadMessagesInChannel' | 'onAlsoSentToChannelHeaderPress'>
   > & {
     shouldSyncChannel: boolean;
     thread: ThreadType;

--- a/package/src/components/Channel/hooks/useCreateThreadContext.ts
+++ b/package/src/components/Channel/hooks/useCreateThreadContext.ts
@@ -12,7 +12,7 @@ const selector = (nextValue: ThreadState) =>
 
 export const useCreateThreadContext = ({
   allowThreadMessagesInChannel,
-  onBackPressThread,
+  onAlsoSentToChannelHeaderPress,
   closeThread,
   loadMoreThread,
   openThread,
@@ -40,7 +40,7 @@ export const useCreateThreadContext = ({
 
   return {
     allowThreadMessagesInChannel,
-    onBackPressThread,
+    onAlsoSentToChannelHeaderPress,
     closeThread,
     loadMoreThread,
     openThread,

--- a/package/src/components/Message/MessageSimple/Headers/SentToChannelHeader.tsx
+++ b/package/src/components/Message/MessageSimple/Headers/SentToChannelHeader.tsx
@@ -100,7 +100,12 @@ export const SentToChannelHeader = (props: SentToChannelHeaderProps) => {
   }, [onAlsoSentToChannelHeaderPress]);
 
   return (
-    <MemoizedSentToChannelHeader onPress={handleOnPress} showViewText={showViewText} {...props} />
+    <MemoizedSentToChannelHeader
+      onPress={handleOnPress}
+      showViewText={showViewText}
+      threadList={threadList}
+      {...props}
+    />
   );
 };
 

--- a/package/src/components/Message/MessageSimple/Headers/SentToChannelHeader.tsx
+++ b/package/src/components/Message/MessageSimple/Headers/SentToChannelHeader.tsx
@@ -63,33 +63,41 @@ export type SentToChannelHeaderProps = Partial<SentToChannelHeaderPropsWithConte
 
 export const SentToChannelHeader = (props: SentToChannelHeaderProps) => {
   const { onAlsoSentToChannelHeaderPress } = useThreadContext();
-  const { threadList, channel, setTargetedMessage } = useChannelContext();
-  const { onThreadSelect, message } = useMessageContext();
+  const { channel, threadList } = useChannelContext();
+  const { message } = useMessageContext();
 
+  // TODO: V9: This should be handled by the channel/thread entirely. We should only fetch
+  //           if we don't have the message in state already.
   const handleOnPress = useStableCallback(async () => {
-    if (!threadList) {
-      return await channel
-        .getClient()
-        .search({ cid: channel.cid }, { id: message.parent_id })
-        .then(({ results }) => {
-          if (!results.length) {
-            return;
-          }
-          const targetMessage = formatMessage(results[0].message);
-          onThreadSelect?.(targetMessage, message.id);
-        })
-        .catch((error) => {
-          console.error('Error querying parent message:', error);
-        });
-    } else {
-      setTargetedMessage(message.id);
-      onAlsoSentToChannelHeaderPress?.(message.id);
+    if (threadList) {
+      onAlsoSentToChannelHeaderPress?.({ targetedMessageId: message.id });
+      return;
+    }
+
+    if (!message.parent_id) {
+      return;
+    }
+
+    try {
+      const { messages } = await channel.getMessagesById([message.parent_id]);
+      const parentThreadMessage = formatMessage(messages?.[0]);
+
+      if (!parentThreadMessage) {
+        return;
+      }
+
+      onAlsoSentToChannelHeaderPress?.({
+        parentMessage: formatMessage(parentThreadMessage),
+        targetedMessageId: message.id,
+      });
+    } catch (error) {
+      console.error('Error querying parent message:', error);
     }
   });
 
   const showViewText = useMemo(() => {
-    return !!((!threadList && onThreadSelect) || (threadList && onAlsoSentToChannelHeaderPress));
-  }, [threadList, onThreadSelect, onAlsoSentToChannelHeaderPress]);
+    return !!onAlsoSentToChannelHeaderPress;
+  }, [onAlsoSentToChannelHeaderPress]);
 
   return (
     <MemoizedSentToChannelHeader onPress={handleOnPress} showViewText={showViewText} {...props} />

--- a/package/src/components/Message/MessageSimple/Headers/SentToChannelHeader.tsx
+++ b/package/src/components/Message/MessageSimple/Headers/SentToChannelHeader.tsx
@@ -62,7 +62,7 @@ const MemoizedSentToChannelHeader = React.memo(
 export type SentToChannelHeaderProps = Partial<SentToChannelHeaderPropsWithContext>;
 
 export const SentToChannelHeader = (props: SentToChannelHeaderProps) => {
-  const { onBackPressThread } = useThreadContext();
+  const { onAlsoSentToChannelHeaderPress } = useThreadContext();
   const { threadList, channel, setTargetedMessage } = useChannelContext();
   const { onThreadSelect, message } = useMessageContext();
 
@@ -83,13 +83,13 @@ export const SentToChannelHeader = (props: SentToChannelHeaderProps) => {
         });
     } else {
       setTargetedMessage(message.id);
-      onBackPressThread?.(message.id);
+      onAlsoSentToChannelHeaderPress?.(message.id);
     }
   });
 
   const showViewText = useMemo(() => {
-    return !!((!threadList && onThreadSelect) || (threadList && onBackPressThread));
-  }, [threadList, onThreadSelect, onBackPressThread]);
+    return !!((!threadList && onThreadSelect) || (threadList && onAlsoSentToChannelHeaderPress));
+  }, [threadList, onThreadSelect, onAlsoSentToChannelHeaderPress]);
 
   return (
     <MemoizedSentToChannelHeader onPress={handleOnPress} showViewText={showViewText} {...props} />

--- a/package/src/contexts/threadContext/ThreadContext.tsx
+++ b/package/src/contexts/threadContext/ThreadContext.tsx
@@ -7,6 +7,10 @@ import { DEFAULT_BASE_CONTEXT_VALUE } from '../utils/defaultBaseContextValue';
 import { isTestEnvironment } from '../utils/isTestEnvironment';
 
 export type ThreadType = { thread: LocalMessage; threadInstance: Thread };
+export type AlsoSentToChannelHeaderPressPayload = {
+  parentMessage?: LocalMessage;
+  targetedMessageId: string;
+};
 
 export type ThreadContextValue = {
   allowThreadMessagesInChannel: boolean;
@@ -28,10 +32,10 @@ export type ThreadContextValue = {
   threadLoadingMoreRecent?: boolean;
   /**
    * Function to handle press on the "Also sent to channel" header action.
-   * @param messageId - The id of the message to target
+   * @param payload - Navigation payload with optional parent thread message and targeted message id
    * @returns void
    */
-  onAlsoSentToChannelHeaderPress?: (messageId?: string) => void;
+  onAlsoSentToChannelHeaderPress?: (payload: AlsoSentToChannelHeaderPressPayload) => void;
 };
 
 export const ThreadContext = React.createContext(DEFAULT_BASE_CONTEXT_VALUE as ThreadContextValue);

--- a/package/src/contexts/threadContext/ThreadContext.tsx
+++ b/package/src/contexts/threadContext/ThreadContext.tsx
@@ -27,11 +27,11 @@ export type ThreadContextValue = {
   threadLoadingMore?: boolean;
   threadLoadingMoreRecent?: boolean;
   /**
-   * Function to handle back press on thread
-   * @param messageId - The id of the message to go back to
+   * Function to handle press on the "Also sent to channel" header action.
+   * @param messageId - The id of the message to target
    * @returns void
    */
-  onBackPressThread?: (messageId?: string) => void;
+  onAlsoSentToChannelHeaderPress?: (messageId?: string) => void;
 };
 
 export const ThreadContext = React.createContext(DEFAULT_BASE_CONTEXT_VALUE as ThreadContextValue);


### PR DESCRIPTION
## 🎯 Goal

This PR improves the API for switching between thread and channel views when participating in navigation through a message that has also been sent to the channel (through the message header). 

As a note, as we improve the state of thread we should also seriously consider moving most of this logic there (i.e there is no reason to pass anything more than an `id` to the higher level components and they should know how to handle this on their own).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


