### PR TITLE
feat: attachment customization and handle unsupported attachments

### DIFF
--- a/package/src/components/Attachment/Attachment.tsx
+++ b/package/src/components/Attachment/Attachment.tsx
@@ -13,7 +13,9 @@ import {
 
 import { AudioAttachment as AudioAttachmentDefault } from './Audio';
 
+import { UnsupportedAttachment as UnsupportedAttachmentDefault } from './UnsupportedAttachment';
 import { URLPreview as URLPreviewDefault } from './UrlPreview';
+import { URLPreviewCompact as URLPreviewCompactDefault } from './UrlPreview/URLPreviewCompact';
 
 import { FileAttachment as FileAttachmentDefault } from '../../components/Attachment/FileAttachment';
 import { Gallery as GalleryDefault } from '../../components/Attachment/Gallery';
@@ -43,7 +45,10 @@ export type AttachmentPropsWithContext = Pick<
   | 'Giphy'
   | 'isAttachmentEqual'
   | 'UrlPreview'
+  | 'URLPreviewCompact'
   | 'myMessageTheme'
+  | 'urlPreviewType'
+  | 'UnsupportedAttachment'
 > &
   Pick<MessageContextValue, 'message'> & {
     /**
@@ -64,8 +69,11 @@ const AttachmentWithContext = (props: AttachmentPropsWithContext) => {
     Gallery,
     Giphy,
     UrlPreview,
+    URLPreviewCompact,
     index,
     message,
+    urlPreviewType,
+    UnsupportedAttachment,
   } = props;
   const audioAttachmentStyles = useAudioAttachmentStyles();
 
@@ -74,6 +82,9 @@ const AttachmentWithContext = (props: AttachmentPropsWithContext) => {
   }
 
   if (attachment.og_scrape_url || attachment.title_link) {
+    if (urlPreviewType === 'compact') {
+      return <URLPreviewCompact attachment={attachment} />;
+    }
     return <UrlPreview attachment={attachment} />;
   }
 
@@ -109,8 +120,7 @@ const AttachmentWithContext = (props: AttachmentPropsWithContext) => {
     return <FileAttachment attachment={attachment} />;
   }
 
-  // TODO: Handle custom attachments
-  return <UrlPreview attachment={attachment} />;
+  return <UnsupportedAttachment attachment={attachment} />;
 };
 
 const areEqual = (prevProps: AttachmentPropsWithContext, nextProps: AttachmentPropsWithContext) => {
@@ -162,6 +172,9 @@ export const Attachment = (props: AttachmentProps) => {
     Giphy: PropGiphy,
     myMessageTheme: PropMyMessageTheme,
     UrlPreview: PropUrlPreview,
+    URLPreviewCompact: PropURLPreviewCompact,
+    urlPreviewType: PropUrlPreviewType,
+    UnsupportedAttachment: PropUnsupportedAttachment,
   } = props;
 
   const {
@@ -172,6 +185,9 @@ export const Attachment = (props: AttachmentProps) => {
     isAttachmentEqual,
     myMessageTheme: ContextMyMessageTheme,
     UrlPreview: ContextUrlPreview,
+    URLPreviewCompact: ContextURLPreviewCompact,
+    urlPreviewType: ContextUrlPreviewType,
+    UnsupportedAttachment: ContextUnsupportedAttachment,
   } = useMessagesContext();
 
   const { message } = useMessageContext();
@@ -186,6 +202,11 @@ export const Attachment = (props: AttachmentProps) => {
   const Giphy = PropGiphy || ContextGiphy || GiphyDefault;
   const UrlPreview = PropUrlPreview || ContextUrlPreview || URLPreviewDefault;
   const myMessageTheme = PropMyMessageTheme || ContextMyMessageTheme;
+  const URLPreviewCompact =
+    PropURLPreviewCompact || ContextURLPreviewCompact || URLPreviewCompactDefault;
+  const urlPreviewType = PropUrlPreviewType || ContextUrlPreviewType;
+  const UnsupportedAttachment =
+    PropUnsupportedAttachment || ContextUnsupportedAttachment || UnsupportedAttachmentDefault;
 
   return (
     <MemoizedAttachment
@@ -199,6 +220,9 @@ export const Attachment = (props: AttachmentProps) => {
         isAttachmentEqual,
         myMessageTheme,
         UrlPreview,
+        URLPreviewCompact,
+        urlPreviewType,
+        UnsupportedAttachment,
       }}
     />
   );

--- a/package/src/components/Attachment/FileAttachment.tsx
+++ b/package/src/components/Attachment/FileAttachment.tsx
@@ -3,10 +3,10 @@ import { Pressable, StyleProp, StyleSheet, TextStyle, ViewStyle } from 'react-na
 
 import type { Attachment } from 'stream-chat';
 
-import { FilePreview } from './FilePreview';
 import { openUrlSafely } from './utils/openUrlSafely';
 
-import { FileIcon as FileIconDefault, FileIconProps } from '../../components/Attachment/FileIcon';
+import { FileIconProps } from '../../components/Attachment/FileIcon';
+
 import {
   MessageContextValue,
   useMessageContext,
@@ -21,7 +21,7 @@ export type FileAttachmentPropsWithContext = Pick<
   MessageContextValue,
   'onLongPress' | 'onPress' | 'onPressIn' | 'preventPress'
 > &
-  Pick<MessagesContextValue, 'additionalPressableProps'> & {
+  Pick<MessagesContextValue, 'additionalPressableProps' | 'FilePreview'> & {
     /** The attachment to render */
     attachment: Attachment;
     attachmentIconSize?: FileIconProps['size'];
@@ -41,6 +41,7 @@ const FileAttachmentWithContext = (props: FileAttachmentPropsWithContext) => {
     additionalPressableProps,
     attachment,
     attachmentIconSize,
+    FilePreview,
     onLongPress,
     onPress,
     onPressIn,
@@ -98,14 +99,17 @@ export type FileAttachmentProps = Partial<Omit<FileAttachmentPropsWithContext, '
   Pick<FileAttachmentPropsWithContext, 'attachment'>;
 
 export const FileAttachment = (props: FileAttachmentProps) => {
+  const { FilePreview: PropFilePreview } = props;
   const { onLongPress, onPress, onPressIn, preventPress } = useMessageContext();
-  const { additionalPressableProps, FileAttachmentIcon = FileIconDefault } = useMessagesContext();
+  const { additionalPressableProps, FilePreview: ContextFilePreview } = useMessagesContext();
+
+  const FilePreview = PropFilePreview || ContextFilePreview;
 
   return (
     <FileAttachmentWithContext
       {...{
         additionalPressableProps,
-        FileAttachmentIcon,
+        FilePreview,
         onLongPress,
         onPress,
         onPressIn,

--- a/package/src/components/Attachment/FilePreview.tsx
+++ b/package/src/components/Attachment/FilePreview.tsx
@@ -30,12 +30,14 @@ export type FilePreviewProps = Partial<Pick<MessagesContextValue, 'FileAttachmen
 export const FilePreview = (props: FilePreviewProps) => {
   const {
     attachment,
+    FileAttachmentIcon: PropFileAttachmentIcon,
     attachmentIconSize,
     styles: stylesProp = {},
     titleNumberOfLines = 2,
     indicator,
   } = props;
-  const { FileAttachmentIcon = FileIconDefault } = useMessagesContext();
+  const { FileAttachmentIcon: ContextFileAttachmentIcon } = useMessagesContext();
+  const FileAttachmentIcon = PropFileAttachmentIcon || ContextFileAttachmentIcon || FileIconDefault;
 
   const styles = useStyles();
 

--- a/package/src/components/Attachment/UnsupportedAttachment.tsx
+++ b/package/src/components/Attachment/UnsupportedAttachment.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import type { Attachment } from 'stream-chat';
+
+import { FileIconProps } from './FileIcon';
+
+import {
+  MessagesContextValue,
+  useMessagesContext,
+} from '../../contexts/messagesContext/MessagesContext';
+import { useTheme } from '../../contexts/themeContext/ThemeContext';
+import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
+import { primitives } from '../../theme';
+
+export type UnsupportedAttachmentProps = Partial<
+  Pick<MessagesContextValue, 'FileAttachmentIcon'>
+> & {
+  /** The attachment to render */
+  attachment: Attachment;
+  attachmentIconSize?: FileIconProps['size'];
+};
+
+export const UnsupportedAttachment = (props: UnsupportedAttachmentProps) => {
+  const { FileAttachmentIcon: FileAttachmentIconDefault } = useMessagesContext();
+  const { attachment, attachmentIconSize, FileAttachmentIcon = FileAttachmentIconDefault } = props;
+
+  const styles = useStyles();
+
+  const {
+    theme: {
+      messageSimple: {
+        unsupportedAttachment: { container, details, title },
+      },
+    },
+  } = useTheme();
+  const { t } = useTranslationContext();
+
+  return (
+    <View style={[styles.container, container]}>
+      <FileAttachmentIcon mimeType={attachment.mime_type} size={attachmentIconSize} />
+      <View style={[styles.details, details]}>
+        <Text numberOfLines={2} style={[styles.title, title]}>
+          {attachment.title ?? t('Unsupported Attachment')}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+UnsupportedAttachment.displayName = 'UnsupportedAttachment{messageSimple{file}}';
+
+const useStyles = () => {
+  const {
+    theme: { semantics },
+  } = useTheme();
+  return useMemo(() => {
+    return StyleSheet.create({
+      container: {
+        alignItems: 'center',
+        flexDirection: 'row',
+        padding: primitives.spacingSm,
+        gap: primitives.spacingSm,
+        width: 256, // TODO: Fix this
+      },
+      details: {
+        flexShrink: 1,
+        gap: primitives.spacingXxs,
+      },
+      title: {
+        color: semantics.textPrimary,
+        fontSize: primitives.typographyFontSizeSm,
+        fontWeight: primitives.typographyFontWeightSemiBold,
+        lineHeight: primitives.typographyLineHeightTight,
+      },
+    });
+  }, [semantics]);
+};

--- a/package/src/components/Attachment/__tests__/Attachment.test.js
+++ b/package/src/components/Attachment/__tests__/Attachment.test.js
@@ -17,6 +17,7 @@ import { generateMessage } from '../../../mock-builders/generator/message';
 import { ImageLoadingFailedIndicator } from '../../Attachment/ImageLoadingFailedIndicator';
 import { ImageLoadingIndicator } from '../../Attachment/ImageLoadingIndicator';
 import { Attachment } from '../Attachment';
+import { FilePreview as FilePreviewDefault } from '../FilePreview';
 
 jest.mock('../../../native.ts', () => ({
   isVideoPlayerAvailable: jest.fn(() => false),
@@ -27,7 +28,13 @@ const getAttachmentComponent = (props) => {
   const message = generateMessage();
   return (
     <ThemeProvider>
-      <MessagesProvider value={{ ImageLoadingFailedIndicator, ImageLoadingIndicator }}>
+      <MessagesProvider
+        value={{
+          ImageLoadingFailedIndicator,
+          ImageLoadingIndicator,
+          FilePreview: FilePreviewDefault,
+        }}
+      >
         <MessageProvider value={{ message }}>
           <Attachment {...props} />
         </MessageProvider>

--- a/package/src/components/Channel/Channel.tsx
+++ b/package/src/components/Channel/Channel.tsx
@@ -115,11 +115,14 @@ import { AudioAttachment as AudioAttachmentDefault } from '../Attachment/Audio';
 import { FileAttachment as FileAttachmentDefault } from '../Attachment/FileAttachment';
 import { FileAttachmentGroup as FileAttachmentGroupDefault } from '../Attachment/FileAttachmentGroup';
 import { FileIcon as FileIconDefault } from '../Attachment/FileIcon';
+import { FilePreview as FilePreviewDefault } from '../Attachment/FilePreview';
 import { Gallery as GalleryDefault } from '../Attachment/Gallery';
 import { Giphy as GiphyDefault } from '../Attachment/Giphy';
 import { ImageLoadingFailedIndicator as ImageLoadingFailedIndicatorDefault } from '../Attachment/ImageLoadingFailedIndicator';
 import { ImageLoadingIndicator as ImageLoadingIndicatorDefault } from '../Attachment/ImageLoadingIndicator';
+import { UnsupportedAttachment as UnsupportedAttachmentDefault } from '../Attachment/UnsupportedAttachment';
 import { URLPreview as URLPreviewDefault } from '../Attachment/UrlPreview';
+import { URLPreviewCompact as URLPreviewCompactDefault } from '../Attachment/UrlPreview/URLPreviewCompact';
 import { VideoThumbnail as VideoThumbnailDefault } from '../Attachment/VideoThumbnail';
 import { AttachmentPicker } from '../AttachmentPicker/AttachmentPicker';
 import { AttachmentPickerContent as DefaultAttachmentPickerContent } from '../AttachmentPicker/components/AttachmentPickerContent';
@@ -326,9 +329,12 @@ export type ChannelPropsWithContext = Pick<ChannelContextValue, 'channel'> &
       | 'disableTypingIndicator'
       | 'dismissKeyboardOnMessageTouch'
       | 'enableSwipeToReply'
+      | 'urlPreviewType'
+      | 'UnsupportedAttachment'
       | 'FileAttachment'
       | 'FileAttachmentIcon'
       | 'FileAttachmentGroup'
+      | 'FilePreview'
       | 'FlatList'
       | 'forceAlignMessages'
       | 'Gallery'
@@ -409,6 +415,7 @@ export type ChannelPropsWithContext = Pick<ChannelContextValue, 'channel'> &
       | 'TypingIndicator'
       | 'TypingIndicatorContainer'
       | 'UrlPreview'
+      | 'URLPreviewCompact'
       | 'VideoThumbnail'
       | 'PollContent'
       | 'hasCreatePoll'
@@ -616,6 +623,7 @@ const ChannelWithContext = (props: PropsWithChildren<ChannelPropsWithContext>) =
     FileAttachmentUploadPreview = FileAttachmentUploadPreviewDefault,
     FileAttachmentGroup = FileAttachmentGroupDefault,
     FileAttachmentIcon = FileIconDefault,
+    FilePreview = FilePreviewDefault,
     FileUploadInProgressIndicator = FileUploadInProgressIndicatorDefault,
     FileUploadRetryIndicator = FileUploadRetryIndicatorDefault,
     FileUploadNotSupportedIndicator = FileUploadNotSupportedIndicatorDefault,
@@ -759,12 +767,15 @@ const ChannelWithContext = (props: PropsWithChildren<ChannelPropsWithContext>) =
     TypingIndicatorContainer = TypingIndicatorContainerDefault,
     UnreadMessagesNotification = UnreadMessagesNotificationDefault,
     UrlPreview = URLPreviewDefault,
+    URLPreviewCompact = URLPreviewCompactDefault,
     VideoAttachmentUploadPreview = VideoAttachmentUploadPreviewDefault,
     VideoThumbnail = VideoThumbnailDefault,
     isOnline,
     maximumMessageLimit,
     initializeOnMount = true,
     AttachmentPickerContent = DefaultAttachmentPickerContent,
+    urlPreviewType = 'full',
+    UnsupportedAttachment = UnsupportedAttachmentDefault,
   } = props;
 
   const { thread: threadProps, threadInstance } = threadFromProps;
@@ -1917,6 +1928,7 @@ const ChannelWithContext = (props: PropsWithChildren<ChannelPropsWithContext>) =
     FileAttachment,
     FileAttachmentGroup,
     FileAttachmentIcon,
+    FilePreview,
     FlatList,
     forceAlignMessages,
     Gallery,
@@ -2009,7 +2021,10 @@ const ChannelWithContext = (props: PropsWithChildren<ChannelPropsWithContext>) =
     UnreadMessagesNotification,
     updateMessage,
     UrlPreview,
+    URLPreviewCompact,
     VideoThumbnail,
+    urlPreviewType,
+    UnsupportedAttachment,
   });
 
   const threadContext = useCreateThreadContext({

--- a/package/src/components/Channel/__tests__/isAttachmentEqualHandler.test.js
+++ b/package/src/components/Channel/__tests__/isAttachmentEqualHandler.test.js
@@ -62,7 +62,7 @@ describe('isAttachmentEqualHandler', () => {
       <OverlayProvider>
         <Chat client={chatClient}>
           <Channel
-            UrlPreview={({ attachment: { customField, type } }) => {
+            UnsupportedAttachment={({ attachment: { customField, type } }) => {
               if (type === 'test') {
                 return <Text testID='attachment-custom-field'>{customField}</Text>;
               }

--- a/package/src/components/Channel/hooks/useCreateMessagesContext.ts
+++ b/package/src/components/Channel/hooks/useCreateMessagesContext.ts
@@ -19,6 +19,7 @@ export const useCreateMessagesContext = ({
   FileAttachment,
   FileAttachmentGroup,
   FileAttachmentIcon,
+  FilePreview,
   FlatList,
   forceAlignMessages,
   Gallery,
@@ -110,7 +111,10 @@ export const useCreateMessagesContext = ({
   UnreadMessagesNotification,
   updateMessage,
   UrlPreview,
+  URLPreviewCompact,
   VideoThumbnail,
+  urlPreviewType,
+  UnsupportedAttachment,
 }: MessagesContextValue & {
   /**
    * To ensure we allow re-render, when channel is changed
@@ -139,6 +143,7 @@ export const useCreateMessagesContext = ({
       FileAttachment,
       FileAttachmentGroup,
       FileAttachmentIcon,
+      FilePreview,
       FlatList,
       forceAlignMessages,
       Gallery,
@@ -230,7 +235,10 @@ export const useCreateMessagesContext = ({
       UnreadMessagesNotification,
       updateMessage,
       UrlPreview,
+      URLPreviewCompact,
       VideoThumbnail,
+      urlPreviewType,
+      UnsupportedAttachment,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [

--- a/package/src/contexts/messagesContext/MessagesContext.tsx
+++ b/package/src/contexts/messagesContext/MessagesContext.tsx
@@ -22,10 +22,15 @@ import type { AudioAttachmentProps } from '../../components/Attachment/Audio';
 import type { FileAttachmentProps } from '../../components/Attachment/FileAttachment';
 import type { FileAttachmentGroupProps } from '../../components/Attachment/FileAttachmentGroup';
 import type { FileIconProps } from '../../components/Attachment/FileIcon';
+import { FilePreviewProps } from '../../components/Attachment/FilePreview';
 import type { GalleryProps } from '../../components/Attachment/Gallery';
 import type { GiphyProps } from '../../components/Attachment/Giphy';
 import type { ImageLoadingFailedIndicatorProps } from '../../components/Attachment/ImageLoadingFailedIndicator';
-import type { URLPreviewProps } from '../../components/Attachment/UrlPreview';
+import { UnsupportedAttachmentProps } from '../../components/Attachment/UnsupportedAttachment';
+import type {
+  URLPreviewCompactProps,
+  URLPreviewProps,
+} from '../../components/Attachment/UrlPreview';
 import type { VideoThumbnailProps } from '../../components/Attachment/VideoThumbnail';
 import type {
   MessagePressableHandlerPayload,
@@ -129,6 +134,24 @@ export type MessagesContextValue = Pick<MessageContextValue, 'isMessageAIGenerat
   dismissKeyboardOnMessageTouch: boolean;
 
   enableMessageGroupingByUser: boolean;
+
+  /**
+   * The type of URL preview to render.
+   * Defaults to: 'full'
+   */
+  urlPreviewType: 'compact' | 'full';
+
+  /**
+   * UI component to display unsupported attachment.
+   * Defaults to: [UnsupportedAttachment](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/Attachment/UnsupportedAttachment.tsx)
+   */
+  UnsupportedAttachment: React.ComponentType<UnsupportedAttachmentProps>;
+
+  /**
+   * UI component for FilePreview
+   * Defaults to: [FilePreview](https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/Attachment/FilePreview.tsx)
+   */
+  FilePreview: React.ComponentType<FilePreviewProps>;
 
   /**
    * UI component to display File type attachment.
@@ -353,6 +376,11 @@ export type MessagesContextValue = Pick<MessageContextValue, 'isMessageAIGenerat
    * Defaults to https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/Attachment/UrlPreview/URLPreview.tsx
    */
   UrlPreview: React.ComponentType<URLPreviewProps>;
+  /**
+   * Custom UI component to display compact url preview.
+   * Defaults to https://github.com/GetStream/stream-chat-react-native/blob/main/package/src/components/Attachment/UrlPreview/URLPreviewCompact.tsx
+   */
+  URLPreviewCompact: React.ComponentType<URLPreviewCompactProps>;
   VideoThumbnail: React.ComponentType<VideoThumbnailProps>;
   /**
    * Provide any additional props for `Pressable` which wraps inner MessageContent component here.

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -641,6 +641,11 @@ export type Theme = {
       icon: IconProps;
       title: TextStyle;
     };
+    unsupportedAttachment: {
+      container: ViewStyle;
+      details: ViewStyle;
+      title: TextStyle;
+    };
     fileAttachmentGroup: {
       attachmentContainer: ViewStyle;
       container: ViewStyle;
@@ -1537,6 +1542,11 @@ export const defaultTheme: Theme = {
       details: {},
       fileSize: {},
       icon: {},
+      title: {},
+    },
+    unsupportedAttachment: {
+      container: {},
+      details: {},
       title: {},
     },
     fileAttachmentGroup: {

--- a/package/src/i18n/en.json
+++ b/package/src/i18n/en.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} members, {{onlineCount}} online",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} members, {{onlineCount}} online",
   "{{count}} unread": "{{count}} unread",
-  "{{count}} new messages": "{{count}} new messages"
+  "{{count}} new messages": "{{count}} new messages",
+  "Unsupported Attachment": "Unsupported Attachment"
 }

--- a/package/src/i18n/es.json
+++ b/package/src/i18n/es.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} miembros, {{onlineCount}} en línea",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} miembros, {{onlineCount}} en línea",
   "{{count}} unread": "{{count}} no leídos",
-  "{{count}} new messages": "{{count}} nuevos mensajes"
+  "{{count}} new messages": "{{count}} nuevos mensajes",
+  "Unsupported Attachment": "Adjunto no admitido"
 }

--- a/package/src/i18n/fr.json
+++ b/package/src/i18n/fr.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} membres, {{onlineCount}} en ligne",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} membres, {{onlineCount}} en ligne",
   "{{count}} unread": "{{count}} non lus",
-  "{{count}} new messages": "{{count}} nouveaux messages"
+  "{{count}} new messages": "{{count}} nouveaux messages",
+  "Unsupported Attachment": "Pièce jointe non prise en charge"
 }

--- a/package/src/i18n/he.json
+++ b/package/src/i18n/he.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} חברים, {{onlineCount}} מחוברים",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} חברים, {{onlineCount}} מחוברים",
   "{{count}} unread": "{{count}} שטרם נקרא",
-  "{{count}} new messages": "{{count}} הודעות חדשות"
+  "{{count}} new messages": "{{count}} הודעות חדשות",
+  "Unsupported Attachment": "קובץ לא נתמך"
 }

--- a/package/src/i18n/hi.json
+++ b/package/src/i18n/hi.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} सदस्य, {{onlineCount}} ऑनलाइन",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} सदस्य, {{onlineCount}} ऑनलाइन",
   "{{count}} unread": "{{count}} ना पढ़े हुए",
-  "{{count}} new messages": "{{count}} नये संदेश"
+  "{{count}} new messages": "{{count}} नये संदेश",
+  "Unsupported Attachment": "असमर्थित अटैचमेंट"
 }

--- a/package/src/i18n/it.json
+++ b/package/src/i18n/it.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} membri, {{onlineCount}} online",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} membri, {{onlineCount}} online",
   "{{count}} unread": "{{count}} non letti",
-  "{{count}} new messages": "{{count}} nuovi messaggi"
+  "{{count}} new messages": "{{count}} nuovi messaggi",
+  "Unsupported Attachment": "Allegato non supportato"
 }

--- a/package/src/i18n/ja.json
+++ b/package/src/i18n/ja.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}}人のメンバー、{{onlineCount}}人がオンライン",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}}人のメンバー、{{onlineCount}}人がオンライン",
   "{{count}} unread": "{{count}} 未読",
-  "{{count}} new messages": "{{count}} 新しいメッセージ"
+  "{{count}} new messages": "{{count}} 新しいメッセージ",
+  "Unsupported Attachment": "サポートされていない添付ファイル"
 }

--- a/package/src/i18n/ko.json
+++ b/package/src/i18n/ko.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}}명, {{onlineCount}}명 온라인",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}}명, {{onlineCount}}명 온라인",
   "{{count}} unread": "{{count}} 읽지 않은",
-  "{{count}} new messages": "{{count}} 새로운 메시지"
+  "{{count}} new messages": "{{count}} 새로운 메시지",
+  "Unsupported Attachment": "지원하지 않는 첨부파일"
 }

--- a/package/src/i18n/nl.json
+++ b/package/src/i18n/nl.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} leden, {{onlineCount}} online",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} leden, {{onlineCount}} online",
   "{{count}} unread": "{{count}} ongelezen",
-  "{{count}} new messages": "{{count}} nieuwe berichten"
+  "{{count}} new messages": "{{count}} nieuwe berichten",
+  "Unsupported Attachment": "Ondersteunde bijlage"
 }

--- a/package/src/i18n/pt-br.json
+++ b/package/src/i18n/pt-br.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} membros, {{onlineCount}} online",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} membros, {{onlineCount}} online",
   "{{count}} unread": "{{count}} não lidas",
-  "{{count}} new messages": "{{count}} novas mensagens"
+  "{{count}} new messages": "{{count}} novas mensagens",
+  "Unsupported Attachment": "Anexo não suportado"
 }

--- a/package/src/i18n/ru.json
+++ b/package/src/i18n/ru.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} участника, {{onlineCount}} онлайн",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} участников, {{onlineCount}} онлайн",
   "{{count}} unread": "{{count}} непрочитанных",
-  "{{count}} new messages": "{{count}} новых сообщений"
+  "{{count}} new messages": "{{count}} новых сообщений",
+  "Unsupported Attachment": "Неподдерживаемое вложение"
 }

--- a/package/src/i18n/tr.json
+++ b/package/src/i18n/tr.json
@@ -202,5 +202,6 @@
   "{{memberCount}} members, {{onlineCount}} online_other": "{{memberCount}} üye, {{onlineCount}} çevrimiçi",
   "{{memberCount}} members, {{onlineCount}} online_many": "{{memberCount}} üye, {{onlineCount}} çevrimiçi",
   "{{count}} unread": "{{count}} okunmamış",
-  "{{count}} new messages": "{{count}} yeni mesaj"
+  "{{count}} new messages": "{{count}} yeni mesaj",
+  "Unsupported Attachment": "Desteklenmeyen ek"
 }


### PR DESCRIPTION
This pull request introduces support for handling unsupported attachments and adds flexibility in rendering URL previews. The main changes include the addition of a new `UnsupportedAttachment` component, updates to context and prop handling for attachments, and improved extensibility for file and URL preview components.

**Attachment Handling Enhancements**

* Added a new `UnsupportedAttachment` component to gracefully render unsupported attachment types, with context and prop integration throughout the codebase. [[1]](diffhunk://#diff-e195456c1fd7824e506ebbae69e4344649adc9be284cb62215dc8a7c08d4ca2eR1-R78) [[2]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cL112-R123) [[3]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR48-R51) [[4]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR72-R76) [[5]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR175-R177) [[6]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR188-R190) [[7]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR205-R209) [[8]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR223-R225) [[9]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R332-R337) [[10]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R770-R778) [[11]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R2024-R2027) Ff5a4848L111R111, Ff5a4848L235R235)
* Updated tests and usages to utilize `UnsupportedAttachment` instead of `UrlPreview` for custom/unsupported types.

**URL Preview Improvements**

* Added support for a compact URL preview (`URLPreviewCompact`) and a new `urlPreviewType` prop/context, allowing selection between full and compact previews. [[1]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR16-R18) [[2]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR48-R51) [[3]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR72-R76) [[4]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR85-R87) [[5]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR175-R177) [[6]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR188-R190) [[7]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR205-R209) [[8]](diffhunk://#diff-1670642465fdc5fe8366183c13a85a345adf29ea22b903c07e0b5c8bb2c7e12cR223-R225) [[9]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R418) [[10]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R770-R778) [[11]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R2024-R2027) Ff5a4848L111R111, Ff5a4848L235R235)

**File Attachment Extensibility**

* Introduced context and prop support for a customizable `FilePreview` component, allowing easier overrides and improved testability. [[1]](diffhunk://#diff-f09731000017089225ce75654729be49248377cebfe66c4b1acd92060e357f84L6-R9) [[2]](diffhunk://#diff-f09731000017089225ce75654729be49248377cebfe66c4b1acd92060e357f84L24-R24) [[3]](diffhunk://#diff-f09731000017089225ce75654729be49248377cebfe66c4b1acd92060e357f84R44) [[4]](diffhunk://#diff-f09731000017089225ce75654729be49248377cebfe66c4b1acd92060e357f84R102-R112) [[5]](diffhunk://#diff-da00da93e87c5e0879e43ba5dcecef0891feb4fc91eca0a3943f57bf15706082R33-R40) [[6]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R118-R125) [[7]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R332-R337) [[8]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R626) [[9]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R1931) [[10]](diffhunk://#diff-d3e4f4cdcef10807a38eab86f6ead6bbfe01980e7326f3cadfeb8186760d7af1R22) [[11]](diffhunk://#diff-d3e4f4cdcef10807a38eab86f6ead6bbfe01980e7326f3cadfeb8186760d7af1R146)
* Updated tests to provide `FilePreview` via context for consistent rendering. [[1]](diffhunk://#diff-21fb4deb539ec364494b9bd30bcef64eab699f0e4dc758b859f622bf985e4a15R20) [[2]](diffhunk://#diff-21fb4deb539ec364494b9bd30bcef64eab699f0e4dc758b859f622bf985e4a15L30-R37)

**Context Propagation and Integration**

* Extended context propagation in `Channel`, `Attachment`, and related hooks to include new components and props (`UnsupportedAttachment`, `FilePreview`, `URLPreviewCompact`, `urlPreviewType`). [[1]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R118-R125) [[2]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R332-R337) [[3]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R418) [[4]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R626) [[5]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R770-R778) [[6]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R1931) [[7]](diffhunk://#diff-f7139f4cdb523365cfc277d72b827a3432325b9c6460cf14628f9df67d0e4d85R2024-R2027) [[8]](diffhunk://#diff-d3e4f4cdcef10807a38eab86f6ead6bbfe01980e7326f3cadfeb8186760d7af1R22) Ff5a4848L111R111, [[9]](diffhunk://#diff-d3e4f4cdcef10807a38eab86f6ead6bbfe01980e7326f3cadfeb8186760d7af1R146) [[10]](diffhunk://#diff-d3e4f4cdcef10807a38eab86f6ead6bbfe01980e7326f3cadfeb8186760d7af1R238-R241)

**Theming and Localization**

* The new `UnsupportedAttachment` component uses theme and translation context for styling and localization, ensuring consistent appearance and messaging.

These changes collectively improve the robustness and flexibility of attachment handling, making it easier to support new attachment types and customize their rendering.