### PR TITLE
feat: custom context menu background

### DIFF
--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { DevSettings, LogBox, Platform, useColorScheme } from 'react-native';
+import { DevSettings, LogBox, Platform, StyleSheet, useColorScheme, View } from 'react-native';
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { BlurView } from '@react-native-community/blur';
 import {
   Chat,
   createTextComposerEmojiMiddleware,
@@ -14,7 +15,9 @@ import {
   Streami18n,
   ThemeProvider,
   useOverlayContext,
+  useTheme,
 } from 'stream-chat-react-native';
+import type { MessageOverlayBackgroundProps } from 'stream-chat-react-native';
 
 import { getMessaging } from '@react-native-firebase/messaging';
 import notifee, { EventType } from '@notifee/react-native';
@@ -95,6 +98,35 @@ notifee.onBackgroundEvent(async ({ detail, type }) => {
 const Drawer = createDrawerNavigator();
 const Stack = createNativeStackNavigator<StackNavigatorParamList>();
 const UserSelectorStack = createNativeStackNavigator<UserSelectorParamList>();
+
+const MessageOverlayBlurBackground = ({ style }: MessageOverlayBackgroundProps) => {
+  const {
+    theme: { semantics },
+  } = useTheme();
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const isIOS = Platform.OS === 'ios';
+
+  return (
+    <>
+      <BlurView
+        blurAmount={isIOS ? 10 : 6}
+        blurType={isDark ? 'dark' : 'light'}
+        blurRadius={isIOS ? undefined : 6}
+        downsampleFactor={isIOS ? undefined : 12}
+        pointerEvents='none'
+        reducedTransparencyFallbackColor='rgba(0, 0, 0, 0.8)'
+        style={[styles.messageOverlayBlurBackground, style]}
+      />
+      <View
+        style={[
+          styles.messageOverlayBlurBackground,
+          { backgroundColor: semantics.backgroundCoreScrim },
+        ]}
+      />
+    </>
+  );
+};
 
 const App = () => {
   const { chatClient, isConnecting, loginUser, logout, switchUser } = useChatClient();
@@ -198,7 +230,7 @@ const App = () => {
         },
         linkPreviews: {
           enabled: true,
-        }
+        },
       });
 
       setupCommandUIMiddlewares(composer);
@@ -226,7 +258,11 @@ const App = () => {
       }}
     >
       <GestureHandlerRootView style={{ flex: 1 }}>
-        <OverlayProvider value={{ style: streamChatTheme }} i18nInstance={streami18n}>
+        <OverlayProvider
+          MessageOverlayBackground={MessageOverlayBlurBackground}
+          value={{ style: streamChatTheme }}
+          i18nInstance={streami18n}
+        >
           <ThemeProvider style={streamChatTheme}>
             <NavigationContainer
               ref={RootNavigationRef}
@@ -416,3 +452,9 @@ const HomeScreen = () => {
 };
 
 export default App;
+
+const styles = StyleSheet.create({
+  messageOverlayBlurBackground: {
+    ...StyleSheet.absoluteFillObject,
+  },
+});

--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -17,7 +17,6 @@ import {
   useOverlayContext,
   useTheme,
 } from 'stream-chat-react-native';
-import type { MessageOverlayBackgroundProps } from 'stream-chat-react-native';
 
 import { getMessaging } from '@react-native-firebase/messaging';
 import notifee, { EventType } from '@notifee/react-native';
@@ -99,7 +98,7 @@ const Drawer = createDrawerNavigator();
 const Stack = createNativeStackNavigator<StackNavigatorParamList>();
 const UserSelectorStack = createNativeStackNavigator<UserSelectorParamList>();
 
-const MessageOverlayBlurBackground = ({ style }: MessageOverlayBackgroundProps) => {
+const MessageOverlayBlurBackground = () => {
   const {
     theme: { semantics },
   } = useTheme();
@@ -116,7 +115,7 @@ const MessageOverlayBlurBackground = ({ style }: MessageOverlayBackgroundProps) 
         downsampleFactor={isIOS ? undefined : 12}
         pointerEvents='none'
         reducedTransparencyFallbackColor='rgba(0, 0, 0, 0.8)'
-        style={[styles.messageOverlayBlurBackground, style]}
+        style={styles.messageOverlayBlurBackground}
       />
       <View
         style={[

--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -63,6 +63,7 @@ import { useClientNotificationsToastHandler } from './src/hooks/useClientNotific
 import AsyncStore from './src/utils/AsyncStore.ts';
 import {
   MessageInputFloatingConfigItem,
+  MessageOverlayBackdropConfigItem,
   MessageListImplementationConfigItem,
   MessageListModeConfigItem,
   MessageListPruningConfigItem,
@@ -141,6 +142,9 @@ const App = () => {
   const [messageInputFloating, setMessageInputFloating] = useState<
     MessageInputFloatingConfigItem['value'] | undefined
   >(undefined);
+  const [messageOverlayBackdrop, setMessageOverlayBackdrop] = useState<
+    MessageOverlayBackdropConfigItem['value'] | undefined
+  >(undefined);
   const colorScheme = useColorScheme();
   const streamChatTheme = useStreamChatTheme();
   const streami18n = new Streami18n();
@@ -200,6 +204,10 @@ const App = () => {
         '@stream-rn-sampleapp-messageinput-floating',
         { value: false },
       );
+      const messageOverlayBackdropStoredValue = await AsyncStore.getItem(
+        '@stream-rn-sampleapp-message-overlay-backdrop',
+        { value: 'default' },
+      );
       setMessageListImplementation(
         messageListImplementationStoredValue?.id as MessageListImplementationConfigItem['id'],
       );
@@ -209,6 +217,9 @@ const App = () => {
       );
       setMessageInputFloating(
         messageInputFloatingStoredValue?.value as MessageInputFloatingConfigItem['value'],
+      );
+      setMessageOverlayBackdrop(
+        messageOverlayBackdropStoredValue?.value as MessageOverlayBackdropConfigItem['value'],
       );
     };
     getMessageListConfig();
@@ -258,7 +269,9 @@ const App = () => {
     >
       <GestureHandlerRootView style={{ flex: 1 }}>
         <OverlayProvider
-          MessageOverlayBackground={MessageOverlayBlurBackground}
+          MessageOverlayBackground={
+            messageOverlayBackdrop === 'blurview' ? MessageOverlayBlurBackground : undefined
+          }
           value={{ style: streamChatTheme }}
           i18nInstance={streami18n}
         >

--- a/examples/SampleApp/package.json
+++ b/examples/SampleApp/package.json
@@ -35,6 +35,7 @@
     "@react-native-clipboard/clipboard": "^1.16.3",
     "@react-native-community/geolocation": "^3.4.0",
     "@react-native-community/netinfo": "^11.4.1",
+    "@react-native-community/blur": "^4.4.1",
     "@react-native-documents/picker": "^10.1.3",
     "@react-native-firebase/app": "22.2.1",
     "@react-native-firebase/messaging": "22.2.1",

--- a/examples/SampleApp/src/components/ScreenHeader.tsx
+++ b/examples/SampleApp/src/components/ScreenHeader.tsx
@@ -64,15 +64,17 @@ export const BackButton: React.FC<{
   return (
     <TouchableOpacity
       onPress={() => {
+        if (onBack) {
+          onBack();
+          return;
+        }
+
         if (!navigation.canGoBack()) {
           // if no previous screen was present in history, go to the list screen
           // this can happen when opened through push notification
           navigation.reset({ index: 0, routes: [{ name: 'HomeScreen' }] });
         } else {
           navigation.goBack();
-        }
-        if (onBack) {
-          onBack();
         }
       }}
       style={styles.backButton}

--- a/examples/SampleApp/src/components/SecretMenu.tsx
+++ b/examples/SampleApp/src/components/SecretMenu.tsx
@@ -29,6 +29,10 @@ export type MessageListImplementationConfigItem = { label: string; id: 'flatlist
 export type MessageListModeConfigItem = { label: string; mode: 'default' | 'livestream' };
 export type MessageListPruningConfigItem = { label: string; value: 100 | 500 | 1000 | undefined };
 export type MessageInputFloatingConfigItem = { label: string; value: boolean };
+export type MessageOverlayBackdropConfigItem = {
+  label: string;
+  value: 'default' | 'blurview';
+};
 
 const messageListImplementationConfigItems: MessageListImplementationConfigItem[] = [
   { label: 'FlatList', id: 'flatlist' },
@@ -50,6 +54,11 @@ const messageListPruningConfigItems: MessageListPruningConfigItem[] = [
 const messageInputFloatingConfigItems: MessageInputFloatingConfigItem[] = [
   { label: 'Normal', value: false },
   { label: 'Floating', value: true },
+];
+
+const messageOverlayBackdropConfigItems: MessageOverlayBackdropConfigItem[] = [
+  { label: 'Default', value: 'default' },
+  { label: 'BlurView', value: 'blurview' },
 ];
 
 export const SlideInView = ({
@@ -220,6 +229,23 @@ const SecretMenuMessageListPruningConfigItem = ({
   </TouchableOpacity>
 );
 
+const SecretMenuMessageOverlayBackdropConfigItem = ({
+  isSelected,
+  messageOverlayBackdropConfigItem,
+  storeMessageOverlayBackdrop,
+}: {
+  isSelected: boolean;
+  messageOverlayBackdropConfigItem: MessageOverlayBackdropConfigItem;
+  storeMessageOverlayBackdrop: (item: MessageOverlayBackdropConfigItem) => void;
+}) => (
+  <TouchableOpacity
+    style={[styles.notificationItemContainer, { borderColor: isSelected ? 'green' : 'gray' }]}
+    onPress={() => storeMessageOverlayBackdrop(messageOverlayBackdropConfigItem)}
+  >
+    <Text style={styles.notificationItem}>{messageOverlayBackdropConfigItem.label}</Text>
+  </TouchableOpacity>
+);
+
 /*
  * TODO: Please rewrite this entire component.
  */
@@ -245,6 +271,9 @@ export const SecretMenu = ({
   >(null);
   const [selectedMessageInputFloating, setSelectedMessageInputFloating] =
     useState<MessageInputFloatingConfigItem['value']>(false);
+  const [selectedMessageOverlayBackdrop, setSelectedMessageOverlayBackdrop] = useState<
+    MessageOverlayBackdropConfigItem['value'] | null
+  >(null);
   const {
     theme: {
       colors: { black, grey },
@@ -281,6 +310,10 @@ export const SecretMenu = ({
         '@stream-rn-sampleapp-messageinput-floating',
         messageInputFloatingConfigItems[0],
       );
+      const messageOverlayBackdrop = await AsyncStore.getItem(
+        '@stream-rn-sampleapp-message-overlay-backdrop',
+        messageOverlayBackdropConfigItems[0],
+      );
       setSelectedProvider(notificationProvider?.id ?? notificationConfigItems[0].id);
       setSelectedMessageListImplementation(
         messageListImplementation?.id ?? messageListImplementationConfigItems[0].id,
@@ -289,6 +322,9 @@ export const SecretMenu = ({
       setSelectedMessageListPruning(messageListPruning?.value);
       setSelectedMessageInputFloating(
         messageInputFloating?.value ?? messageInputFloatingConfigItems[0].value,
+      );
+      setSelectedMessageOverlayBackdrop(
+        messageOverlayBackdrop?.value ?? messageOverlayBackdropConfigItems[0].value,
       );
     };
     getSelectedConfig();
@@ -321,6 +357,14 @@ export const SecretMenu = ({
     await AsyncStore.setItem('@stream-rn-sampleapp-messageinput-floating', item);
     setSelectedMessageInputFloating(item.value);
   }, []);
+
+  const storeMessageOverlayBackdrop = useCallback(
+    async (item: MessageOverlayBackdropConfigItem) => {
+      await AsyncStore.setItem('@stream-rn-sampleapp-message-overlay-backdrop', item);
+      setSelectedMessageOverlayBackdrop(item.value);
+    },
+    [],
+  );
 
   const removeAllDevices = useCallback(async () => {
     const { devices } = await chatClient.getDevices(chatClient.userID);
@@ -385,6 +429,22 @@ export const SecretMenu = ({
                   messageInputFloatingConfigItem={item}
                   storeMessageInputFloating={storeMessageInputFloating}
                   isSelected={item.value === selectedMessageInputFloating}
+                />
+              ))}
+            </View>
+          </View>
+        </View>
+        <View style={[menuDrawerStyles.menuItem, { alignItems: 'flex-start' }]}>
+          <Folder height={20} pathFill={grey} width={20} />
+          <View>
+            <Text style={[menuDrawerStyles.menuTitle]}>Message Overlay Backdrop</Text>
+            <View style={{ marginLeft: 16 }}>
+              {messageOverlayBackdropConfigItems.map((item) => (
+                <SecretMenuMessageOverlayBackdropConfigItem
+                  key={item.value}
+                  isSelected={item.value === selectedMessageOverlayBackdrop}
+                  messageOverlayBackdropConfigItem={item}
+                  storeMessageOverlayBackdrop={storeMessageOverlayBackdrop}
                 />
               ))}
             </View>

--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -2199,6 +2199,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.16.3.tgz#7807a90fd9984bf4d3a96faf2eee20457984a9bd"
   integrity sha512-cMIcvoZKIrShzJHEaHbTAp458R9WOv0fB6UyC7Ek4Qk561Ow/DrzmmJmH/rAZg21Z6ixJ4YSdFDC14crqIBmCQ==
 
+"@react-native-community/blur@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/blur/-/blur-4.4.1.tgz#72cbc0be5a84022c33091683ec6888925ebcca6e"
+  integrity sha512-XBSsRiYxE/MOEln2ayunShfJtWztHwUxLFcSL20o+HNNRnuUDv+GXkF6FmM2zE8ZUfrnhQ/zeTqvnuDPGw6O8A==
+
 "@react-native-community/cli-clean@19.1.2":
   version "19.1.2"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-19.1.2.tgz#10be56a6ab966c141090176e54937cb7b7618a9b"

--- a/package/src/components/Message/MessageSimple/Headers/MessagePinnedHeader.tsx
+++ b/package/src/components/Message/MessageSimple/Headers/MessagePinnedHeader.tsx
@@ -10,6 +10,7 @@ import { useTheme } from '../../../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../../../contexts/translationContext/TranslationContext';
 import { Pin } from '../../../../icons/Pin';
 import { primitives } from '../../../../theme';
+import { useShouldUseOverlayStyles } from '../../hooks/useShouldUseOverlayStyles';
 
 export type MessagePinnedHeaderProps = Partial<Pick<MessageContextValue, 'message'>>;
 
@@ -17,9 +18,6 @@ export const MessagePinnedHeader = (props: MessagePinnedHeaderProps) => {
   const { message: propMessage } = props;
   const { message: contextMessage } = useMessageContext();
   const message = propMessage || contextMessage;
-  const {
-    theme: { semantics },
-  } = useTheme();
   const styles = useStyles();
   const { t } = useTranslationContext();
   const { client } = useChatContext();
@@ -30,7 +28,7 @@ export const MessagePinnedHeader = (props: MessagePinnedHeaderProps) => {
 
   return (
     <View accessibilityLabel='Message Pinned Header' style={styles.container}>
-      <Pin height={16} width={16} stroke={semantics.textPrimary} />
+      <Pin height={16} width={16} stroke={styles.label.color} />
       <Text style={styles.label}>
         {t('Pinned by')}{' '}
         {message?.pinned_by?.id === client?.user?.id ? t('You') : message?.pinned_by?.name}
@@ -48,6 +46,7 @@ const useStyles = () => {
       },
     },
   } = useTheme();
+  const shouldUseOverlayStyles = useShouldUseOverlayStyles();
 
   return useMemo(() => {
     return StyleSheet.create({
@@ -59,12 +58,12 @@ const useStyles = () => {
         ...container,
       },
       label: {
-        color: semantics.textPrimary,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.textPrimary,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightTight,
         ...label,
       },
     });
-  }, [semantics, container, label]);
+  }, [shouldUseOverlayStyles, semantics, container, label]);
 };

--- a/package/src/components/Message/MessageSimple/Headers/MessageReminderHeader.tsx
+++ b/package/src/components/Message/MessageSimple/Headers/MessageReminderHeader.tsx
@@ -11,6 +11,7 @@ import { useMessageReminder } from '../../../../hooks/useMessageReminder';
 import { useStateStore } from '../../../../hooks/useStateStore';
 import { Bell } from '../../../../icons';
 import { primitives } from '../../../../theme';
+import { useShouldUseOverlayStyles } from '../../hooks/useShouldUseOverlayStyles';
 
 const reminderStateSelector = (state: ReminderState) => ({
   timeLeftMs: state.timeLeftMs,
@@ -23,15 +24,12 @@ type MessageReminderHeaderPropsWithContext = {
 
 const MessageReminderHeaderWithContext = (props: MessageReminderHeaderPropsWithContext) => {
   const { timeLeftMs, isReminderTimeLeft } = props;
-  const {
-    theme: { semantics },
-  } = useTheme();
   const { t } = useTranslationContext();
   const styles = useStyles();
 
   return (
     <View accessibilityLabel='Message Saved For Later Header' style={styles.container}>
-      <Bell height={16} width={16} stroke={semantics.textPrimary} />
+      <Bell height={16} width={16} stroke={styles.time.color} />
       <Text style={styles.label}>
         {isReminderTimeLeft ? t('Reminder set') : t('Reminder overdue')}
       </Text>
@@ -72,6 +70,7 @@ const useStyles = () => {
       },
     },
   } = useTheme();
+  const shouldUseOverlayStyles = useShouldUseOverlayStyles();
 
   return useMemo(() => {
     return StyleSheet.create({
@@ -83,26 +82,26 @@ const useStyles = () => {
         ...container,
       },
       label: {
-        color: semantics.textPrimary,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.textPrimary,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightTight,
         ...label,
       },
       dot: {
-        color: semantics.textPrimary,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.textPrimary,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightTight,
         ...dot,
       },
       time: {
-        color: semantics.textPrimary,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.textPrimary,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightTight,
         ...time,
       },
     });
-  }, [container, semantics, label, dot, time]);
+  }, [shouldUseOverlayStyles, container, semantics, label, dot, time]);
 };

--- a/package/src/components/Message/MessageSimple/Headers/MessageSavedForLaterHeader.tsx
+++ b/package/src/components/Message/MessageSimple/Headers/MessageSavedForLaterHeader.tsx
@@ -6,19 +6,17 @@ import { useTheme } from '../../../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../../../contexts/translationContext/TranslationContext';
 import { Bookmark } from '../../../../icons/Bookmark';
 import { primitives } from '../../../../theme';
+import { useShouldUseOverlayStyles } from '../../hooks/useShouldUseOverlayStyles';
 
 export type MessageSavedForLaterHeaderProps = Partial<Pick<MessageContextValue, 'message'>>;
 
 export const MessageSavedForLaterHeader = () => {
-  const {
-    theme: { semantics },
-  } = useTheme();
   const styles = useStyles();
   const { t } = useTranslationContext();
 
   return (
     <View accessibilityLabel='Message Saved For Later Header' style={styles.container}>
-      <Bookmark height={16} width={16} stroke={semantics.accentPrimary} />
+      <Bookmark height={16} width={16} stroke={styles.label.color} />
       <Text style={styles.label}>{t('Saved For Later')}</Text>
     </View>
   );
@@ -33,6 +31,7 @@ const useStyles = () => {
       },
     },
   } = useTheme();
+  const shouldUseOverlayStyles = useShouldUseOverlayStyles();
 
   return useMemo(() => {
     return StyleSheet.create({
@@ -44,12 +43,12 @@ const useStyles = () => {
         ...container,
       },
       label: {
-        color: semantics.accentPrimary,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.accentPrimary,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightTight,
         ...label,
       },
     });
-  }, [semantics, container, label]);
+  }, [shouldUseOverlayStyles, semantics, container, label]);
 };

--- a/package/src/components/Message/MessageSimple/Headers/SentToChannelHeader.tsx
+++ b/package/src/components/Message/MessageSimple/Headers/SentToChannelHeader.tsx
@@ -15,6 +15,7 @@ import { useTranslationContext } from '../../../../contexts/translationContext/T
 import { useStableCallback } from '../../../../hooks';
 import { ArrowUpRight } from '../../../../icons/ArrowUpRight';
 import { primitives } from '../../../../theme';
+import { useShouldUseOverlayStyles } from '../../hooks/useShouldUseOverlayStyles';
 
 type SentToChannelHeaderPropsWithContext = Pick<ChannelContextValue, 'threadList'> & {
   /**
@@ -31,15 +32,12 @@ type SentToChannelHeaderPropsWithContext = Pick<ChannelContextValue, 'threadList
 
 const SentToChannelHeaderWithContext = (props: SentToChannelHeaderPropsWithContext) => {
   const { threadList, onPress, showViewText } = props;
-  const {
-    theme: { semantics },
-  } = useTheme();
   const { t } = useTranslationContext();
   const styles = useStyles();
 
   return (
     <View accessibilityLabel='Message Saved For Later Header' style={styles.container}>
-      <ArrowUpRight height={16} width={16} stroke={semantics.textPrimary} />
+      <ArrowUpRight height={16} width={16} stroke={styles.link.color} />
       <Text style={styles.label}>
         {threadList ? t('Also sent in channel') : t('Replied to a thread')}
       </Text>
@@ -118,6 +116,7 @@ const useStyles = () => {
       },
     },
   } = useTheme();
+  const shouldUseOverlayStyles = useShouldUseOverlayStyles();
 
   return useMemo(() => {
     return StyleSheet.create({
@@ -129,26 +128,28 @@ const useStyles = () => {
         ...container,
       },
       label: {
-        color: semantics.textPrimary,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.textPrimary,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightTight,
         ...label,
       },
       dot: {
-        color: semantics.textPrimary,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.textPrimary,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightTight,
         ...dot,
       },
       link: {
-        color: semantics.accentPrimary,
+        color: shouldUseOverlayStyles
+          ? semantics.buttonPrimaryTextOnAccent
+          : semantics.accentPrimary,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightTight,
         ...link,
       },
     });
-  }, [container, semantics, label, dot, link]);
+  }, [shouldUseOverlayStyles, container, semantics, label, dot, link]);
 };

--- a/package/src/components/Message/MessageSimple/MessageFooter.tsx
+++ b/package/src/components/Message/MessageSimple/MessageFooter.tsx
@@ -21,6 +21,7 @@ import { useTranslationContext } from '../../../contexts/translationContext/Tran
 
 import { primitives } from '../../../theme';
 import { isEditedMessage, MessageStatusTypes } from '../../../utils/utils';
+import { useShouldUseOverlayStyles } from '../hooks/useShouldUseOverlayStyles';
 
 type MessageFooterComponentProps = {
   date?: string | Date;
@@ -196,6 +197,7 @@ const useStyles = () => {
   const {
     theme: { semantics },
   } = useTheme();
+  const shouldUseOverlayStyles = useShouldUseOverlayStyles();
   return useMemo(() => {
     return StyleSheet.create({
       container: {
@@ -206,17 +208,22 @@ const useStyles = () => {
         gap: primitives.spacingXs,
       },
       name: {
-        color: semantics.chatTextUsername,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.chatTextUsername,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightTight,
       },
       editedText: {
-        color: semantics.chatTextTimestamp,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.chatTextTimestamp,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightTight,
       },
     });
-  }, [semantics]);
+  }, [
+    shouldUseOverlayStyles,
+    semantics.chatTextTimestamp,
+    semantics.chatTextUsername,
+    semantics.textOnAccent,
+  ]);
 };

--- a/package/src/components/Message/MessageSimple/MessageReplies.tsx
+++ b/package/src/components/Message/MessageSimple/MessageReplies.tsx
@@ -17,6 +17,7 @@ import {
 import { ReplyConnectorLeft } from '../../../icons/ReplyConnectorLeft';
 import { ReplyConnectorRight } from '../../../icons/ReplyConnectorRight';
 import { primitives } from '../../../theme';
+import { useShouldUseOverlayStyles } from '../hooks/useShouldUseOverlayStyles';
 
 export type MessageRepliesPropsWithContext = Pick<
   MessageContextValue,
@@ -206,6 +207,7 @@ const useStyles = () => {
   const {
     theme: { semantics },
   } = useTheme();
+  const shouldUseOverlayStyles = useShouldUseOverlayStyles();
   return useMemo(() => {
     return StyleSheet.create({
       container: {
@@ -223,11 +225,11 @@ const useStyles = () => {
         paddingBottom: primitives.spacingXxs,
       },
       messageRepliesText: {
-        color: semantics.textPrimary,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.textPrimary,
         fontSize: primitives.typographyFontSizeSm,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightTight,
       },
     });
-  }, [semantics]);
+  }, [shouldUseOverlayStyles, semantics]);
 };

--- a/package/src/components/Message/MessageSimple/MessageStatus.tsx
+++ b/package/src/components/Message/MessageSimple/MessageStatus.tsx
@@ -16,6 +16,7 @@ import { CheckAll } from '../../../icons/CheckAll';
 import { Time } from '../../../icons/Time';
 import { primitives } from '../../../theme';
 import { MessageStatusTypes } from '../../../utils/utils';
+import { useShouldUseOverlayStyles } from '../hooks/useShouldUseOverlayStyles';
 
 export type MessageStatusPropsWithContext = Pick<
   MessageContextValue,
@@ -179,11 +180,12 @@ const useStyles = () => {
   const {
     theme: { semantics },
   } = useTheme();
+  const shouldUseOverlayStyles = useShouldUseOverlayStyles();
 
   return useMemo(() => {
     return StyleSheet.create({
       readByCount: {
-        color: semantics.accentPrimary,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.accentPrimary,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightTight,
@@ -194,5 +196,5 @@ const useStyles = () => {
         gap: primitives.spacingXxs,
       },
     });
-  }, [semantics]);
+  }, [shouldUseOverlayStyles, semantics]);
 };

--- a/package/src/components/Message/MessageSimple/MessageTimestamp.tsx
+++ b/package/src/components/Message/MessageSimple/MessageTimestamp.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../contexts/translationContext/TranslationContext';
 import { primitives } from '../../../theme';
 import { getDateString } from '../../../utils/i18n/getDateString';
+import { useShouldUseOverlayStyles } from '../hooks/useShouldUseOverlayStyles';
 
 export type MessageTimestampProps = Partial<Pick<TranslationContextValue, 'tDateTimeParser'>> & {
   /**
@@ -66,15 +67,17 @@ const useStyles = () => {
       },
     },
   } = useTheme();
+  const shouldUseOverlayStyles = useShouldUseOverlayStyles();
+
   return useMemo(() => {
     return StyleSheet.create({
       text: {
-        color: semantics.chatTextTimestamp,
+        color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.chatTextTimestamp,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightTight,
         ...timestampText,
       },
     });
-  }, [semantics, timestampText]);
+  }, [shouldUseOverlayStyles, semantics, timestampText]);
 };

--- a/package/src/components/Message/hooks/useShouldUseOverlayStyles.ts
+++ b/package/src/components/Message/hooks/useShouldUseOverlayStyles.ts
@@ -3,7 +3,7 @@ import { useIsOverlayActive } from '../../../state-store';
 
 export const useShouldUseOverlayStyles = () => {
   const { message } = useMessageContext();
-  const { active, closing } = useIsOverlayActive(message.id);
+  const { active, closing } = useIsOverlayActive(message?.id);
 
   return active && !closing;
 };

--- a/package/src/components/Message/hooks/useShouldUseOverlayStyles.ts
+++ b/package/src/components/Message/hooks/useShouldUseOverlayStyles.ts
@@ -1,0 +1,9 @@
+import { useMessageContext } from '../../../contexts';
+import { useIsOverlayActive } from '../../../state-store';
+
+export const useShouldUseOverlayStyles = () => {
+  const { message } = useMessageContext();
+  const { active, closing } = useIsOverlayActive(message.id);
+
+  return active && !closing;
+};

--- a/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.js.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.js.snap
@@ -814,16 +814,6 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
                 },
               ],
             },
-            {
-              "overflow": "visible",
-              "shadowColor": "white",
-              "shadowOffset": {
-                "height": 4,
-                "width": 0,
-              },
-              "shadowOpacity": 0.4,
-              "shadowRadius": 10,
-            },
           ]
         }
       >
@@ -885,16 +875,6 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
                   "translateY": 0,
                 },
               ],
-            },
-            {
-              "overflow": "visible",
-              "shadowColor": "white",
-              "shadowOffset": {
-                "height": 4,
-                "width": 0,
-              },
-              "shadowOpacity": 0.4,
-              "shadowRadius": 10,
             },
           ]
         }
@@ -1731,16 +1711,6 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
                 },
               ],
             },
-            {
-              "overflow": "visible",
-              "shadowColor": "white",
-              "shadowOffset": {
-                "height": 4,
-                "width": 0,
-              },
-              "shadowOpacity": 0.4,
-              "shadowRadius": 10,
-            },
           ]
         }
       >
@@ -1802,16 +1772,6 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
                   "translateY": 0,
                 },
               ],
-            },
-            {
-              "overflow": "visible",
-              "shadowColor": "white",
-              "shadowOffset": {
-                "height": 4,
-                "width": 0,
-              },
-              "shadowOpacity": 0.4,
-              "shadowRadius": 10,
             },
           ]
         }
@@ -2648,16 +2608,6 @@ exports[`AttachButton should render an disabled AttachButton 1`] = `
                 },
               ],
             },
-            {
-              "overflow": "visible",
-              "shadowColor": "white",
-              "shadowOffset": {
-                "height": 4,
-                "width": 0,
-              },
-              "shadowOpacity": 0.4,
-              "shadowRadius": 10,
-            },
           ]
         }
       >
@@ -2719,16 +2669,6 @@ exports[`AttachButton should render an disabled AttachButton 1`] = `
                   "translateY": 0,
                 },
               ],
-            },
-            {
-              "overflow": "visible",
-              "shadowColor": "white",
-              "shadowOffset": {
-                "height": 4,
-                "width": 0,
-              },
-              "shadowOpacity": 0.4,
-              "shadowRadius": 10,
             },
           ]
         }

--- a/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.js.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.js.snap
@@ -812,16 +812,6 @@ exports[`SendButton should render a SendButton 1`] = `
                 },
               ],
             },
-            {
-              "overflow": "visible",
-              "shadowColor": "white",
-              "shadowOffset": {
-                "height": 4,
-                "width": 0,
-              },
-              "shadowOpacity": 0.4,
-              "shadowRadius": 10,
-            },
           ]
         }
       >
@@ -883,16 +873,6 @@ exports[`SendButton should render a SendButton 1`] = `
                   "translateY": 0,
                 },
               ],
-            },
-            {
-              "overflow": "visible",
-              "shadowColor": "white",
-              "shadowOffset": {
-                "height": 4,
-                "width": 0,
-              },
-              "shadowOpacity": 0.4,
-              "shadowRadius": 10,
             },
           ]
         }
@@ -1727,16 +1707,6 @@ exports[`SendButton should render a disabled SendButton 1`] = `
                 },
               ],
             },
-            {
-              "overflow": "visible",
-              "shadowColor": "white",
-              "shadowOffset": {
-                "height": 4,
-                "width": 0,
-              },
-              "shadowOpacity": 0.4,
-              "shadowRadius": 10,
-            },
           ]
         }
       >
@@ -1798,16 +1768,6 @@ exports[`SendButton should render a disabled SendButton 1`] = `
                   "translateY": 0,
                 },
               ],
-            },
-            {
-              "overflow": "visible",
-              "shadowColor": "white",
-              "shadowOffset": {
-                "height": 4,
-                "width": 0,
-              },
-              "shadowOpacity": 0.4,
-              "shadowRadius": 10,
             },
           ]
         }

--- a/package/src/components/MessageMenu/MessageReactionPicker.tsx
+++ b/package/src/components/MessageMenu/MessageReactionPicker.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, useColorScheme, View } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 
 import { EmojiPickerList } from './EmojiPickerList';
@@ -58,6 +58,7 @@ export const MessageReactionPickerList = ({
       },
     },
   } = useTheme();
+  const styles = useStyles();
 
   const reactions: ReactionPickerItemType[] = useMemo(
     () =>
@@ -87,6 +88,7 @@ export const EmojiViewerButton = ({
 }: {
   onSelectReaction: (type: string) => void;
 }) => {
+  const styles = useStyles();
   const [emojiViewerOpened, setEmojiViewerOpened] = React.useState<boolean>(false);
 
   const {
@@ -146,12 +148,12 @@ export const MessageReactionPicker = (props: MessageReactionPickerProps) => {
   const { dismissOverlay, handleReaction } = props;
   const {
     theme: {
-      colors: { white },
       messageMenu: {
         reactionPicker: { container },
       },
     },
   } = useTheme();
+  const styles = useStyles();
   const own_capabilities = useOwnCapabilitiesContext();
 
   const onSelectReaction = useStableCallback((type: string) => {
@@ -169,7 +171,7 @@ export const MessageReactionPicker = (props: MessageReactionPickerProps) => {
   return (
     <View
       accessibilityLabel='Reaction Selector on long pressing message'
-      style={[styles.container, { backgroundColor: white }, container]}
+      style={[styles.container, container]}
     >
       <MessageReactionPickerList onSelectReaction={onSelectReaction} />
       <EmojiViewerButton onSelectReaction={onSelectReaction} />
@@ -177,24 +179,39 @@ export const MessageReactionPicker = (props: MessageReactionPickerProps) => {
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    alignSelf: 'stretch',
-    borderRadius: primitives.radius4xl,
-    marginVertical: 8,
-  },
-  reactionListContent: {
-    flexGrow: 1,
-    justifyContent: 'space-around',
-    gap: primitives.spacingXxxs,
-    paddingVertical: primitives.spacingXxs,
-    paddingLeft: primitives.spacingXxs,
-  },
-  emojiViewerButton: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingRight: primitives.spacingXs,
-    paddingLeft: primitives.spacingXs,
-  },
-});
+const useStyles = () => {
+  const {
+    theme: { semantics },
+  } = useTheme();
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+
+  return useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flexDirection: 'row',
+          alignSelf: 'stretch',
+          borderRadius: primitives.radius4xl,
+          marginVertical: 8,
+          overflow: 'visible',
+          ...(isDark ? primitives.darkElevation3 : primitives.lightElevation3),
+          backgroundColor: semantics.backgroundElevationElevation2,
+        },
+        reactionListContent: {
+          flexGrow: 1,
+          justifyContent: 'space-around',
+          gap: primitives.spacingXxxs,
+          paddingVertical: primitives.spacingXxs,
+          paddingLeft: primitives.spacingXxs,
+        },
+        emojiViewerButton: {
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingRight: primitives.spacingXs,
+          paddingLeft: primitives.spacingXs,
+        },
+      }),
+    [isDark, semantics.backgroundElevationElevation2],
+  );
+};

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useMemo } from 'react';
-import { Platform, Pressable, StyleSheet, useWindowDimensions, View } from 'react-native';
+import {
+  Platform,
+  Pressable,
+  StyleSheet,
+  useColorScheme,
+  useWindowDimensions,
+  View,
+} from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   clamp,
@@ -13,6 +20,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PortalHost } from 'react-native-teleport';
 
 import { ClosingPortalHostsLayer } from './ClosingPortalHostsLayer';
+import type { MessageOverlayBackgroundProps } from './OverlayContext';
 
 import {
   closeOverlay,
@@ -21,10 +29,35 @@ import {
   Rect,
   useOverlayController,
 } from '../../state-store';
+import { useTheme } from '../themeContext/ThemeContext';
 
 const DURATION = 300;
 
-export const MessageOverlayHostLayer = () => {
+const DefaultMessageOverlayBackground = ({ style }: MessageOverlayBackgroundProps) => {
+  const {
+    theme: { semantics },
+  } = useTheme();
+
+  return (
+    <View pointerEvents='none' style={[StyleSheet.absoluteFillObject, style]}>
+      <View
+        pointerEvents='none'
+        style={[
+          StyleSheet.absoluteFillObject,
+          {
+            backgroundColor: semantics.badgeBgOverlay,
+          },
+        ]}
+      />
+    </View>
+  );
+};
+
+type MessageOverlayHostLayerProps = {
+  BackgroundComponent?: React.ComponentType<MessageOverlayBackgroundProps>;
+};
+
+export const MessageOverlayHostLayer = ({ BackgroundComponent }: MessageOverlayHostLayerProps) => {
   const { id, closing } = useOverlayController();
   const insets = useSafeAreaInsets();
   const { height: screenH } = useWindowDimensions();
@@ -90,6 +123,8 @@ export const MessageOverlayHostLayer = () => {
   const backdropStyle = useAnimatedStyle(() => ({
     opacity: backdrop.value,
   }));
+
+  const OverlayBackground = BackgroundComponent ?? DefaultMessageOverlayBackground;
 
   const messageShiftY = useDerivedValue(() => {
     if (!messageH.value || !topH.value || !bottomH.value) return 0;
@@ -233,9 +268,11 @@ export const MessageOverlayHostLayer = () => {
       <View pointerEvents='box-none' style={StyleSheet.absoluteFill}>
         {isActive ? (
           <Animated.View
-            pointerEvents='box-none'
-            style={[StyleSheet.absoluteFillObject, { backgroundColor: '#000000CC' }, backdropStyle]}
-          />
+            pointerEvents='none'
+            style={[StyleSheet.absoluteFillObject, backdropStyle]}
+          >
+            <OverlayBackground overlayOpacity={backdrop} style={StyleSheet.absoluteFillObject} />
+          </Animated.View>
         ) : null}
 
         <View pointerEvents='box-none' style={StyleSheet.absoluteFill}>
@@ -243,7 +280,7 @@ export const MessageOverlayHostLayer = () => {
             <Pressable onPress={closeOverlay} style={StyleSheet.absoluteFillObject} />
           ) : null}
 
-          <Animated.View style={[topItemStyle, topItemTranslateStyle, styles.shadow3]}>
+          <Animated.View style={[topItemStyle, topItemTranslateStyle]}>
             <PortalHost name='top-item' style={StyleSheet.absoluteFillObject} />
           </Animated.View>
 
@@ -251,7 +288,7 @@ export const MessageOverlayHostLayer = () => {
             <PortalHost name='message-overlay' style={StyleSheet.absoluteFillObject} />
           </Animated.View>
 
-          <Animated.View style={[bottomItemStyle, bottomItemTranslateStyle, styles.shadow3]}>
+          <Animated.View style={[bottomItemStyle, bottomItemTranslateStyle]}>
             <PortalHost name='bottom-item' style={StyleSheet.absoluteFillObject} />
           </Animated.View>
         </View>
@@ -261,22 +298,3 @@ export const MessageOverlayHostLayer = () => {
     </GestureDetector>
   );
 };
-
-const styles = StyleSheet.create({
-  shadow3: {
-    overflow: 'visible',
-    ...Platform.select({
-      android: {
-        elevation: 3,
-        // helps on newer Android (API 28+) to tint elevation shadow
-        shadowColor: '#000000',
-      },
-      ios: {
-        shadowColor: 'white',
-        shadowOffset: { height: 4, width: 0 },
-        shadowOpacity: 0.4,
-        shadowRadius: 10,
-      },
-    }),
-  },
-});

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -1,11 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
-import {
-  Platform,
-  Pressable,
-  StyleSheet,
-  useWindowDimensions,
-  View,
-} from 'react-native';
+import { Platform, Pressable, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   clamp,

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -3,7 +3,6 @@ import {
   Platform,
   Pressable,
   StyleSheet,
-  useColorScheme,
   useWindowDimensions,
   View,
 } from 'react-native';
@@ -20,7 +19,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PortalHost } from 'react-native-teleport';
 
 import { ClosingPortalHostsLayer } from './ClosingPortalHostsLayer';
-import type { MessageOverlayBackgroundProps } from './OverlayContext';
 
 import {
   closeOverlay,
@@ -33,13 +31,13 @@ import { useTheme } from '../themeContext/ThemeContext';
 
 const DURATION = 300;
 
-const DefaultMessageOverlayBackground = ({ style }: MessageOverlayBackgroundProps) => {
+const DefaultMessageOverlayBackground = () => {
   const {
     theme: { semantics },
   } = useTheme();
 
   return (
-    <View pointerEvents='none' style={[StyleSheet.absoluteFillObject, style]}>
+    <View pointerEvents='none' style={StyleSheet.absoluteFillObject}>
       <View
         pointerEvents='none'
         style={[
@@ -54,7 +52,7 @@ const DefaultMessageOverlayBackground = ({ style }: MessageOverlayBackgroundProp
 };
 
 type MessageOverlayHostLayerProps = {
-  BackgroundComponent?: React.ComponentType<MessageOverlayBackgroundProps>;
+  BackgroundComponent?: React.ComponentType;
 };
 
 export const MessageOverlayHostLayer = ({ BackgroundComponent }: MessageOverlayHostLayerProps) => {
@@ -271,7 +269,7 @@ export const MessageOverlayHostLayer = ({ BackgroundComponent }: MessageOverlayH
             pointerEvents='none'
             style={[StyleSheet.absoluteFillObject, backdropStyle]}
           >
-            <OverlayBackground overlayOpacity={backdrop} style={StyleSheet.absoluteFillObject} />
+            <OverlayBackground />
           </Animated.View>
         ) : null}
 

--- a/package/src/contexts/overlayContext/OverlayContext.tsx
+++ b/package/src/contexts/overlayContext/OverlayContext.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 
-import { StyleProp, ViewStyle } from 'react-native';
 import { SharedValue } from 'react-native-reanimated';
 
 import type { Streami18n } from '../../utils/i18n/Streami18n';
@@ -12,10 +11,6 @@ import { DEFAULT_BASE_CONTEXT_VALUE } from '../utils/defaultBaseContextValue';
 import { isTestEnvironment } from '../utils/isTestEnvironment';
 
 export type Overlay = 'alert' | 'gallery' | 'none';
-export type MessageOverlayBackgroundProps = {
-  overlayOpacity: SharedValue<number>;
-  style?: StyleProp<ViewStyle>;
-};
 
 export type OverlayContextValue = {
   overlay: Overlay;
@@ -33,9 +28,8 @@ export type OverlayProviderProps = ImageGalleryProviderProps & {
   i18nInstance?: Streami18n;
   /**
    * Custom backdrop component rendered behind overlay content in `MessageOverlayHostLayer`.
-   * Receives a shared opacity value that should be used for its visibility animation.
    */
-  MessageOverlayBackground?: React.ComponentType<MessageOverlayBackgroundProps>;
+  MessageOverlayBackground?: React.ComponentType;
   value?: Partial<OverlayContextValue>;
 };
 

--- a/package/src/contexts/overlayContext/OverlayContext.tsx
+++ b/package/src/contexts/overlayContext/OverlayContext.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 
+import { StyleProp, ViewStyle } from 'react-native';
 import { SharedValue } from 'react-native-reanimated';
 
 import type { Streami18n } from '../../utils/i18n/Streami18n';
@@ -11,6 +12,10 @@ import { DEFAULT_BASE_CONTEXT_VALUE } from '../utils/defaultBaseContextValue';
 import { isTestEnvironment } from '../utils/isTestEnvironment';
 
 export type Overlay = 'alert' | 'gallery' | 'none';
+export type MessageOverlayBackgroundProps = {
+  overlayOpacity: SharedValue<number>;
+  style?: StyleProp<ViewStyle>;
+};
 
 export type OverlayContextValue = {
   overlay: Overlay;
@@ -26,6 +31,11 @@ export const OverlayContext = React.createContext(
 export type OverlayProviderProps = ImageGalleryProviderProps & {
   /** https://github.com/GetStream/stream-chat-react-native/wiki/Internationalization-(i18n) */
   i18nInstance?: Streami18n;
+  /**
+   * Custom backdrop component rendered behind overlay content in `MessageOverlayHostLayer`.
+   * Receives a shared opacity value that should be used for its visibility animation.
+   */
+  MessageOverlayBackground?: React.ComponentType<MessageOverlayBackgroundProps>;
   value?: Partial<OverlayContextValue>;
 };
 

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -44,6 +44,7 @@ export const OverlayProvider = (props: PropsWithChildren<OverlayProviderProps>) 
   const {
     children,
     i18nInstance,
+    MessageOverlayBackground,
     value,
     autoPlayVideo,
     giphyVersion,
@@ -106,7 +107,7 @@ export const OverlayProvider = (props: PropsWithChildren<OverlayProviderProps>) 
             <PortalProvider>
               {children}
               {overlay === 'gallery' && <ImageGallery overlayOpacity={overlayOpacity} />}
-              <MessageOverlayHostLayer />
+              <MessageOverlayHostLayer BackgroundComponent={MessageOverlayBackground} />
             </PortalProvider>
           </ThemeProvider>
         </ImageGalleryProvider>


### PR DESCRIPTION
## 🎯 Goal

This PR introduces an optional background component that can be used as a backdrop for the message context menu. This can be used to introduce something like a `BlurView` for example to mimic `iOS` contextual menus a bit better.

It also resolves some issues around teleported text specifically in terms of colors.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


