### PR TITLE
feat: introduce stack behaviour for message overlay

### DIFF
--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -11,6 +11,8 @@ import {
   useTheme,
   useTranslationContext,
   useTypingString,
+  useClosingPortalHostBlacklist,
+  PortalWhileClosingView,
 } from 'stream-chat-react-native';
 import { useStateStore } from 'stream-chat-react-native';
 
@@ -161,7 +163,12 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
         onAlsoSentToChannelHeaderPress={onAlsoSentToChannelHeaderPress}
         messageId={targetedMessageIdFromParams}
       >
-        <ThreadHeader thread={thread} />
+        <PortalWhileClosingView
+          portalHostName='overlay-header'
+          portalName='channel-header'
+        >
+          <ThreadHeader thread={thread} />
+        </PortalWhileClosingView>
         <Thread
           onThreadDismount={onThreadDismount}
           shouldUseFlashList={messageListImplementation === 'flashlist'}

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -11,7 +11,6 @@ import {
   useTheme,
   useTranslationContext,
   useTypingString,
-  useClosingPortalHostBlacklist,
   PortalWhileClosingView,
 } from 'stream-chat-react-native';
 import { useStateStore } from 'stream-chat-react-native';

--- a/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.js.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.js.snap
@@ -816,6 +816,7 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
             },
           ]
         }
+        testID="message-overlay-top"
       >
         <View
           name="top-item"
@@ -846,6 +847,7 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
             },
           ]
         }
+        testID="message-overlay-message"
       >
         <View
           name="message-overlay"
@@ -878,6 +880,7 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
             },
           ]
         }
+        testID="message-overlay-bottom"
       >
         <View
           name="bottom-item"
@@ -1713,6 +1716,7 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-top"
       >
         <View
           name="top-item"
@@ -1743,6 +1747,7 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-message"
       >
         <View
           name="message-overlay"
@@ -1775,6 +1780,7 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-bottom"
       >
         <View
           name="bottom-item"
@@ -2610,6 +2616,7 @@ exports[`AttachButton should render an disabled AttachButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-top"
       >
         <View
           name="top-item"
@@ -2640,6 +2647,7 @@ exports[`AttachButton should render an disabled AttachButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-message"
       >
         <View
           name="message-overlay"
@@ -2672,6 +2680,7 @@ exports[`AttachButton should render an disabled AttachButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-bottom"
       >
         <View
           name="bottom-item"

--- a/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.js.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.js.snap
@@ -814,6 +814,7 @@ exports[`SendButton should render a SendButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-top"
       >
         <View
           name="top-item"
@@ -844,6 +845,7 @@ exports[`SendButton should render a SendButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-message"
       >
         <View
           name="message-overlay"
@@ -876,6 +878,7 @@ exports[`SendButton should render a SendButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-bottom"
       >
         <View
           name="bottom-item"
@@ -1709,6 +1712,7 @@ exports[`SendButton should render a disabled SendButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-top"
       >
         <View
           name="top-item"
@@ -1739,6 +1743,7 @@ exports[`SendButton should render a disabled SendButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-message"
       >
         <View
           name="message-overlay"
@@ -1771,6 +1776,7 @@ exports[`SendButton should render a disabled SendButton 1`] = `
             },
           ]
         }
+        testID="message-overlay-bottom"
       >
         <View
           name="bottom-item"

--- a/package/src/components/UIComponents/PortalWhileClosingView.tsx
+++ b/package/src/components/UIComponents/PortalWhileClosingView.tsx
@@ -8,8 +8,9 @@ import { Portal } from 'react-native-teleport';
 import { useStableCallback } from '../../hooks';
 import {
   clearClosingPortalLayout,
+  createClosingPortalLayoutRegistrationId,
   setClosingPortalLayout,
-  useOverlayController,
+  useShouldTeleportToClosingPortal,
 } from '../../state-store';
 
 type PortalWhileClosingViewProps = {
@@ -39,15 +40,16 @@ type PortalWhileClosingViewProps = {
  * This wrapper moves that UI into the overlay host layer for the closing phase, so stacking stays correct.
  *
  * To use it, simply wrap any view that should remain on top while the overlay is closing, and pass a `portalHostName`
- * and a `portalName`. Registration within the host layer will happen automatically, as will calculating layout.
+ * and a `portalName`. Once the wrapped view has a valid measured layout, it can participate in the closing host layer.
  *
  * Behavior:
  * - renders children in place during normal operation
- * - registers absolute layout for `portalHostName`
+ * - registers absolute layout for `portalHostName` once a valid measurement exists
  * - while overlay state is `closing`, teleports children to the matching closing host
  * - renders a local placeholder while closing to preserve original layout space
  *
- * Host registration is done once per key; subsequent layout updates are pushed via shared values.
+ * Stack presence only starts after first valid measurement. That prevents unmeasured entries from taking over a host
+ * slot and rendering with incomplete geometry.
  *
  * Note: As the `PortalWhileClosingView` relies heavily on being able to calculate the layout and positioning
  * properties of its children automatically, make sure that you do not wrap absolutely positioned views with
@@ -65,10 +67,17 @@ export const PortalWhileClosingView = ({
   portalHostName,
   portalName,
 }: PortalWhileClosingViewProps) => {
-  const { closing } = useOverlayController();
   const containerRef = useRef<View | null>(null);
+  const registrationIdRef = useRef<string | null>(null);
   const placeholderLayout = useSharedValue({ h: 0, w: 0 });
   const insets = useSafeAreaInsets();
+
+  if (!registrationIdRef.current) {
+    registrationIdRef.current = createClosingPortalLayoutRegistrationId();
+  }
+
+  const registrationId = registrationIdRef.current;
+  const shouldTeleport = useShouldTeleportToClosingPortal(portalHostName, registrationId);
 
   const syncPortalLayout = useStableCallback(() => {
     containerRef.current?.measureInWindow((x, y, width, height) => {
@@ -83,13 +92,19 @@ export const PortalWhileClosingView = ({
 
       placeholderLayout.value = { h: height, w: width };
 
-      setClosingPortalLayout(portalHostName, {
+      setClosingPortalLayout(portalHostName, registrationId, {
         ...absolute,
         h: height,
         w: width,
       });
     });
   });
+
+  useEffect(() => {
+    return () => {
+      clearClosingPortalLayout(portalHostName, registrationId);
+    };
+  }, [portalHostName, registrationId]);
 
   useEffect(() => {
     // Measure once after mount and layout settle.
@@ -100,14 +115,6 @@ export const PortalWhileClosingView = ({
     });
   }, [insets.top, portalHostName, syncPortalLayout]);
 
-  const unregisterPortalHost = useStableCallback(() => clearClosingPortalLayout(portalHostName));
-
-  useEffect(() => {
-    return () => {
-      unregisterPortalHost();
-    };
-  }, [unregisterPortalHost]);
-
   const placeholderStyle = useAnimatedStyle(() => ({
     height: placeholderLayout.value.h,
     width: placeholderLayout.value.w > 0 ? placeholderLayout.value.w : '100%',
@@ -115,12 +122,12 @@ export const PortalWhileClosingView = ({
 
   return (
     <>
-      <Portal hostName={closing ? portalHostName : undefined} name={portalName}>
+      <Portal hostName={shouldTeleport ? portalHostName : undefined} name={portalName}>
         <View collapsable={false} ref={containerRef} onLayout={syncPortalLayout}>
           {children}
         </View>
       </Portal>
-      {closing ? <Animated.View pointerEvents='none' style={placeholderStyle} /> : null}
+      {shouldTeleport ? <Animated.View pointerEvents='none' style={placeholderStyle} /> : null}
     </>
   );
 };

--- a/package/src/components/UIComponents/PortalWhileClosingView.tsx
+++ b/package/src/components/UIComponents/PortalWhileClosingView.tsx
@@ -127,7 +127,13 @@ export const PortalWhileClosingView = ({
           {children}
         </View>
       </Portal>
-      {shouldTeleport ? <Animated.View pointerEvents='none' style={placeholderStyle} /> : null}
+      {shouldTeleport ? (
+        <Animated.View
+          pointerEvents='none'
+          style={placeholderStyle}
+          testID={`portal-while-closing-placeholder-${portalName}`}
+        />
+      ) : null}
     </>
   );
 };

--- a/package/src/components/UIComponents/__tests__/PortalWhileClosingView.test.tsx
+++ b/package/src/components/UIComponents/__tests__/PortalWhileClosingView.test.tsx
@@ -1,41 +1,16 @@
-jest.mock('react-native-teleport', () => {
-  const React = require('react');
-  const { Text, View } = require('react-native');
-
-  return {
-    Portal: ({
-      children,
-      hostName,
-      name,
-    }: {
-      children: React.ReactNode;
-      hostName?: string;
-      name: string;
-    }) => (
-      <View testID={`portal-${name}`}>
-        <Text testID={`portal-${name}-host`}>{hostName ?? 'none'}</Text>
-        {children}
-      </View>
-    ),
-    PortalHost: ({ name }: { name: string }) => <Text testID={`portal-host-${name}`}>{name}</Text>,
-    PortalProvider: View,
-    usePortal: jest.fn().mockReturnValue({ removePortal: jest.fn() }),
-  };
-});
-
-jest.mock('../../../state-store/message-overlay-store', () => ({
-  clearClosingPortalLayout: jest.fn(),
-  createClosingPortalLayoutRegistrationId: jest.fn(),
-  setClosingPortalLayout: jest.fn(),
-  useShouldTeleportToClosingPortal: jest.fn(),
-}));
-
 jest.mock('../../../state-store', () => {
-  const mockedMessageOverlayStore = jest.requireMock('../../../state-store/message-overlay-store');
+  const actual = jest.requireActual('../../../state-store');
+  const createClosingPortalLayoutRegistrationId = jest.fn(() => 'registration-1');
 
-  return {
-    ...mockedMessageOverlayStore,
-  };
+  return new Proxy(actual, {
+    get(target, prop, receiver) {
+      if (prop === 'createClosingPortalLayoutRegistrationId') {
+        return createClosingPortalLayoutRegistrationId;
+      }
+
+      return Reflect.get(target, prop, receiver);
+    },
+  });
 });
 
 import React from 'react';
@@ -43,69 +18,193 @@ import { Text } from 'react-native';
 
 import { act, cleanup, render, screen } from '@testing-library/react-native';
 
-import * as stateStore from '../../../state-store/message-overlay-store';
+import * as stateStore from '../../../state-store';
 import { PortalWhileClosingView } from '../PortalWhileClosingView';
 
-const mockedCreateClosingPortalLayoutRegistrationId =
-  stateStore.createClosingPortalLayoutRegistrationId as jest.Mock;
-const mockedClearClosingPortalLayout = stateStore.clearClosingPortalLayout as jest.Mock;
-const mockedUseShouldTeleportToClosingPortal =
-  stateStore.useShouldTeleportToClosingPortal as jest.Mock;
+const BASE_RECT = { h: 48, w: 120, x: 12, y: 24 };
+
+const flushAnimationFrameQueue = () => {
+  act(() => {
+    jest.runAllTimers();
+  });
+};
+
+const TeleportStateProbe = ({
+  hostName,
+  id,
+  testID,
+}: {
+  hostName: string;
+  id: string;
+  testID: string;
+}) => {
+  const shouldTeleport = stateStore.useShouldTeleportToClosingPortal(hostName, id);
+
+  return <Text testID={testID}>{shouldTeleport ? 'true' : 'false'}</Text>;
+};
+
+const BlacklistRegistrar = ({ hostNames }: { hostNames: string[] }) => {
+  stateStore.useClosingPortalHostBlacklist(hostNames);
+  return null;
+};
+
+const findPortalNode = (
+  node: ReturnType<ReturnType<typeof render>['toJSON']>,
+  portalName: string,
+): null | { props?: { hostName?: string; name?: string } } => {
+  if (!node) {
+    return null;
+  }
+
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findPortalNode(child, portalName);
+      if (found) {
+        return found;
+      }
+    }
+
+    return null;
+  }
+
+  if (node.props?.name === portalName) {
+    return node;
+  }
+
+  for (const child of node.children ?? []) {
+    if (typeof child === 'string') {
+      continue;
+    }
+
+    const found = findPortalNode(child, portalName);
+    if (found) {
+      return found;
+    }
+  }
+
+  return null;
+};
 
 describe('PortalWhileClosingView', () => {
   beforeEach(() => {
-    mockedClearClosingPortalLayout.mockClear();
-    mockedUseShouldTeleportToClosingPortal.mockReset();
-    mockedUseShouldTeleportToClosingPortal.mockReturnValue(false);
-    mockedCreateClosingPortalLayoutRegistrationId.mockReset();
-    mockedCreateClosingPortalLayoutRegistrationId
-      .mockReturnValueOnce('registration-1')
-      .mockReturnValueOnce('registration-2')
-      .mockReturnValue('registration-fallback');
+    jest.useFakeTimers();
+
+    act(() => {
+      stateStore.finalizeCloseOverlay();
+      stateStore.overlayStore.next({
+        closing: false,
+        closingPortalHostBlacklist: [],
+        id: undefined,
+      });
+    });
   });
 
   afterEach(() => {
     cleanup();
+
+    act(() => {
+      stateStore.clearClosingPortalLayout('overlay-composer', 'registration-1');
+      stateStore.finalizeCloseOverlay();
+      stateStore.overlayStore.next({
+        closing: false,
+        closingPortalHostBlacklist: [],
+        id: undefined,
+      });
+    });
+
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
-  it('keeps content local when the teleport hook returns false', () => {
-    render(
-      <PortalWhileClosingView portalHostName='overlay-composer' portalName='local-portal'>
-        <Text>Local</Text>
-      </PortalWhileClosingView>,
-    );
-
-    expect(screen.getByTestId('portal-local-portal-host')).toHaveTextContent('none');
-  });
-
-  it('teleports content to the closing host when the teleport hook returns true', () => {
-    mockedUseShouldTeleportToClosingPortal.mockReturnValue(true);
-
-    render(
-      <PortalWhileClosingView portalHostName='overlay-composer' portalName='teleported-portal'>
-        <Text>Teleported</Text>
-      </PortalWhileClosingView>,
-    );
-
-    expect(screen.getByTestId('portal-teleported-portal-host')).toHaveTextContent(
-      'overlay-composer',
-    );
-  });
-
-  it('clears its registered layout entry when it unmounts', () => {
-    const { unmount } = render(
-      <PortalWhileClosingView portalHostName='overlay-composer' portalName='cleanup-portal'>
-        <Text>Cleanup</Text>
-      </PortalWhileClosingView>,
+  it('uses the real store to teleport once the overlay is closing and this host is active', () => {
+    const { toJSON } = render(
+      <>
+        <PortalWhileClosingView portalHostName='overlay-composer' portalName='composer-portal'>
+          <Text>Composer</Text>
+        </PortalWhileClosingView>
+        <TeleportStateProbe
+          hostName='overlay-composer'
+          id='registration-1'
+          testID='teleport-state'
+        />
+      </>,
     );
 
     act(() => {
-      unmount();
+      stateStore.setClosingPortalLayout('overlay-composer', 'registration-1', BASE_RECT);
     });
 
-    expect(mockedClearClosingPortalLayout).toHaveBeenCalledWith(
-      'overlay-composer',
-      'registration-1',
+    expect(screen.getByTestId('teleport-state')).toHaveTextContent('false');
+    expect(findPortalNode(toJSON(), 'composer-portal')?.props?.hostName).toBeUndefined();
+
+    act(() => {
+      stateStore.openOverlay('message-1');
+      stateStore.closeOverlay();
+    });
+    flushAnimationFrameQueue();
+
+    expect(screen.getByTestId('teleport-state')).toHaveTextContent('true');
+    expect(findPortalNode(toJSON(), 'composer-portal')?.props?.hostName).toBe('overlay-composer');
+  });
+
+  it('keeps the portal local when the host is blacklisted', () => {
+    const { toJSON } = render(
+      <>
+        <BlacklistRegistrar hostNames={['overlay-composer']} />
+        <PortalWhileClosingView portalHostName='overlay-composer' portalName='composer-portal'>
+          <Text>Composer</Text>
+        </PortalWhileClosingView>
+        <TeleportStateProbe
+          hostName='overlay-composer'
+          id='registration-1'
+          testID='teleport-state'
+        />
+      </>,
     );
+
+    act(() => {
+      stateStore.setClosingPortalLayout('overlay-composer', 'registration-1', BASE_RECT);
+      stateStore.openOverlay('message-1');
+      stateStore.closeOverlay();
+    });
+    flushAnimationFrameQueue();
+
+    expect(screen.getByTestId('teleport-state')).toHaveTextContent('false');
+    expect(findPortalNode(toJSON(), 'composer-portal')?.props?.hostName).toBeUndefined();
+  });
+
+  it('clears its registration from the real store when it unmounts', () => {
+    const { rerender } = render(
+      <>
+        <PortalWhileClosingView portalHostName='overlay-composer' portalName='composer-portal'>
+          <Text>Composer</Text>
+        </PortalWhileClosingView>
+        <TeleportStateProbe
+          hostName='overlay-composer'
+          id='registration-1'
+          testID='teleport-state'
+        />
+      </>,
+    );
+
+    act(() => {
+      stateStore.setClosingPortalLayout('overlay-composer', 'registration-1', BASE_RECT);
+      stateStore.openOverlay('message-1');
+      stateStore.closeOverlay();
+    });
+    flushAnimationFrameQueue();
+
+    expect(screen.getByTestId('teleport-state')).toHaveTextContent('true');
+
+    rerender(
+      <TeleportStateProbe
+        hostName='overlay-composer'
+        id='registration-1'
+        testID='teleport-state'
+      />,
+    );
+
+    expect(screen.getByTestId('teleport-state')).toHaveTextContent('false');
   });
 });

--- a/package/src/components/UIComponents/__tests__/PortalWhileClosingView.test.tsx
+++ b/package/src/components/UIComponents/__tests__/PortalWhileClosingView.test.tsx
@@ -48,43 +48,6 @@ const BlacklistRegistrar = ({ hostNames }: { hostNames: string[] }) => {
   return null;
 };
 
-const findPortalNode = (
-  node: ReturnType<ReturnType<typeof render>['toJSON']>,
-  portalName: string,
-): null | { props?: { hostName?: string; name?: string } } => {
-  if (!node) {
-    return null;
-  }
-
-  if (Array.isArray(node)) {
-    for (const child of node) {
-      const found = findPortalNode(child, portalName);
-      if (found) {
-        return found;
-      }
-    }
-
-    return null;
-  }
-
-  if (node.props?.name === portalName) {
-    return node;
-  }
-
-  for (const child of node.children ?? []) {
-    if (typeof child === 'string') {
-      continue;
-    }
-
-    const found = findPortalNode(child, portalName);
-    if (found) {
-      return found;
-    }
-  }
-
-  return null;
-};
-
 describe('PortalWhileClosingView', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -118,7 +81,7 @@ describe('PortalWhileClosingView', () => {
   });
 
   it('uses the real store to teleport once the overlay is closing and this host is active', () => {
-    const { toJSON } = render(
+    render(
       <>
         <PortalWhileClosingView portalHostName='overlay-composer' portalName='composer-portal'>
           <Text>Composer</Text>
@@ -136,7 +99,7 @@ describe('PortalWhileClosingView', () => {
     });
 
     expect(screen.getByTestId('teleport-state')).toHaveTextContent('false');
-    expect(findPortalNode(toJSON(), 'composer-portal')?.props?.hostName).toBeUndefined();
+    expect(screen.queryByTestId('portal-while-closing-placeholder-composer-portal')).toBeNull();
 
     act(() => {
       stateStore.openOverlay('message-1');
@@ -145,11 +108,11 @@ describe('PortalWhileClosingView', () => {
     flushAnimationFrameQueue();
 
     expect(screen.getByTestId('teleport-state')).toHaveTextContent('true');
-    expect(findPortalNode(toJSON(), 'composer-portal')?.props?.hostName).toBe('overlay-composer');
+    expect(screen.getByTestId('portal-while-closing-placeholder-composer-portal')).toBeTruthy();
   });
 
   it('keeps the portal local when the host is blacklisted', () => {
-    const { toJSON } = render(
+    render(
       <>
         <BlacklistRegistrar hostNames={['overlay-composer']} />
         <PortalWhileClosingView portalHostName='overlay-composer' portalName='composer-portal'>
@@ -171,7 +134,7 @@ describe('PortalWhileClosingView', () => {
     flushAnimationFrameQueue();
 
     expect(screen.getByTestId('teleport-state')).toHaveTextContent('false');
-    expect(findPortalNode(toJSON(), 'composer-portal')?.props?.hostName).toBeUndefined();
+    expect(screen.queryByTestId('portal-while-closing-placeholder-composer-portal')).toBeNull();
   });
 
   it('clears its registration from the real store when it unmounts', () => {

--- a/package/src/components/UIComponents/__tests__/PortalWhileClosingView.test.tsx
+++ b/package/src/components/UIComponents/__tests__/PortalWhileClosingView.test.tsx
@@ -1,0 +1,111 @@
+jest.mock('react-native-teleport', () => {
+  const React = require('react');
+  const { Text, View } = require('react-native');
+
+  return {
+    Portal: ({
+      children,
+      hostName,
+      name,
+    }: {
+      children: React.ReactNode;
+      hostName?: string;
+      name: string;
+    }) => (
+      <View testID={`portal-${name}`}>
+        <Text testID={`portal-${name}-host`}>{hostName ?? 'none'}</Text>
+        {children}
+      </View>
+    ),
+    PortalHost: ({ name }: { name: string }) => <Text testID={`portal-host-${name}`}>{name}</Text>,
+    PortalProvider: View,
+    usePortal: jest.fn().mockReturnValue({ removePortal: jest.fn() }),
+  };
+});
+
+jest.mock('../../../state-store/message-overlay-store', () => ({
+  clearClosingPortalLayout: jest.fn(),
+  createClosingPortalLayoutRegistrationId: jest.fn(),
+  setClosingPortalLayout: jest.fn(),
+  useShouldTeleportToClosingPortal: jest.fn(),
+}));
+
+jest.mock('../../../state-store', () => {
+  const mockedMessageOverlayStore = jest.requireMock('../../../state-store/message-overlay-store');
+
+  return {
+    ...mockedMessageOverlayStore,
+  };
+});
+
+import React from 'react';
+import { Text } from 'react-native';
+
+import { act, cleanup, render, screen } from '@testing-library/react-native';
+
+import * as stateStore from '../../../state-store/message-overlay-store';
+import { PortalWhileClosingView } from '../PortalWhileClosingView';
+
+const mockedCreateClosingPortalLayoutRegistrationId =
+  stateStore.createClosingPortalLayoutRegistrationId as jest.Mock;
+const mockedClearClosingPortalLayout = stateStore.clearClosingPortalLayout as jest.Mock;
+const mockedUseShouldTeleportToClosingPortal =
+  stateStore.useShouldTeleportToClosingPortal as jest.Mock;
+
+describe('PortalWhileClosingView', () => {
+  beforeEach(() => {
+    mockedClearClosingPortalLayout.mockClear();
+    mockedUseShouldTeleportToClosingPortal.mockReset();
+    mockedUseShouldTeleportToClosingPortal.mockReturnValue(false);
+    mockedCreateClosingPortalLayoutRegistrationId.mockReset();
+    mockedCreateClosingPortalLayoutRegistrationId
+      .mockReturnValueOnce('registration-1')
+      .mockReturnValueOnce('registration-2')
+      .mockReturnValue('registration-fallback');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('keeps content local when the teleport hook returns false', () => {
+    render(
+      <PortalWhileClosingView portalHostName='overlay-composer' portalName='local-portal'>
+        <Text>Local</Text>
+      </PortalWhileClosingView>,
+    );
+
+    expect(screen.getByTestId('portal-local-portal-host')).toHaveTextContent('none');
+  });
+
+  it('teleports content to the closing host when the teleport hook returns true', () => {
+    mockedUseShouldTeleportToClosingPortal.mockReturnValue(true);
+
+    render(
+      <PortalWhileClosingView portalHostName='overlay-composer' portalName='teleported-portal'>
+        <Text>Teleported</Text>
+      </PortalWhileClosingView>,
+    );
+
+    expect(screen.getByTestId('portal-teleported-portal-host')).toHaveTextContent(
+      'overlay-composer',
+    );
+  });
+
+  it('clears its registered layout entry when it unmounts', () => {
+    const { unmount } = render(
+      <PortalWhileClosingView portalHostName='overlay-composer' portalName='cleanup-portal'>
+        <Text>Cleanup</Text>
+      </PortalWhileClosingView>,
+    );
+
+    act(() => {
+      unmount();
+    });
+
+    expect(mockedClearClosingPortalLayout).toHaveBeenCalledWith(
+      'overlay-composer',
+      'registration-1',
+    );
+  });
+});

--- a/package/src/components/UIComponents/__tests__/PortalWhileClosingView.test.tsx
+++ b/package/src/components/UIComponents/__tests__/PortalWhileClosingView.test.tsx
@@ -1,3 +1,11 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+import { act, cleanup, render, screen } from '@testing-library/react-native';
+
+import * as stateStore from '../../../state-store';
+import { PortalWhileClosingView } from '../PortalWhileClosingView';
+
 jest.mock('../../../state-store', () => {
   const actual = jest.requireActual('../../../state-store');
   const createClosingPortalLayoutRegistrationId = jest.fn(() => 'registration-1');
@@ -12,14 +20,6 @@ jest.mock('../../../state-store', () => {
     },
   });
 });
-
-import React from 'react';
-import { Text } from 'react-native';
-
-import { act, cleanup, render, screen } from '@testing-library/react-native';
-
-import * as stateStore from '../../../state-store';
-import { PortalWhileClosingView } from '../PortalWhileClosingView';
 
 const BASE_RECT = { h: 48, w: 120, x: 12, y: 24 };
 

--- a/package/src/contexts/overlayContext/ClosingPortalHostsLayer.tsx
+++ b/package/src/contexts/overlayContext/ClosingPortalHostsLayer.tsx
@@ -31,7 +31,11 @@ const ClosingPortalHostSlot = ({
   });
 
   return (
-    <Animated.View pointerEvents='box-none' style={style}>
+    <Animated.View
+      pointerEvents='box-none'
+      style={style}
+      testID={`closing-portal-host-slot-${hostName}`}
+    >
       <PortalHost name={hostName} style={StyleSheet.absoluteFillObject} />
     </Animated.View>
   );

--- a/package/src/contexts/overlayContext/ClosingPortalHostsLayer.tsx
+++ b/package/src/contexts/overlayContext/ClosingPortalHostsLayer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 import Animated, { SharedValue, useAnimatedStyle } from 'react-native-reanimated';
 import { PortalHost } from 'react-native-teleport';
@@ -42,16 +42,31 @@ type ClosingPortalHostsLayerProps = {
 };
 
 export const ClosingPortalHostsLayer = ({ closeCoverOpacity }: ClosingPortalHostsLayerProps) => {
-  const closingPortalLayouts = useClosingPortalLayouts();
+  const closingPortalLayoutStacks = useClosingPortalLayouts();
+  const closingPortalHosts = useMemo(() => {
+    const topHosts: Array<{
+      hostName: string;
+      layout: ClosingPortalLayoutEntry['layout'];
+    }> = [];
+
+    Object.entries(closingPortalLayoutStacks).forEach(([hostName, entries]) => {
+      const topEntry = entries[entries.length - 1];
+      if (topEntry) {
+        topHosts.push({ hostName, layout: topEntry.layout });
+      }
+    });
+
+    return topHosts;
+  }, [closingPortalLayoutStacks]);
 
   return (
     <>
-      {Object.entries(closingPortalLayouts).map(([hostName, entry]) => (
+      {closingPortalHosts.map(({ hostName, layout }) => (
         <ClosingPortalHostSlot
           closeCoverOpacity={closeCoverOpacity}
           hostName={hostName}
           key={hostName}
-          layout={entry.layout}
+          layout={layout}
         />
       ))}
     </>

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -264,18 +264,29 @@ export const MessageOverlayHostLayer = ({ BackgroundComponent }: MessageOverlayH
 
         <View pointerEvents='box-none' style={StyleSheet.absoluteFill}>
           {isActive ? (
-            <Pressable onPress={closeOverlay} style={StyleSheet.absoluteFillObject} />
+            <Pressable
+              onPress={closeOverlay}
+              style={StyleSheet.absoluteFillObject}
+              testID='message-overlay-backdrop'
+            />
           ) : null}
 
-          <Animated.View style={[topItemStyle, topItemTranslateStyle]}>
+          <Animated.View style={[topItemStyle, topItemTranslateStyle]} testID='message-overlay-top'>
             <PortalHost name='top-item' style={StyleSheet.absoluteFillObject} />
           </Animated.View>
 
-          <Animated.View pointerEvents='box-none' style={[hostStyle, hostTranslateStyle]}>
+          <Animated.View
+            pointerEvents='box-none'
+            style={[hostStyle, hostTranslateStyle]}
+            testID='message-overlay-message'
+          >
             <PortalHost name='message-overlay' style={StyleSheet.absoluteFillObject} />
           </Animated.View>
 
-          <Animated.View style={[bottomItemStyle, bottomItemTranslateStyle]}>
+          <Animated.View
+            style={[bottomItemStyle, bottomItemTranslateStyle]}
+            testID='message-overlay-bottom'
+          >
             <PortalHost name='bottom-item' style={StyleSheet.absoluteFillObject} />
           </Animated.View>
         </View>

--- a/package/src/contexts/overlayContext/__tests__/ClosingPortalHostsLayer.test.tsx
+++ b/package/src/contexts/overlayContext/__tests__/ClosingPortalHostsLayer.test.tsx
@@ -17,23 +17,8 @@ jest.mock('react-native-reanimated', () => {
   };
 });
 
-jest.mock('react-native-teleport', () => {
-  const React = require('react');
-  const { Text, View } = require('react-native');
-
-  return {
-    Portal: View,
-    PortalHost: ({ name }: { name: string }) => (
-      <View testID={`portal-host-${name}`}>
-        <Text>{name}</Text>
-      </View>
-    ),
-    PortalProvider: View,
-    usePortal: jest.fn().mockReturnValue({ removePortal: jest.fn() }),
-  };
-});
-
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 
 import { act, cleanup, render, screen } from '@testing-library/react-native';
@@ -59,93 +44,58 @@ describe('ClosingPortalHostsLayer', () => {
   });
 
   it('renders the geometry for the top-most registration of a host and falls back when it is removed', () => {
-    const { toJSON } = render(
-      <ClosingPortalHostsLayer closeCoverOpacity={{ value: 0.5 } as SharedValue<number>} />,
-    );
+    render(<ClosingPortalHostsLayer closeCoverOpacity={{ value: 0.5 } as SharedValue<number>} />);
 
     act(() => {
       setClosingPortalLayout('overlay-header', 'first-entry', FIRST_RECT);
     });
 
-    let tree = toJSON();
-    let slot = Array.isArray(tree) ? tree[0] : tree;
-
-    expect(slot).toMatchObject({
-      children: [
-        expect.objectContaining({
-          props: expect.objectContaining({ testID: 'portal-host-overlay-header' }),
-        }),
-      ],
-      props: expect.objectContaining({
-        pointerEvents: 'box-none',
-        style: expect.objectContaining({
-          height: FIRST_RECT.h,
-          left: FIRST_RECT.x,
-          opacity: 0.5,
-          position: 'absolute',
-          top: FIRST_RECT.y,
-          width: FIRST_RECT.w,
-        }),
-      }),
+    expect(
+      StyleSheet.flatten(screen.getByTestId('closing-portal-host-slot-overlay-header').props.style),
+    ).toMatchObject({
+      height: FIRST_RECT.h,
+      left: FIRST_RECT.x,
+      opacity: 0.5,
+      position: 'absolute',
+      top: FIRST_RECT.y,
+      width: FIRST_RECT.w,
     });
 
     act(() => {
       setClosingPortalLayout('overlay-header', 'second-entry', SECOND_RECT);
     });
 
-    tree = toJSON();
-    slot = Array.isArray(tree) ? tree[0] : tree;
-
-    expect(slot).toMatchObject({
-      children: [
-        expect.objectContaining({
-          props: expect.objectContaining({ testID: 'portal-host-overlay-header' }),
-        }),
-      ],
-      props: expect.objectContaining({
-        pointerEvents: 'box-none',
-        style: expect.objectContaining({
-          height: SECOND_RECT.h,
-          left: SECOND_RECT.x,
-          opacity: 0.5,
-          position: 'absolute',
-          top: SECOND_RECT.y,
-          width: SECOND_RECT.w,
-        }),
-      }),
+    expect(
+      StyleSheet.flatten(screen.getByTestId('closing-portal-host-slot-overlay-header').props.style),
+    ).toMatchObject({
+      height: SECOND_RECT.h,
+      left: SECOND_RECT.x,
+      opacity: 0.5,
+      position: 'absolute',
+      top: SECOND_RECT.y,
+      width: SECOND_RECT.w,
     });
 
     act(() => {
       clearClosingPortalLayout('overlay-header', 'second-entry');
     });
 
-    tree = toJSON();
-    slot = Array.isArray(tree) ? tree[0] : tree;
-
-    expect(slot).toMatchObject({
-      children: [
-        expect.objectContaining({
-          props: expect.objectContaining({ testID: 'portal-host-overlay-header' }),
-        }),
-      ],
-      props: expect.objectContaining({
-        pointerEvents: 'box-none',
-        style: expect.objectContaining({
-          height: FIRST_RECT.h,
-          left: FIRST_RECT.x,
-          opacity: 0.5,
-          position: 'absolute',
-          top: FIRST_RECT.y,
-          width: FIRST_RECT.w,
-        }),
-      }),
+    expect(
+      StyleSheet.flatten(screen.getByTestId('closing-portal-host-slot-overlay-header').props.style),
+    ).toMatchObject({
+      height: FIRST_RECT.h,
+      left: FIRST_RECT.x,
+      opacity: 0.5,
+      position: 'absolute',
+      top: FIRST_RECT.y,
+      width: FIRST_RECT.w,
     });
 
     act(() => {
       clearClosingPortalLayout('overlay-header', 'first-entry');
     });
 
-    expect(toJSON()).toBeNull();
+    expect(screen.queryByTestId('closing-portal-host-slot-overlay-header')).toBeNull();
   });
 
   it('renders one closing host slot per host name even when multiple entries are registered', () => {
@@ -162,7 +112,7 @@ describe('ClosingPortalHostsLayer', () => {
       });
     });
 
-    expect(screen.getAllByTestId('portal-host-overlay-header')).toHaveLength(1);
-    expect(screen.getAllByTestId('portal-host-overlay-composer')).toHaveLength(1);
+    expect(screen.getAllByTestId('closing-portal-host-slot-overlay-header')).toHaveLength(1);
+    expect(screen.getAllByTestId('closing-portal-host-slot-overlay-composer')).toHaveLength(1);
   });
 });

--- a/package/src/contexts/overlayContext/__tests__/ClosingPortalHostsLayer.test.tsx
+++ b/package/src/contexts/overlayContext/__tests__/ClosingPortalHostsLayer.test.tsx
@@ -1,0 +1,168 @@
+jest.mock('react-native-reanimated', () => {
+  const actual = jest.requireActual('react-native-reanimated/mock');
+  const { View } = require('react-native');
+
+  return {
+    ...actual,
+    Animated: {
+      ...actual.default,
+      View,
+    },
+    default: {
+      ...actual.default,
+      View,
+    },
+    makeMutable: (value: unknown) => ({ value }),
+    useAnimatedStyle: (updater: () => unknown) => updater(),
+  };
+});
+
+jest.mock('react-native-teleport', () => {
+  const React = require('react');
+  const { Text, View } = require('react-native');
+
+  return {
+    Portal: View,
+    PortalHost: ({ name }: { name: string }) => (
+      <View testID={`portal-host-${name}`}>
+        <Text>{name}</Text>
+      </View>
+    ),
+    PortalProvider: View,
+    usePortal: jest.fn().mockReturnValue({ removePortal: jest.fn() }),
+  };
+});
+
+import React from 'react';
+import type { SharedValue } from 'react-native-reanimated';
+
+import { act, cleanup, render, screen } from '@testing-library/react-native';
+
+import { clearClosingPortalLayout, setClosingPortalLayout } from '../../../state-store';
+import { ClosingPortalHostsLayer } from '../ClosingPortalHostsLayer';
+
+const FIRST_RECT = { h: 40, w: 100, x: 10, y: 20 };
+const SECOND_RECT = { h: 52, w: 140, x: 30, y: 45 };
+
+describe('ClosingPortalHostsLayer', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  afterEach(() => {
+    act(() => {
+      clearClosingPortalLayout('overlay-header', 'first-entry');
+      clearClosingPortalLayout('overlay-header', 'second-entry');
+      clearClosingPortalLayout('overlay-composer', 'composer-entry');
+    });
+    cleanup();
+  });
+
+  it('renders the geometry for the top-most registration of a host and falls back when it is removed', () => {
+    const { toJSON } = render(
+      <ClosingPortalHostsLayer closeCoverOpacity={{ value: 0.5 } as SharedValue<number>} />,
+    );
+
+    act(() => {
+      setClosingPortalLayout('overlay-header', 'first-entry', FIRST_RECT);
+    });
+
+    let tree = toJSON();
+    let slot = Array.isArray(tree) ? tree[0] : tree;
+
+    expect(slot).toMatchObject({
+      children: [
+        expect.objectContaining({
+          props: expect.objectContaining({ testID: 'portal-host-overlay-header' }),
+        }),
+      ],
+      props: expect.objectContaining({
+        pointerEvents: 'box-none',
+        style: expect.objectContaining({
+          height: FIRST_RECT.h,
+          left: FIRST_RECT.x,
+          opacity: 0.5,
+          position: 'absolute',
+          top: FIRST_RECT.y,
+          width: FIRST_RECT.w,
+        }),
+      }),
+    });
+
+    act(() => {
+      setClosingPortalLayout('overlay-header', 'second-entry', SECOND_RECT);
+    });
+
+    tree = toJSON();
+    slot = Array.isArray(tree) ? tree[0] : tree;
+
+    expect(slot).toMatchObject({
+      children: [
+        expect.objectContaining({
+          props: expect.objectContaining({ testID: 'portal-host-overlay-header' }),
+        }),
+      ],
+      props: expect.objectContaining({
+        pointerEvents: 'box-none',
+        style: expect.objectContaining({
+          height: SECOND_RECT.h,
+          left: SECOND_RECT.x,
+          opacity: 0.5,
+          position: 'absolute',
+          top: SECOND_RECT.y,
+          width: SECOND_RECT.w,
+        }),
+      }),
+    });
+
+    act(() => {
+      clearClosingPortalLayout('overlay-header', 'second-entry');
+    });
+
+    tree = toJSON();
+    slot = Array.isArray(tree) ? tree[0] : tree;
+
+    expect(slot).toMatchObject({
+      children: [
+        expect.objectContaining({
+          props: expect.objectContaining({ testID: 'portal-host-overlay-header' }),
+        }),
+      ],
+      props: expect.objectContaining({
+        pointerEvents: 'box-none',
+        style: expect.objectContaining({
+          height: FIRST_RECT.h,
+          left: FIRST_RECT.x,
+          opacity: 0.5,
+          position: 'absolute',
+          top: FIRST_RECT.y,
+          width: FIRST_RECT.w,
+        }),
+      }),
+    });
+
+    act(() => {
+      clearClosingPortalLayout('overlay-header', 'first-entry');
+    });
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders one closing host slot per host name even when multiple entries are registered', () => {
+    render(<ClosingPortalHostsLayer closeCoverOpacity={{ value: 1 } as SharedValue<number>} />);
+
+    act(() => {
+      setClosingPortalLayout('overlay-header', 'first-entry', FIRST_RECT);
+      setClosingPortalLayout('overlay-header', 'second-entry', SECOND_RECT);
+      setClosingPortalLayout('overlay-composer', 'composer-entry', {
+        h: 60,
+        w: 160,
+        x: 5,
+        y: 200,
+      });
+    });
+
+    expect(screen.getAllByTestId('portal-host-overlay-header')).toHaveLength(1);
+    expect(screen.getAllByTestId('portal-host-overlay-composer')).toHaveLength(1);
+  });
+});

--- a/package/src/contexts/overlayContext/__tests__/ClosingPortalHostsLayer.test.tsx
+++ b/package/src/contexts/overlayContext/__tests__/ClosingPortalHostsLayer.test.tsx
@@ -1,3 +1,12 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import type { SharedValue } from 'react-native-reanimated';
+
+import { act, cleanup, render, screen } from '@testing-library/react-native';
+
+import { clearClosingPortalLayout, setClosingPortalLayout } from '../../../state-store';
+import { ClosingPortalHostsLayer } from '../ClosingPortalHostsLayer';
+
 jest.mock('react-native-reanimated', () => {
   const actual = jest.requireActual('react-native-reanimated/mock');
   const { View } = require('react-native');
@@ -16,15 +25,6 @@ jest.mock('react-native-reanimated', () => {
     useAnimatedStyle: (updater: () => unknown) => updater(),
   };
 });
-
-import React from 'react';
-import { StyleSheet } from 'react-native';
-import type { SharedValue } from 'react-native-reanimated';
-
-import { act, cleanup, render, screen } from '@testing-library/react-native';
-
-import { clearClosingPortalLayout, setClosingPortalLayout } from '../../../state-store';
-import { ClosingPortalHostsLayer } from '../ClosingPortalHostsLayer';
 
 const FIRST_RECT = { h: 40, w: 100, x: 10, y: 20 };
 const SECOND_RECT = { h: 52, w: 140, x: 30, y: 45 };

--- a/package/src/contexts/overlayContext/__tests__/MessageOverlayHostLayer.test.tsx
+++ b/package/src/contexts/overlayContext/__tests__/MessageOverlayHostLayer.test.tsx
@@ -1,3 +1,20 @@
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import * as SafeAreaContext from 'react-native-safe-area-context';
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react-native';
+
+import {
+  finalizeCloseOverlay,
+  openOverlay,
+  overlayStore,
+  setOverlayBottomH,
+  setOverlayMessageH,
+  setOverlayTopH,
+} from '../../../state-store';
+import { MessageOverlayHostLayer } from '../MessageOverlayHostLayer';
+
 jest.mock('react-native', () => {
   const actual = jest.requireActual('react-native');
 
@@ -64,23 +81,6 @@ jest.mock('react-native-reanimated', () => {
     withSpring: (value: unknown) => value,
   };
 });
-
-import React from 'react';
-import { StyleSheet, Text } from 'react-native';
-
-import * as SafeAreaContext from 'react-native-safe-area-context';
-
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react-native';
-
-import {
-  finalizeCloseOverlay,
-  openOverlay,
-  overlayStore,
-  setOverlayBottomH,
-  setOverlayMessageH,
-  setOverlayTopH,
-} from '../../../state-store';
-import { MessageOverlayHostLayer } from '../MessageOverlayHostLayer';
 
 const TOP_RECT = { h: 20, w: 90, x: 5, y: 0 };
 const MESSAGE_RECT = { h: 50, w: 180, x: 10, y: 0 };

--- a/package/src/contexts/overlayContext/__tests__/MessageOverlayHostLayer.test.tsx
+++ b/package/src/contexts/overlayContext/__tests__/MessageOverlayHostLayer.test.tsx
@@ -1,0 +1,240 @@
+jest.mock('react-native', () => {
+  const actual = jest.requireActual('react-native');
+
+  return new Proxy(actual, {
+    get(target, prop, receiver) {
+      if (prop === 'useWindowDimensions') {
+        return () => ({ fontScale: 1, height: 200, scale: 1, width: 320 });
+      }
+
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+});
+
+jest.mock('react-native-reanimated', () => {
+  const React = require('react');
+  const actual = jest.requireActual('react-native-reanimated/mock');
+  const { View } = require('react-native');
+
+  const useStableSharedValue = (init: unknown) => {
+    const ref = React.useRef<{
+      value: unknown;
+    }>();
+
+    if (!ref.current) {
+      const value = { value: init };
+      ref.current = new Proxy(value, {
+        get(target, prop) {
+          if (prop === 'value') {
+            return target.value;
+          }
+
+          return undefined;
+        },
+        set(target, prop, nextValue) {
+          if (prop === 'value') {
+            target.value = nextValue;
+            return true;
+          }
+
+          return false;
+        },
+      });
+    }
+
+    return ref.current;
+  };
+
+  return {
+    ...actual,
+    Animated: {
+      ...actual.default,
+      View,
+    },
+    default: {
+      ...actual.default,
+      View,
+    },
+    clamp: (value: number, min: number, max: number) => Math.min(Math.max(value, min), max),
+    runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+    useAnimatedStyle: (updater: () => unknown) => updater(),
+    useDerivedValue: (updater: () => unknown) => ({ value: updater() }),
+    useSharedValue: useStableSharedValue,
+    withSpring: (value: unknown) => value,
+  };
+});
+
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import * as SafeAreaContext from 'react-native-safe-area-context';
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react-native';
+
+import {
+  finalizeCloseOverlay,
+  openOverlay,
+  overlayStore,
+  setOverlayBottomH,
+  setOverlayMessageH,
+  setOverlayTopH,
+} from '../../../state-store';
+import { MessageOverlayHostLayer } from '../MessageOverlayHostLayer';
+
+const TOP_RECT = { h: 20, w: 90, x: 5, y: 0 };
+const MESSAGE_RECT = { h: 50, w: 180, x: 10, y: 0 };
+const BOTTOM_RECT = { h: 30, w: 140, x: 20, y: 100 };
+const NoopBackground = () => null;
+
+const flushAnimationFrameQueue = () => {
+  act(() => {
+    jest.runAllTimers();
+  });
+};
+
+describe('MessageOverlayHostLayer', () => {
+  let useSafeAreaInsetsSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    useSafeAreaInsetsSpy = jest.spyOn(SafeAreaContext, 'useSafeAreaInsets').mockReturnValue({
+      bottom: 15,
+      left: 0,
+      right: 0,
+      top: 10,
+    });
+
+    act(() => {
+      finalizeCloseOverlay();
+      overlayStore.next({
+        closing: false,
+        closingPortalHostBlacklist: [],
+        id: undefined,
+      });
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+
+    act(() => {
+      finalizeCloseOverlay();
+      overlayStore.next({
+        closing: false,
+        closingPortalHostBlacklist: [],
+        id: undefined,
+      });
+    });
+
+    useSafeAreaInsetsSpy.mockRestore();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('renders the custom background only while active and pressing the backdrop starts closing', () => {
+    const CustomBackground = () => <Text testID='custom-background'>Background</Text>;
+    render(<MessageOverlayHostLayer BackgroundComponent={CustomBackground} />);
+
+    expect(screen.queryByTestId('custom-background')).toBeNull();
+    expect(screen.queryByTestId('message-overlay-backdrop')).toBeNull();
+
+    act(() => {
+      openOverlay('message-1');
+    });
+
+    expect(screen.getByTestId('custom-background')).toBeTruthy();
+    expect(screen.getByTestId('message-overlay-backdrop')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('message-overlay-backdrop'));
+    flushAnimationFrameQueue();
+
+    expect(overlayStore.getLatestValue().closing).toBe(true);
+  });
+
+  it('positions and translates the top, message, and bottom hosts using the registered rects', () => {
+    const { rerender } = render(<MessageOverlayHostLayer BackgroundComponent={NoopBackground} />);
+
+    act(() => {});
+
+    act(() => {
+      setOverlayTopH(TOP_RECT);
+      setOverlayMessageH(MESSAGE_RECT);
+      setOverlayBottomH(BOTTOM_RECT);
+      openOverlay('message-1');
+    });
+
+    rerender(<MessageOverlayHostLayer BackgroundComponent={NoopBackground} />);
+
+    const topSlot = screen.getByTestId('message-overlay-top');
+    const messageSlot = screen.getByTestId('message-overlay-message');
+    const bottomSlot = screen.getByTestId('message-overlay-bottom');
+
+    expect(StyleSheet.flatten(topSlot.props.style)).toMatchObject({
+      height: TOP_RECT.h,
+      left: TOP_RECT.x,
+      position: 'absolute',
+      top: TOP_RECT.y,
+      transform: [{ scale: 1 }, { translateY: 38 }],
+      width: TOP_RECT.w,
+    });
+    expect(StyleSheet.flatten(messageSlot.props.style)).toMatchObject({
+      height: MESSAGE_RECT.h,
+      left: MESSAGE_RECT.x,
+      position: 'absolute',
+      top: MESSAGE_RECT.y,
+      transform: [{ translateY: 38 }],
+      width: MESSAGE_RECT.w,
+    });
+    expect(StyleSheet.flatten(bottomSlot.props.style)).toMatchObject({
+      height: BOTTOM_RECT.h,
+      left: BOTTOM_RECT.x,
+      position: 'absolute',
+      top: BOTTOM_RECT.y,
+      transform: [{ scale: 1 }, { translateY: -12 }],
+      width: BOTTOM_RECT.w,
+    });
+  });
+
+  it('resets host geometry after finalizeCloseOverlay clears the registered rects', () => {
+    const { rerender } = render(<MessageOverlayHostLayer BackgroundComponent={NoopBackground} />);
+
+    act(() => {});
+
+    act(() => {
+      setOverlayTopH(TOP_RECT);
+      setOverlayMessageH(MESSAGE_RECT);
+      setOverlayBottomH(BOTTOM_RECT);
+      openOverlay('message-1');
+    });
+
+    rerender(<MessageOverlayHostLayer BackgroundComponent={NoopBackground} />);
+
+    expect(
+      StyleSheet.flatten(screen.getByTestId('message-overlay-message').props.style),
+    ).toMatchObject({
+      height: MESSAGE_RECT.h,
+      width: MESSAGE_RECT.w,
+    });
+
+    act(() => {
+      finalizeCloseOverlay();
+    });
+
+    rerender(<MessageOverlayHostLayer BackgroundComponent={NoopBackground} />);
+
+    expect(StyleSheet.flatten(screen.getByTestId('message-overlay-top').props.style)).toMatchObject(
+      {
+        height: 0,
+      },
+    );
+    expect(
+      StyleSheet.flatten(screen.getByTestId('message-overlay-message').props.style),
+    ).toMatchObject({ height: 0 });
+    expect(
+      StyleSheet.flatten(screen.getByTestId('message-overlay-bottom').props.style),
+    ).toMatchObject({
+      height: 0,
+    });
+  });
+});

--- a/package/src/state-store/__tests__/message-overlay-store.test.tsx
+++ b/package/src/state-store/__tests__/message-overlay-store.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+import { act, cleanup, render, renderHook, screen } from '@testing-library/react-native';
+
+import {
+  clearClosingPortalLayout,
+  closeOverlay,
+  finalizeCloseOverlay,
+  openOverlay,
+  overlayStore,
+  setClosingPortalLayout,
+  useClosingPortalHostBlacklist,
+  useClosingPortalHostBlacklistState,
+  useShouldTeleportToClosingPortal,
+} from '../message-overlay-store';
+
+const BASE_RECT = { h: 40, w: 100, x: 10, y: 20 };
+
+type RegisteredLayout = {
+  hostName: string;
+  id: string;
+};
+
+const flushAnimationFrameQueue = () => {
+  act(() => {
+    jest.runAllTimers();
+  });
+};
+
+const BlacklistRegistrar = ({
+  enabled = true,
+  hostNames,
+}: {
+  enabled?: boolean;
+  hostNames: string[];
+}) => {
+  useClosingPortalHostBlacklist(hostNames, enabled);
+  return null;
+};
+
+const BlacklistProbe = () => {
+  const hostNames = useClosingPortalHostBlacklistState();
+
+  return <Text testID='blacklist-state'>{hostNames.join(',') || 'empty'}</Text>;
+};
+
+describe('message overlay store portal hooks', () => {
+  let registeredLayouts: RegisteredLayout[] = [];
+
+  const rememberLayout = (hostName: string, id: string, layout = BASE_RECT) => {
+    registeredLayouts.push({ hostName, id });
+    act(() => {
+      setClosingPortalLayout(hostName, id, layout);
+    });
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    registeredLayouts = [];
+
+    act(() => {
+      finalizeCloseOverlay();
+      overlayStore.next({
+        closing: false,
+        closingPortalHostBlacklist: [],
+        id: undefined,
+      });
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+
+    act(() => {
+      registeredLayouts.forEach(({ hostName, id }) => {
+        clearClosingPortalLayout(hostName, id);
+      });
+      finalizeCloseOverlay();
+      overlayStore.next({
+        closing: false,
+        closingPortalHostBlacklist: [],
+        id: undefined,
+      });
+    });
+
+    registeredLayouts = [];
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('returns true only for the top-most registration when the overlay is closing', () => {
+    const first = renderHook(() => useShouldTeleportToClosingPortal('overlay-composer', 'first'));
+    const second = renderHook(() => useShouldTeleportToClosingPortal('overlay-composer', 'second'));
+
+    rememberLayout('overlay-composer', 'first');
+
+    expect(first.result.current).toBe(false);
+    expect(second.result.current).toBe(false);
+
+    act(() => {
+      openOverlay('message-1');
+      closeOverlay();
+    });
+    flushAnimationFrameQueue();
+
+    expect(first.result.current).toBe(true);
+    expect(second.result.current).toBe(false);
+
+    rememberLayout('overlay-composer', 'second', { ...BASE_RECT, x: 30, y: 50 });
+
+    expect(first.result.current).toBe(false);
+    expect(second.result.current).toBe(true);
+
+    act(() => {
+      clearClosingPortalLayout('overlay-composer', 'second');
+    });
+
+    expect(first.result.current).toBe(true);
+    expect(second.result.current).toBe(false);
+
+    first.unmount();
+    second.unmount();
+  });
+
+  it('restores the previous blacklist when the top blacklist registration disappears', () => {
+    const { rerender } = render(
+      <>
+        <BlacklistRegistrar hostNames={['overlay-header']} />
+        <BlacklistProbe />
+      </>,
+    );
+
+    expect(screen.getByTestId('blacklist-state')).toHaveTextContent('overlay-header');
+
+    rerender(
+      <>
+        <BlacklistRegistrar hostNames={['overlay-header']} />
+        <BlacklistRegistrar hostNames={['overlay-composer']} />
+        <BlacklistProbe />
+      </>,
+    );
+
+    expect(screen.getByTestId('blacklist-state')).toHaveTextContent('overlay-composer');
+
+    rerender(
+      <>
+        <BlacklistRegistrar hostNames={['overlay-header']} />
+        <BlacklistRegistrar enabled={false} hostNames={['overlay-composer']} />
+        <BlacklistProbe />
+      </>,
+    );
+
+    expect(screen.getByTestId('blacklist-state')).toHaveTextContent('overlay-header');
+
+    rerender(<BlacklistProbe />);
+
+    expect(screen.getByTestId('blacklist-state')).toHaveTextContent('empty');
+  });
+
+  it('prevents teleporting blacklisted hosts even when they are top of stack and closing', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <>
+        <BlacklistRegistrar hostNames={['overlay-composer']} />
+        {children}
+      </>
+    );
+
+    const blocked = renderHook(
+      () => useShouldTeleportToClosingPortal('overlay-composer', 'blocked'),
+      { wrapper },
+    );
+    const allowed = renderHook(
+      () => useShouldTeleportToClosingPortal('overlay-header', 'allowed'),
+      {
+        wrapper,
+      },
+    );
+
+    rememberLayout('overlay-composer', 'blocked');
+    rememberLayout('overlay-header', 'allowed', { ...BASE_RECT, x: 90, y: 120 });
+
+    act(() => {
+      openOverlay('message-1');
+      closeOverlay();
+    });
+    flushAnimationFrameQueue();
+
+    expect(blocked.result.current).toBe(false);
+    expect(allowed.result.current).toBe(true);
+
+    blocked.unmount();
+    allowed.unmount();
+  });
+});

--- a/package/src/state-store/message-overlay-store.ts
+++ b/package/src/state-store/message-overlay-store.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { makeMutable, type SharedValue } from 'react-native-reanimated';
 
@@ -8,6 +8,7 @@ import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import { useStateStore } from '../hooks';
 
 type OverlayState = {
+  closingPortalHostBlacklist: string[];
   id: string | undefined;
   closing: boolean;
 };
@@ -22,6 +23,7 @@ type ClosingPortalLayoutsState = {
 };
 
 const DefaultState = {
+  closingPortalHostBlacklist: [],
   closing: false,
   id: undefined,
 };
@@ -30,6 +32,8 @@ const DefaultClosingPortalLayoutsState: ClosingPortalLayoutsState = {
 };
 
 let closingPortalLayoutRegistrationCounter = 0;
+let closingPortalHostBlacklistRegistrationCounter = 0;
+let closingPortalHostBlacklistStack: Array<{ hostNames: string[]; id: string }> = [];
 
 type OverlaySharedValueController = {
   incrementCloseCorrectionY: (deltaY: number) => void;
@@ -69,7 +73,11 @@ export const bumpOverlayLayoutRevision = (closeCorrectionDeltaY = 0) => {
 
 export const openOverlay = (id: string) => {
   sharedValueController?.resetCloseCorrectionY();
-  overlayStore.partialNext({ closing: false, id });
+  overlayStore.partialNext({
+    closing: false,
+    closingPortalHostBlacklist: getCurrentClosingPortalHostBlacklist(),
+    id,
+  });
 };
 
 export const closeOverlay = () => {
@@ -90,7 +98,10 @@ export const scheduleActionOnClose = (action: () => void | Promise<void>) => {
 };
 
 export const finalizeCloseOverlay = () => {
-  overlayStore.partialNext(DefaultState);
+  overlayStore.next({
+    ...DefaultState,
+    closingPortalHostBlacklist: getCurrentClosingPortalHostBlacklist(),
+  });
   sharedValueController?.reset();
 };
 
@@ -101,6 +112,43 @@ const closingPortalLayoutsStore = new StateStore<ClosingPortalLayoutsState>(
 
 export const createClosingPortalLayoutRegistrationId = () =>
   `closing-portal-layout-${closingPortalLayoutRegistrationCounter++}`;
+
+const getCurrentClosingPortalHostBlacklist = () =>
+  closingPortalHostBlacklistStack[closingPortalHostBlacklistStack.length - 1]?.hostNames ?? [];
+
+const syncClosingPortalHostBlacklist = () => {
+  overlayStore.partialNext({
+    closingPortalHostBlacklist: getCurrentClosingPortalHostBlacklist(),
+  });
+};
+
+const createClosingPortalHostBlacklistRegistrationId = () =>
+  `closing-portal-host-blacklist-${closingPortalHostBlacklistRegistrationCounter++}`;
+
+const setClosingPortalHostBlacklist = (id: string, hostNames: string[]) => {
+  const existingEntryIndex = closingPortalHostBlacklistStack.findIndex((entry) => entry.id === id);
+
+  if (existingEntryIndex === -1) {
+    closingPortalHostBlacklistStack = [...closingPortalHostBlacklistStack, { hostNames, id }];
+  } else {
+    closingPortalHostBlacklistStack = closingPortalHostBlacklistStack.map((entry, index) =>
+      index === existingEntryIndex ? { ...entry, hostNames } : entry,
+    );
+  }
+
+  syncClosingPortalHostBlacklist();
+};
+
+const clearClosingPortalHostBlacklist = (id: string) => {
+  const nextBlacklistStack = closingPortalHostBlacklistStack.filter((entry) => entry.id !== id);
+
+  if (nextBlacklistStack.length === closingPortalHostBlacklistStack.length) {
+    return;
+  }
+
+  closingPortalHostBlacklistStack = nextBlacklistStack;
+  syncClosingPortalHostBlacklist();
+};
 
 export const setClosingPortalLayout = (hostName: string, id: string, layout: Rect) => {
   const { layouts } = closingPortalLayoutsStore.getLatestValue();
@@ -170,16 +218,66 @@ const overlayClosingSelector = (nextState: OverlayState) => ({
   closing: nextState.closing,
 });
 
+const closingPortalHostBlacklistSelector = (nextState: OverlayState) => ({
+  closingPortalHostBlacklist: nextState.closingPortalHostBlacklist,
+});
+
 export const useIsOverlayClosing = () => {
   return useStateStore(overlayStore, overlayClosingSelector).closing;
 };
 
+export const useClosingPortalHostBlacklistState = () => {
+  return useStateStore(overlayStore, closingPortalHostBlacklistSelector).closingPortalHostBlacklist;
+};
+
 export const useShouldTeleportToClosingPortal = (hostName: string, id: string) => {
   const closing = useIsOverlayClosing();
+  const closingPortalHostBlacklist = useClosingPortalHostBlacklistState();
   const closingPortalLayouts = useClosingPortalLayouts();
   const hostEntries = closingPortalLayouts[hostName];
 
-  return !!closing && hostEntries?.[hostEntries.length - 1]?.id === id;
+  return (
+    closing &&
+    !closingPortalHostBlacklist.includes(hostName) &&
+    hostEntries?.[hostEntries.length - 1]?.id === id
+  );
+};
+
+/**
+ * Registers a screen-level blacklist of closing portal hosts that should not render while this hook is active.
+ *
+ * The blacklist uses stack semantics:
+ * - mounting/enabling a new instance makes its blacklist active
+ * - unmounting/disabling restores the previous active blacklist automatically
+ *
+ * This keeps stacked screens predictable without requiring previous screens to rerun effects when the top screen
+ * disappears.
+ */
+export const useClosingPortalHostBlacklist = (hostNames: string[], enabled = true) => {
+  const registrationIdRef = useRef<string | null>(null);
+
+  if (!registrationIdRef.current) {
+    registrationIdRef.current = createClosingPortalHostBlacklistRegistrationId();
+  }
+
+  const registrationId = registrationIdRef.current;
+  const serializedNormalizedHostNames = JSON.stringify([...new Set(hostNames)]);
+
+  useEffect(() => {
+    if (!enabled) {
+      clearClosingPortalHostBlacklist(registrationId);
+      return;
+    }
+
+    setClosingPortalHostBlacklist(
+      registrationId,
+      JSON.parse(serializedNormalizedHostNames) as string[],
+    );
+
+    return () => {
+      clearClosingPortalHostBlacklist(registrationId);
+    };
+  }, [enabled, registrationId, serializedNormalizedHostNames]);
 };
 
 /**

--- a/package/src/state-store/message-overlay-store.ts
+++ b/package/src/state-store/message-overlay-store.ts
@@ -14,10 +14,11 @@ type OverlayState = {
 
 export type Rect = { x: number; y: number; w: number; h: number } | undefined;
 export type ClosingPortalLayoutEntry = {
+  id: string;
   layout: SharedValue<Rect>;
 };
 type ClosingPortalLayoutsState = {
-  layouts: Record<string, ClosingPortalLayoutEntry>;
+  layouts: Record<string, ClosingPortalLayoutEntry[]>;
 };
 
 const DefaultState = {
@@ -27,6 +28,8 @@ const DefaultState = {
 const DefaultClosingPortalLayoutsState: ClosingPortalLayoutsState = {
   layouts: {},
 };
+
+let closingPortalLayoutRegistrationCounter = 0;
 
 type OverlaySharedValueController = {
   incrementCloseCorrectionY: (deltaY: number) => void;
@@ -96,9 +99,13 @@ const closingPortalLayoutsStore = new StateStore<ClosingPortalLayoutsState>(
   DefaultClosingPortalLayoutsState,
 );
 
-export const setClosingPortalLayout = (hostName: string, layout: Rect) => {
+export const createClosingPortalLayoutRegistrationId = () =>
+  `closing-portal-layout-${closingPortalLayoutRegistrationCounter++}`;
+
+export const setClosingPortalLayout = (hostName: string, id: string, layout: Rect) => {
   const { layouts } = closingPortalLayoutsStore.getLatestValue();
-  const existingEntry = layouts[hostName];
+  const hostEntries = layouts[hostName] ?? [];
+  const existingEntry = hostEntries.find((entry) => entry.id === id);
 
   if (existingEntry) {
     existingEntry.layout.value = layout;
@@ -110,17 +117,28 @@ export const setClosingPortalLayout = (hostName: string, layout: Rect) => {
   closingPortalLayoutsStore.next({
     layouts: {
       ...layouts,
-      [hostName]: {
-        layout: makeMutable<Rect>(layout),
-      },
+      [hostName]: [...hostEntries, { id, layout: makeMutable<Rect>(layout) }],
     },
   });
 };
 
-export const clearClosingPortalLayout = (hostName: string) => {
+export const clearClosingPortalLayout = (hostName: string, id: string) => {
   const { layouts } = closingPortalLayoutsStore.getLatestValue();
+  const hostEntries = layouts[hostName];
+
+  if (!hostEntries?.length) {
+    return;
+  }
+
+  const nextHostEntries = hostEntries.filter((entry) => entry.id !== id);
   const nextLayouts = { ...layouts };
-  delete nextLayouts[hostName];
+
+  if (nextHostEntries.length === 0) {
+    delete nextLayouts[hostName];
+  } else {
+    nextLayouts[hostName] = nextHostEntries;
+  }
+
   closingPortalLayoutsStore.next({ layouts: nextLayouts });
 };
 
@@ -148,14 +166,31 @@ export const useOverlayController = () => {
   return useStateStore(overlayStore, selector);
 };
 
+const overlayClosingSelector = (nextState: OverlayState) => ({
+  closing: nextState.closing,
+});
+
+export const useIsOverlayClosing = () => {
+  return useStateStore(overlayStore, overlayClosingSelector).closing;
+};
+
+export const useShouldTeleportToClosingPortal = (hostName: string, id: string) => {
+  const closing = useIsOverlayClosing();
+  const closingPortalLayouts = useClosingPortalLayouts();
+  const hostEntries = closingPortalLayouts[hostName];
+
+  return !!closing && hostEntries?.[hostEntries.length - 1]?.id === id;
+};
+
 /**
  * NOTE:
  * Do not swap this back to `useStateStore(closingPortalLayoutsStore, selector)`.
  *
  * Why this is special:
  * - `layouts` is a dynamic-key map (hosts are added/removed at runtime)
+ * - each host key maintains a stack of registrations
  * - We only need React updates when the key set changes (add/remove/reset)
- * - Per-layout movement is already on UI thread via `entry.layout.value`
+ * - Per-layout movement is already on UI thread via the top `entry.layout.value`
  *
  * Why `useStateStore` is unsafe here:
  * - Both `stream-chat`'s `subscribeWithSelector` and our `useStateStore` snapshot


### PR DESCRIPTION
## 🎯 Goal

This PR changes the closing portal host registry to be stack based per host name instead of a single slot.

The reason for this is the fact that when multiple mounted screens register the same host names, the old behaviour would overwrite entries, teleport the wrong view, or briefly show stale UI during close. With stacks, the last measured host wins, and when it disappears we fall back to the previous one.

This also includes:

- hosts are only registered once they have a real measured rect
- teleporting is gated by a single check: overlay is closing, this host is on top of the stack, and it is not blacklisted
- screens can blacklist specific hosts if they should not teleport there (think, a `ChannelScreen` rendering an additional header which we don't want teleporting to `ThreadScreen`, but we don't want to unmount it either so that we don't do double the work when transitioning)
- regression tests for the overlay and closing portal flow (since the logic for all of this is quickly becoming quite complicated, these are needed)


## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


