### PR TITLE
feat: inline unread separator and notification redesign

### DIFF
--- a/package/src/components/Message/MessageSimple/MessageWrapper.tsx
+++ b/package/src/components/Message/MessageSimple/MessageWrapper.tsx
@@ -136,7 +136,7 @@ export const MessageWrapper = React.memo((props: MessageWrapperProps) => {
       )}
       {showUnreadUnderlay && (
         <View style={styles.unreadUnderlayContainer}>
-          <InlineUnreadIndicator />
+          <InlineUnreadIndicator unreadCount={unread_messages} />
         </View>
       )}
     </View>

--- a/package/src/components/Message/MessageSimple/MessageWrapper.tsx
+++ b/package/src/components/Message/MessageSimple/MessageWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { StyleSheet, View } from 'react-native';
 
@@ -72,10 +72,11 @@ export const MessageWrapper = React.memo((props: MessageWrapperProps) => {
     useStateStore(channelUnreadStateStore.state, channelUnreadStateSelector);
   const {
     theme: {
-      messageList: { messageContainer, inlineDateSeparatorContainer },
+      messageList: { messageContainer },
       screenPadding,
     },
   } = useTheme();
+  const styles = useStyles();
   if (!channel || channel.disconnected) {
     return null;
   }
@@ -95,7 +96,7 @@ export const MessageWrapper = React.memo((props: MessageWrapperProps) => {
 
   const wrapMessageInTheme = client.userID === message.user?.id && !!myMessageTheme;
   const renderDateSeperator = dateSeparatorDate ? (
-    <View style={[styles.dateSeparatorContainer, inlineDateSeparatorContainer]}>
+    <View style={styles.dateSeparatorContainer}>
       <InlineDateSeparator date={dateSeparatorDate} />
     </View>
   ) : null;
@@ -133,13 +134,33 @@ export const MessageWrapper = React.memo((props: MessageWrapperProps) => {
           {renderMessage}
         </View>
       )}
-      {showUnreadUnderlay && <InlineUnreadIndicator />}
+      {showUnreadUnderlay && (
+        <View style={styles.unreadUnderlayContainer}>
+          <InlineUnreadIndicator />
+        </View>
+      )}
     </View>
   );
 });
 
-const styles = StyleSheet.create({
-  dateSeparatorContainer: {
-    paddingVertical: primitives.spacingXs,
-  },
-});
+const useStyles = () => {
+  const {
+    theme: {
+      messageList: { unreadUnderlayContainer, inlineDateSeparatorContainer },
+    },
+  } = useTheme();
+  return useMemo(
+    () =>
+      StyleSheet.create({
+        dateSeparatorContainer: {
+          paddingVertical: primitives.spacingXs,
+          ...inlineDateSeparatorContainer,
+        },
+        unreadUnderlayContainer: {
+          paddingVertical: primitives.spacingXs,
+          ...unreadUnderlayContainer,
+        },
+      }),
+    [unreadUnderlayContainer, inlineDateSeparatorContainer],
+  );
+};

--- a/package/src/components/MessageList/InlineUnreadIndicator.tsx
+++ b/package/src/components/MessageList/InlineUnreadIndicator.tsx
@@ -5,13 +5,20 @@ import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
 import { primitives } from '../../theme';
 
-export const InlineUnreadIndicator = () => {
+export type InlineUnreadIndicatorProps = {
+  unreadCount?: number;
+};
+
+export const InlineUnreadIndicator = (props: InlineUnreadIndicatorProps) => {
+  const { unreadCount } = props;
   const styles = useStyles();
   const { t } = useTranslationContext();
 
   return (
     <View accessibilityLabel='Inline unread indicator' style={styles.container}>
-      <Text style={styles.text}>{t('Unread Messages')}</Text>
+      <Text style={styles.text}>
+        {unreadCount ? t('{{count}} new messages', { count: unreadCount }) : t('Unread Messages')}
+      </Text>
     </View>
   );
 };

--- a/package/src/components/MessageList/InlineUnreadIndicator.tsx
+++ b/package/src/components/MessageList/InlineUnreadIndicator.tsx
@@ -1,38 +1,53 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
+import { primitives } from '../../theme';
 
 export const InlineUnreadIndicator = () => {
-  const {
-    theme: {
-      colors: { grey, light_gray },
-      messageList: {
-        inlineUnreadIndicator: { container, text },
-      },
-    },
-  } = useTheme();
+  const styles = useStyles();
   const { t } = useTranslationContext();
 
   return (
-    <View
-      accessibilityLabel='Inline unread indicator'
-      style={[styles.container, { backgroundColor: light_gray }, container]}
-    >
-      <Text style={[styles.text, { color: grey }, text]}>{t('Unread Messages')}</Text>
+    <View accessibilityLabel='Inline unread indicator' style={styles.container}>
+      <Text style={styles.text}>{t('Unread Messages')}</Text>
     </View>
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginTop: 2,
-    padding: 10,
-  },
-  text: {
-    fontSize: 12,
-  },
-});
+const useStyles = () => {
+  const {
+    theme: {
+      messageList: {
+        inlineUnreadIndicator: { container, text },
+      },
+      semantics,
+    },
+  } = useTheme();
+  return useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingVertical: primitives.spacingXs,
+          paddingHorizontal: primitives.spacingSm,
+          backgroundColor: semantics.backgroundCoreSurfaceSubtle,
+          borderTopWidth: 1,
+          borderTopColor: semantics.borderCoreSubtle,
+          borderBottomWidth: 1,
+          borderBottomColor: semantics.borderCoreSubtle,
+          ...container,
+        },
+        text: {
+          color: semantics.chatTextSystem,
+          fontSize: primitives.typographyFontSizeXs,
+          fontWeight: primitives.typographyFontWeightSemiBold,
+          lineHeight: primitives.typographyLineHeightTight,
+          ...text,
+        },
+      }),
+    [semantics, container, text],
+  );
+};

--- a/package/src/components/MessageList/MessageFlashList.tsx
+++ b/package/src/components/MessageList/MessageFlashList.tsx
@@ -1088,7 +1088,7 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
         layout={LinearTransition.duration(200)}
         style={[
           styles.scrollToBottomButtonContainer,
-          { bottom: messageInputFloating ? messageInputHeight : 16 },
+          { bottom: messageInputFloating ? messageInputHeight : primitives.spacingMd },
         ]}
       >
         <ScrollToBottomButton
@@ -1313,13 +1313,15 @@ const useStyles = () => {
           left: 0,
           position: 'absolute',
           right: 0,
-          top: primitives.spacingXs,
+          top: primitives.spacingMd,
           ...stickyHeaderContainer,
         },
         unreadMessagesNotificationContainer: {
-          alignSelf: 'center',
           position: 'absolute',
-          top: 8,
+          top: primitives.spacingMd,
+          left: 0,
+          right: 0,
+          alignItems: 'center',
           ...unreadMessagesNotificationContainer,
         },
       }),

--- a/package/src/components/MessageList/MessageFlashList.tsx
+++ b/package/src/components/MessageList/MessageFlashList.tsx
@@ -53,6 +53,7 @@ import { mergeThemes, useTheme } from '../../contexts/themeContext/ThemeContext'
 import { ThreadContextValue, useThreadContext } from '../../contexts/threadContext/ThreadContext';
 
 import { useStableCallback, useStateStore } from '../../hooks';
+import { ChannelUnreadStateStoreType } from '../../state-store/channel-unread-state';
 import { MessageInputHeightState } from '../../state-store/message-input-height-store';
 import { primitives } from '../../theme';
 import { MessageWrapper } from '../Message/MessageSimple/MessageWrapper';
@@ -102,6 +103,10 @@ const getPreviousLastMessage = (messages: LocalMessage[], newMessage?: MessageRe
 
 const messageInputHeightStoreSelector = (state: MessageInputHeightState) => ({
   height: state.height,
+});
+
+const channelUnreadStateStoreSelector = (state: ChannelUnreadStateStoreType) => ({
+  unread_messages: state.channelUnreadState?.unread_messages,
 });
 
 type MessageFlashListPropsWithContext = Pick<
@@ -315,6 +320,11 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
   const { height: messageInputHeight } = useStateStore(
     messageInputHeightStore.store,
     messageInputHeightStoreSelector,
+  );
+
+  const { unread_messages } = useStateStore(
+    channelUnreadStateStore.state,
+    channelUnreadStateStoreSelector,
   );
 
   const [hasMoved, setHasMoved] = useState(false);
@@ -1094,13 +1104,16 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
         <ScrollToBottomButton
           onPress={goToNewMessages}
           showNotification={scrollToBottomButtonVisible}
-          unreadCount={threadList ? 0 : channel?.countUnread()}
+          unreadCount={threadList ? 0 : unread_messages}
         />
       </Animated.View>
       <NetworkDownIndicator />
       {isUnreadNotificationOpen && !threadList ? (
         <View style={styles.unreadMessagesNotificationContainer}>
-          <UnreadMessagesNotification onCloseHandler={onUnreadNotificationClose} />
+          <UnreadMessagesNotification
+            onCloseHandler={onUnreadNotificationClose}
+            unreadCount={unread_messages}
+          />
         </View>
       ) : null}
     </View>

--- a/package/src/components/MessageList/MessageFlashList.tsx
+++ b/package/src/components/MessageList/MessageFlashList.tsx
@@ -53,7 +53,6 @@ import { mergeThemes, useTheme } from '../../contexts/themeContext/ThemeContext'
 import { ThreadContextValue, useThreadContext } from '../../contexts/threadContext/ThreadContext';
 
 import { useStableCallback, useStateStore } from '../../hooks';
-import { ChannelUnreadStateStoreType } from '../../state-store/channel-unread-state';
 import { MessageInputHeightState } from '../../state-store/message-input-height-store';
 import { primitives } from '../../theme';
 import { MessageWrapper } from '../Message/MessageSimple/MessageWrapper';
@@ -103,10 +102,6 @@ const getPreviousLastMessage = (messages: LocalMessage[], newMessage?: MessageRe
 
 const messageInputHeightStoreSelector = (state: MessageInputHeightState) => ({
   height: state.height,
-});
-
-const channelUnreadStateStoreSelector = (state: ChannelUnreadStateStoreType) => ({
-  unread_messages: state.channelUnreadState?.unread_messages,
 });
 
 type MessageFlashListPropsWithContext = Pick<
@@ -320,11 +315,6 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
   const { height: messageInputHeight } = useStateStore(
     messageInputHeightStore.store,
     messageInputHeightStoreSelector,
-  );
-
-  const { unread_messages } = useStateStore(
-    channelUnreadStateStore.state,
-    channelUnreadStateStoreSelector,
   );
 
   const [hasMoved, setHasMoved] = useState(false);
@@ -1104,7 +1094,7 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
         <ScrollToBottomButton
           onPress={goToNewMessages}
           showNotification={scrollToBottomButtonVisible}
-          unreadCount={threadList ? 0 : unread_messages}
+          unreadCount={threadList ? 0 : channel?.countUnread()}
         />
       </Animated.View>
       <NetworkDownIndicator />
@@ -1112,7 +1102,7 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
         <View style={styles.unreadMessagesNotificationContainer}>
           <UnreadMessagesNotification
             onCloseHandler={onUnreadNotificationClose}
-            unreadCount={unread_messages}
+            channelUnreadStateStore={channelUnreadStateStore}
           />
         </View>
       ) : null}

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -66,6 +66,7 @@ import { ThreadContextValue, useThreadContext } from '../../contexts/threadConte
 import { useStableCallback } from '../../hooks';
 import { useStateStore } from '../../hooks/useStateStore';
 import { bumpOverlayLayoutRevision } from '../../state-store';
+import { ChannelUnreadStateStoreType } from '../../state-store/channel-unread-state';
 import { MessageInputHeightState } from '../../state-store/message-input-height-store';
 import { primitives } from '../../theme';
 import { MessageWrapper } from '../Message/MessageSimple/MessageWrapper';
@@ -304,6 +305,10 @@ const messageInputHeightStoreSelector = (state: MessageInputHeightState) => ({
   height: state.height,
 });
 
+const channelUnreadStateStoreSelector = (state: ChannelUnreadStateStoreType) => ({
+  unread_messages: state.channelUnreadState?.unread_messages,
+});
+
 /**
  * The message list component renders a list of messages. It consumes the following contexts:
  *
@@ -374,6 +379,10 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
   const { height: messageInputHeight } = useStateStore(
     messageInputHeightStore.store,
     messageInputHeightStoreSelector,
+  );
+  const { unread_messages } = useStateStore(
+    channelUnreadStateStore.state,
+    channelUnreadStateStoreSelector,
   );
 
   const myMessageThemeString = useMemo(() => JSON.stringify(myMessageTheme), [myMessageTheme]);
@@ -1319,7 +1328,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
           <ScrollToBottomButton
             onPress={goToNewMessages}
             showNotification={scrollToBottomButtonVisible}
-            unreadCount={threadList ? 0 : channel?.countUnread()}
+            unreadCount={threadList ? 0 : unread_messages}
           />
         </Animated.View>
       ) : null}
@@ -1327,7 +1336,10 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
       <NetworkDownIndicator />
       {isUnreadNotificationOpen && !threadList ? (
         <View style={styles.unreadMessagesNotificationContainer}>
-          <UnreadMessagesNotification onCloseHandler={onUnreadNotificationClose} />
+          <UnreadMessagesNotification
+            onCloseHandler={onUnreadNotificationClose}
+            unreadCount={unread_messages}
+          />
         </View>
       ) : null}
     </View>

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -126,13 +126,15 @@ const useStyles = () => {
           left: 0,
           position: 'absolute',
           right: 0,
-          top: primitives.spacingXs,
+          top: primitives.spacingMd,
           ...stickyHeaderContainer,
         },
         unreadMessagesNotificationContainer: {
-          alignSelf: 'center',
           position: 'absolute',
-          top: 8,
+          top: primitives.spacingMd,
+          left: 0,
+          right: 0,
+          alignItems: 'center',
           ...unreadMessagesNotificationContainer,
         },
       }),
@@ -1310,7 +1312,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
         <Animated.View
           layout={LinearTransition.duration(200)}
           style={[
-            { bottom: messageInputFloating ? messageInputHeight : 16 },
+            { bottom: messageInputFloating ? messageInputHeight : primitives.spacingMd },
             styles.scrollToBottomButtonContainer,
           ]}
         >

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -66,7 +66,6 @@ import { ThreadContextValue, useThreadContext } from '../../contexts/threadConte
 import { useStableCallback } from '../../hooks';
 import { useStateStore } from '../../hooks/useStateStore';
 import { bumpOverlayLayoutRevision } from '../../state-store';
-import { ChannelUnreadStateStoreType } from '../../state-store/channel-unread-state';
 import { MessageInputHeightState } from '../../state-store/message-input-height-store';
 import { primitives } from '../../theme';
 import { MessageWrapper } from '../Message/MessageSimple/MessageWrapper';
@@ -305,10 +304,6 @@ const messageInputHeightStoreSelector = (state: MessageInputHeightState) => ({
   height: state.height,
 });
 
-const channelUnreadStateStoreSelector = (state: ChannelUnreadStateStoreType) => ({
-  unread_messages: state.channelUnreadState?.unread_messages,
-});
-
 /**
  * The message list component renders a list of messages. It consumes the following contexts:
  *
@@ -379,10 +374,6 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
   const { height: messageInputHeight } = useStateStore(
     messageInputHeightStore.store,
     messageInputHeightStoreSelector,
-  );
-  const { unread_messages } = useStateStore(
-    channelUnreadStateStore.state,
-    channelUnreadStateStoreSelector,
   );
 
   const myMessageThemeString = useMemo(() => JSON.stringify(myMessageTheme), [myMessageTheme]);
@@ -1328,7 +1319,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
           <ScrollToBottomButton
             onPress={goToNewMessages}
             showNotification={scrollToBottomButtonVisible}
-            unreadCount={threadList ? 0 : unread_messages}
+            unreadCount={threadList ? 0 : channel?.countUnread()}
           />
         </Animated.View>
       ) : null}
@@ -1338,7 +1329,7 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
         <View style={styles.unreadMessagesNotificationContainer}>
           <UnreadMessagesNotification
             onCloseHandler={onUnreadNotificationClose}
-            unreadCount={unread_messages}
+            channelUnreadStateStore={channelUnreadStateStore}
           />
         </View>
       ) : null}

--- a/package/src/components/MessageList/UnreadMessagesNotification.tsx
+++ b/package/src/components/MessageList/UnreadMessagesNotification.tsx
@@ -18,10 +18,14 @@ export type UnreadMessagesNotificationProps = {
    * Callback to handle the press event
    */
   onPressHandler?: () => Promise<void>;
+  /**
+   * Unread count
+   */
+  unreadCount?: number;
 };
 
 export const UnreadMessagesNotification = (props: UnreadMessagesNotificationProps) => {
-  const { onCloseHandler, onPressHandler } = props;
+  const { onCloseHandler, onPressHandler, unreadCount } = props;
   const { t } = useTranslationContext();
   const {
     channelUnreadStateStore,
@@ -60,7 +64,7 @@ export const UnreadMessagesNotification = (props: UnreadMessagesNotificationProp
           variant='secondary'
           type='ghost'
           LeadingIcon={ArrowUp}
-          label={t('Unread Messages')}
+          label={unreadCount ? t('{{count}} unread', { count: unreadCount }) : t('Unread Messages')}
           onPress={handleOnPress}
           size='md'
         />

--- a/package/src/components/MessageList/UnreadMessagesNotification.tsx
+++ b/package/src/components/MessageList/UnreadMessagesNotification.tsx
@@ -1,15 +1,23 @@
 import React, { useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import { useChannelContext } from '../../contexts/channelContext/ChannelContext';
+import {
+  ChannelContextValue,
+  useChannelContext,
+} from '../../contexts/channelContext/ChannelContext';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
+import { useStateStore } from '../../hooks/useStateStore';
 import { ArrowUp } from '../../icons/ArrowUp';
 import { NewClose } from '../../icons/NewClose';
+import { ChannelUnreadStateStoreType } from '../../state-store/channel-unread-state';
 import { primitives } from '../../theme';
 import { Button } from '../ui';
 
-export type UnreadMessagesNotificationProps = {
+export type UnreadMessagesNotificationProps = Pick<
+  ChannelContextValue,
+  'channelUnreadStateStore'
+> & {
   /**
    * Callback to handle the close event
    */
@@ -24,16 +32,21 @@ export type UnreadMessagesNotificationProps = {
   unreadCount?: number;
 };
 
+const channelUnreadStateSelector = (state: ChannelUnreadStateStoreType) => ({
+  unread_messages: state.channelUnreadState?.unread_messages,
+});
+
 export const UnreadMessagesNotification = (props: UnreadMessagesNotificationProps) => {
-  const { onCloseHandler, onPressHandler, unreadCount } = props;
+  const { onCloseHandler, onPressHandler, unreadCount, channelUnreadStateStore } = props;
   const { t } = useTranslationContext();
-  const {
-    channelUnreadStateStore,
-    loadChannelAtFirstUnreadMessage,
-    markRead,
-    setChannelUnreadState,
-    setTargetedMessage,
-  } = useChannelContext();
+  const { loadChannelAtFirstUnreadMessage, markRead, setChannelUnreadState, setTargetedMessage } =
+    useChannelContext();
+  const { unread_messages } = useStateStore(
+    channelUnreadStateStore.state,
+    channelUnreadStateSelector,
+  );
+
+  const count = unread_messages ?? unreadCount;
 
   const handleOnPress = async () => {
     if (onPressHandler) {
@@ -64,7 +77,7 @@ export const UnreadMessagesNotification = (props: UnreadMessagesNotificationProp
           variant='secondary'
           type='ghost'
           LeadingIcon={ArrowUp}
-          label={unreadCount ? t('{{count}} unread', { count: unreadCount }) : t('Unread Messages')}
+          label={count ? t('{{count}} unread', { count }) : t('Unread Messages')}
           onPress={handleOnPress}
           size='md'
         />

--- a/package/src/components/MessageList/UnreadMessagesNotification.tsx
+++ b/package/src/components/MessageList/UnreadMessagesNotification.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
-import { Pressable, StyleSheet, Text } from 'react-native';
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
 
 import { useChannelContext } from '../../contexts/channelContext/ChannelContext';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
+import { ArrowUp } from '../../icons/ArrowUp';
 import { NewClose } from '../../icons/NewClose';
+import { primitives } from '../../theme';
+import { Button } from '../ui';
 
 export type UnreadMessagesNotificationProps = {
   /**
@@ -48,57 +51,67 @@ export const UnreadMessagesNotification = (props: UnreadMessagesNotificationProp
     }
   };
 
-  const {
-    theme: {
-      colors: { text_low_emphasis, white_snow },
-      messageList: {
-        unreadMessagesNotification: { closeButtonContainer, closeIcon, container, text },
-      },
-    },
-  } = useTheme();
+  const styles = useStyles();
 
   return (
-    <Pressable
-      onPress={handleOnPress}
-      style={({ pressed }) => [
-        styles.container,
-        { backgroundColor: text_low_emphasis, opacity: pressed ? 0.8 : 1 },
-        container,
-      ]}
-    >
-      <Text style={[styles.text, { color: white_snow }, text]}>{t('Unread Messages')}</Text>
-      <Pressable
-        onPress={handleClose}
-        style={({ pressed }) => [
-          {
-            opacity: pressed ? 0.8 : 1,
-          },
-          closeButtonContainer,
-        ]}
-      >
-        <NewClose pathFill={white_snow} {...closeIcon} />
-      </Pressable>
-    </Pressable>
+    <View style={styles.container}>
+      <View style={styles.leftButtonContainer}>
+        <Button
+          variant='secondary'
+          type='ghost'
+          LeadingIcon={ArrowUp}
+          label={t('Unread Messages')}
+          onPress={handleOnPress}
+          size='md'
+        />
+      </View>
+      <View style={styles.rightButtonContainer}>
+        <Button
+          variant='secondary'
+          type='ghost'
+          iconOnly
+          LeadingIcon={NewClose}
+          onPress={handleClose}
+          size='md'
+        />
+      </View>
+    </View>
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    borderRadius: 20,
-    elevation: 4,
-    flexDirection: 'row',
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    shadowColor: '#000',
-    shadowOffset: {
-      height: 2,
-      width: 0,
+const useStyles = () => {
+  const {
+    theme: {
+      messageList: {
+        unreadMessagesNotification: { container, leftButtonContainer, rightButtonContainer },
+      },
+      semantics,
     },
-    shadowOpacity: 0.23,
-    shadowRadius: 2.62,
-  },
-  text: {
-    fontWeight: '500',
-    marginRight: 8,
-  },
-});
+  } = useTheme();
+  return useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          borderRadius: primitives.radiusMax,
+          borderWidth: 1,
+          borderColor: semantics.borderCoreDefault,
+          backgroundColor: semantics.backgroundCoreApp,
+          flexDirection: 'row',
+          alignItems: 'center',
+          ...primitives.lightElevation4,
+          ...container,
+        },
+        leftButtonContainer: {
+          flexShrink: 0,
+          borderRightWidth: 1,
+          borderRightColor: semantics.borderCoreDefault,
+          ...leftButtonContainer,
+        },
+        rightButtonContainer: {
+          flexShrink: 0,
+          ...rightButtonContainer,
+        },
+      }),
+    [semantics, container, leftButtonContainer, rightButtonContainer],
+  );
+};

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -1035,12 +1035,9 @@ exports[`Thread should match thread snapshot 1`] = `
               >
                 <View
                   style={
-                    [
-                      {
-                        "paddingVertical": 8,
-                      },
-                      {},
-                    ]
+                    {
+                      "paddingVertical": 8,
+                    }
                   }
                 >
                   <View
@@ -1834,7 +1831,7 @@ exports[`Thread should match thread snapshot 1`] = `
             "left": 0,
             "position": "absolute",
             "right": 0,
-            "top": 8,
+            "top": 16,
           }
         }
       />

--- a/package/src/contexts/messagesContext/MessagesContext.tsx
+++ b/package/src/contexts/messagesContext/MessagesContext.tsx
@@ -12,7 +12,11 @@ import type {
   MessageResponse,
 } from 'stream-chat';
 
-import type { PollContentProps, StreamingMessageViewProps } from '../../components';
+import type {
+  InlineUnreadIndicatorProps,
+  PollContentProps,
+  StreamingMessageViewProps,
+} from '../../components';
 import type { AttachmentProps } from '../../components/Attachment/Attachment';
 import type { AudioAttachmentProps } from '../../components/Attachment/Audio';
 import type { FileAttachmentProps } from '../../components/Attachment/FileAttachment';
@@ -181,7 +185,7 @@ export type MessagesContextValue = Pick<MessageContextValue, 'isMessageAIGenerat
    * UI component for InlineUnreadIndicator
    * Defaults to: [InlineUnreadIndicator](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/MessageList/InlineUnreadIndicator.tsx)
    **/
-  InlineUnreadIndicator: React.ComponentType;
+  InlineUnreadIndicator: React.ComponentType<InlineUnreadIndicatorProps>;
 
   Message: React.ComponentType<MessageProps>;
   /**

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -488,6 +488,7 @@ export type Theme = {
     listContainer: ViewStyle;
     messageContainer: ViewStyle;
     inlineDateSeparatorContainer: ViewStyle;
+    unreadUnderlayContainer: ViewStyle;
     messageSystem: {
       container: ViewStyle;
       dateText: TextStyle;
@@ -505,10 +506,9 @@ export type Theme = {
     typingIndicatorContainer: ViewStyle;
     unreadMessagesNotificationContainer: ViewStyle;
     unreadMessagesNotification: {
-      closeButtonContainer: ViewStyle;
-      closeIcon: IconProps;
       container: ViewStyle;
-      text: TextStyle;
+      leftButtonContainer: ViewStyle;
+      rightButtonContainer: ViewStyle;
     };
   };
   messageMenu: {
@@ -1383,6 +1383,7 @@ export const defaultTheme: Theme = {
     listContainer: {},
     messageContainer: {},
     inlineDateSeparatorContainer: {},
+    unreadUnderlayContainer: {},
     messageSystem: {
       container: {},
       dateText: {},
@@ -1399,10 +1400,9 @@ export const defaultTheme: Theme = {
     stickyHeaderContainer: {},
     typingIndicatorContainer: {},
     unreadMessagesNotification: {
-      closeButtonContainer: {},
-      closeIcon: {},
       container: {},
-      text: {},
+      leftButtonContainer: {},
+      rightButtonContainer: {},
     },
     unreadMessagesNotificationContainer: {},
   },

--- a/package/src/i18n/en.json
+++ b/package/src/i18n/en.json
@@ -200,5 +200,7 @@
   "Unmute Group": "Unmute Group",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}} member, {{onlineCount}} online",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} members, {{onlineCount}} online",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} members, {{onlineCount}} online"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} members, {{onlineCount}} online",
+  "{{count}} unread": "{{count}} unread",
+  "{{count}} new messages": "{{count}} new messages"
 }

--- a/package/src/i18n/es.json
+++ b/package/src/i18n/es.json
@@ -200,5 +200,7 @@
   "Unmute Group": "Activar sonido del grupo",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}} miembro, {{onlineCount}} en línea",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} miembros, {{onlineCount}} en línea",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} miembros, {{onlineCount}} en línea"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} miembros, {{onlineCount}} en línea",
+  "{{count}} unread": "{{count}} no leídos",
+  "{{count}} new messages": "{{count}} nuevos mensajes"
 }

--- a/package/src/i18n/fr.json
+++ b/package/src/i18n/fr.json
@@ -200,5 +200,7 @@
   "Unmute Group": "Rétablir le son du groupe",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}} membre, {{onlineCount}} en ligne",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} membres, {{onlineCount}} en ligne",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} membres, {{onlineCount}} en ligne"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} membres, {{onlineCount}} en ligne",
+  "{{count}} unread": "{{count}} non lus",
+  "{{count}} new messages": "{{count}} nouveaux messages"
 }

--- a/package/src/i18n/he.json
+++ b/package/src/i18n/he.json
@@ -200,5 +200,7 @@
   "Unmute Group": "בטל/י השתקת קבוצה",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}} חבר/ה, {{onlineCount}} מחוברים",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} חברים, {{onlineCount}} מחוברים",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} חברים, {{onlineCount}} מחוברים"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} חברים, {{onlineCount}} מחוברים",
+  "{{count}} unread": "{{count}} שטרם נקרא",
+  "{{count}} new messages": "{{count}} הודעות חדשות"
 }

--- a/package/src/i18n/hi.json
+++ b/package/src/i18n/hi.json
@@ -200,5 +200,7 @@
   "Unmute Group": "ग्रुप अनम्यूट करें",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}} सदस्य, {{onlineCount}} ऑनलाइन",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} सदस्य, {{onlineCount}} ऑनलाइन",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} सदस्य, {{onlineCount}} ऑनलाइन"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} सदस्य, {{onlineCount}} ऑनलाइन",
+  "{{count}} unread": "{{count}} ना पढ़े हुए",
+  "{{count}} new messages": "{{count}} नये संदेश"
 }

--- a/package/src/i18n/it.json
+++ b/package/src/i18n/it.json
@@ -200,5 +200,7 @@
   "Unmute Group": "Riattiva audio gruppo",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}} membro, {{onlineCount}} online",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} membri, {{onlineCount}} online",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} membri, {{onlineCount}} online"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} membri, {{onlineCount}} online",
+  "{{count}} unread": "{{count}} non letti",
+  "{{count}} new messages": "{{count}} nuovi messaggi"
 }

--- a/package/src/i18n/ja.json
+++ b/package/src/i18n/ja.json
@@ -200,5 +200,7 @@
   "Unmute Group": "グループのミュートを解除",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}}人のメンバー、{{onlineCount}}人がオンライン",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}}人のメンバー、{{onlineCount}}人がオンライン",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}}人のメンバー、{{onlineCount}}人がオンライン"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}}人のメンバー、{{onlineCount}}人がオンライン",
+  "{{count}} unread": "{{count}} 未読",
+  "{{count}} new messages": "{{count}} 新しいメッセージ"
 }

--- a/package/src/i18n/ko.json
+++ b/package/src/i18n/ko.json
@@ -200,5 +200,7 @@
   "Unmute Group": "그룹 음소거 해제",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}}명, {{onlineCount}}명 온라인",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}}명, {{onlineCount}}명 온라인",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}}명, {{onlineCount}}명 온라인"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}}명, {{onlineCount}}명 온라인",
+  "{{count}} unread": "{{count}} 읽지 않은",
+  "{{count}} new messages": "{{count}} 새로운 메시지"
 }

--- a/package/src/i18n/nl.json
+++ b/package/src/i18n/nl.json
@@ -200,5 +200,7 @@
   "Unmute Group": "Dempen van groep opheffen",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}} lid, {{onlineCount}} online",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} leden, {{onlineCount}} online",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} leden, {{onlineCount}} online"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} leden, {{onlineCount}} online",
+  "{{count}} unread": "{{count}} ongelezen",
+  "{{count}} new messages": "{{count}} nieuwe berichten"
 }

--- a/package/src/i18n/pt-br.json
+++ b/package/src/i18n/pt-br.json
@@ -200,5 +200,7 @@
   "Unmute Group": "Remover grupo do modo silencioso",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}} membro, {{onlineCount}} online",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} membros, {{onlineCount}} online",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} membros, {{onlineCount}} online"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} membros, {{onlineCount}} online",
+  "{{count}} unread": "{{count}} não lidas",
+  "{{count}} new messages": "{{count}} novas mensagens"
 }

--- a/package/src/i18n/ru.json
+++ b/package/src/i18n/ru.json
@@ -200,5 +200,7 @@
   "Unmute Group": "Включить группу",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}} участник, {{onlineCount}} онлайн",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} участника, {{onlineCount}} онлайн",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} участников, {{onlineCount}} онлайн"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} участников, {{onlineCount}} онлайн",
+  "{{count}} unread": "{{count}} непрочитанных",
+  "{{count}} new messages": "{{count}} новых сообщений"
 }

--- a/package/src/i18n/tr.json
+++ b/package/src/i18n/tr.json
@@ -200,5 +200,7 @@
   "Unmute Group": "Grubun sesini ac",
   "{{memberCount}} members, {{onlineCount}} online_one": "{{memberCount}} üye, {{onlineCount}} çevrimiçi",
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} üye, {{onlineCount}} çevrimiçi",
-  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} üye, {{onlineCount}} çevrimiçi"
+  "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} üye, {{onlineCount}} çevrimiçi",
+  "{{count}} unread": "{{count}} okunmamış",
+  "{{count}} new messages": "{{count}} yeni mesaj"
 }

--- a/package/src/icons/ArrowUp.tsx
+++ b/package/src/icons/ArrowUp.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+import { IconProps } from './utils/base';
+
+export const ArrowUp = ({ height, width, ...rest }: IconProps) => (
+  <Svg height={height} viewBox='0 0 20 20' fill='none' width={width}>
+    <Path
+      d='M4.79175 8.33333L10.0001 3.125L15.2084 8.33333M10.0001 16.875V3.75'
+      strokeWidth={1.5}
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      {...rest}
+    />
+  </Svg>
+);


### PR DESCRIPTION
This pull request refactors how unread message indicators and notifications are rendered and styled in the message list components. The main improvements include passing the unread message count through context and props, updating the UI components to reflect this count, and centralizing style management using hooks for better theme integration. Additionally, the notification and indicator components are updated for accessibility and consistency, and the theme type definitions are expanded to support these changes.

**Unread Message Count Propagation and UI Updates:**

* The unread message count is now retrieved from `channelUnreadStateStore` and passed as a prop to `InlineUnreadIndicator`, `ScrollToBottomButton`, and `UnreadMessagesNotification` components, ensuring accurate display of unread counts throughout the UI. [[1]](diffhunk://#diff-3b7bfa0a9867d1a6f4f9a15481eb9d0c1e0a32405f11bce200833e72574bb34bR325-R329) [[2]](diffhunk://#diff-3b7bfa0a9867d1a6f4f9a15481eb9d0c1e0a32405f11bce200833e72574bb34bL1091-R1116) [[3]](diffhunk://#diff-9bc51e90b151dbcd57ae1bc8a631e07b1ae80368242e21faabe531aa69491383R383-R386) [[4]](diffhunk://#diff-9bc51e90b151dbcd57ae1bc8a631e07b1ae80368242e21faabe531aa69491383L1313-R1342) [[5]](diffhunk://#diff-bb93e2dff67e858cbc4fc88d377ca116dd6c2e9d93a4b541c913624e922aebdeR21-R28)

* The `InlineUnreadIndicator` and `UnreadMessagesNotification` components are refactored to accept an `unreadCount` prop and display the count in their labels, improving clarity for users. [[1]](diffhunk://#diff-26441faecc6015ab86531f335c6de26990d4a388f99a382e01668a27da0fcf8fL1-R60) [[2]](diffhunk://#diff-26441faecc6015ab86531f335c6de26990d4a388f99a382e01668a27da0fcf8fL1-R60) [[3]](diffhunk://#diff-bb93e2dff67e858cbc4fc88d377ca116dd6c2e9d93a4b541c913624e922aebdeR21-R28) [[4]](diffhunk://#diff-bb93e2dff67e858cbc4fc88d377ca116dd6c2e9d93a4b541c913624e922aebdeL51-R121)

**Styling and Theme Integration:**

* Styles for unread indicators and notifications are moved into `useStyles` hooks, leveraging `useTheme` and `useMemo` for dynamic theming and performance. This centralizes style logic and ensures consistent theming. [[1]](diffhunk://#diff-ba3f2a9cdd7263bc1150d03cc1be8b765eeb08bf8b3a8c224251cdddf0053444L136-R166) [[2]](diffhunk://#diff-26441faecc6015ab86531f335c6de26990d4a388f99a382e01668a27da0fcf8fL1-R60) [[3]](diffhunk://#diff-bb93e2dff67e858cbc4fc88d377ca116dd6c2e9d93a4b541c913624e922aebdeL51-R121)

* Theme type definitions are updated to include new style properties for unread indicators and notifications, such as `unreadUnderlayContainer`, `leftButtonContainer`, and `rightButtonContainer`, supporting greater customization. [[1]](diffhunk://#diff-e46a40a3ae96cc581b658a86cdfd3699dce9449204a7bb586b774369e5ab583cR491) [[2]](diffhunk://#diff-e46a40a3ae96cc581b658a86cdfd3699dce9449204a7bb586b774369e5ab583cL508-R511)

**Layout and Accessibility Improvements:**

* Layout adjustments are made to the message list and notification containers for better alignment and spacing, including consistent use of theme primitives and improved accessibility labeling. [[1]](diffhunk://#diff-3b7bfa0a9867d1a6f4f9a15481eb9d0c1e0a32405f11bce200833e72574bb34bL1316-R1337) [[2]](diffhunk://#diff-9bc51e90b151dbcd57ae1bc8a631e07b1ae80368242e21faabe531aa69491383L129-R138) [[3]](diffhunk://#diff-0a18f457fa158009da6dace44242bb3a526c6f1c1bbf61384be0ad0c3c53324cL1837-R1834)

**Type and Context Changes:**

* Component type signatures are updated to reflect new props, and context values are extended to support the new indicator props, improving type safety and clarity across the codebase. [[1]](diffhunk://#diff-327d7452e29943b63019b2b135e4c012a8fcd51a85fa38ec099c55db0d9d2cfeL15-R19) [[2]](diffhunk://#diff-327d7452e29943b63019b2b135e4c012a8fcd51a85fa38ec099c55db0d9d2cfeL184-R188)

**Snapshot and Test Updates:**

* Component snapshots are updated to reflect the new layout and style changes, ensuring tests match the refactored UI. [[1]](diffhunk://#diff-0a18f457fa158009da6dace44242bb3a526c6f1c1bbf61384be0ad0c3c53324cL1038-R1040) [[2]](diffhunk://#diff-0a18f457fa158009da6dace44242bb3a526c6f1c1bbf61384be0ad0c3c53324cL1837-R1834)