### PR TITLE
feat: skeletons as components

### DIFF
--- a/package/expo-package/src/native/StreamShimmerViewNativeComponent.ts
+++ b/package/expo-package/src/native/StreamShimmerViewNativeComponent.ts
@@ -1,10 +1,11 @@
 import type { ColorValue, HostComponent, ViewProps } from 'react-native';
 
-import type { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
+import type { Int32, WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 export interface NativeProps extends ViewProps {
   baseColor?: ColorValue;
+  duration?: WithDefault<Int32, 1200>;
   enabled?: WithDefault<boolean, true>;
   gradientColor?: ColorValue;
 }

--- a/package/native-package/src/native/StreamShimmerViewNativeComponent.ts
+++ b/package/native-package/src/native/StreamShimmerViewNativeComponent.ts
@@ -1,10 +1,11 @@
 import type { ColorValue, HostComponent, ViewProps } from 'react-native';
 
-import type { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
+import type { Int32, WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 export interface NativeProps extends ViewProps {
   baseColor?: ColorValue;
+  duration?: WithDefault<Int32, 1200>;
   enabled?: WithDefault<boolean, true>;
   gradientColor?: ColorValue;
 }

--- a/package/shared-native/android/StreamShimmerFrameLayout.kt
+++ b/package/shared-native/android/StreamShimmerFrameLayout.kt
@@ -28,6 +28,7 @@ class StreamShimmerFrameLayout @JvmOverloads constructor(
   attrs: AttributeSet? = null,
 ) : FrameLayout(context, attrs) {
   private var baseColor: Int = DEFAULT_BASE_COLOR
+  private var durationMs: Long = DEFAULT_DURATION_MS
   private var gradientColor: Int = DEFAULT_GRADIENT_COLOR
   private var enabled: Boolean = true
 
@@ -40,6 +41,7 @@ class StreamShimmerFrameLayout @JvmOverloads constructor(
 
   private var shimmerShader: LinearGradient? = null
   private var shimmerTranslateX: Float = 0f
+  private var animatedDurationMs: Long = 0L
   private var animatedViewWidth: Float = 0f
   private var animator: ValueAnimator? = null
 
@@ -59,6 +61,14 @@ class StreamShimmerFrameLayout @JvmOverloads constructor(
     gradientColor = color
     rebuildShimmerShader()
     invalidate()
+  }
+
+  fun setDuration(duration: Int) {
+    val normalizedDurationMs =
+      if (duration > 0) duration.toLong() else DEFAULT_DURATION_MS
+    if (durationMs == normalizedDurationMs) return
+    durationMs = normalizedDurationMs
+    updateAnimatorState()
   }
 
   fun setShimmerEnabled(enabled: Boolean) {
@@ -190,16 +200,17 @@ class StreamShimmerFrameLayout @JvmOverloads constructor(
   private fun startShimmer() {
     val viewWidth = width.toFloat()
     if (viewWidth <= 0f) return
-    // Keep the existing animator if the same-sized shimmer is already active.
-    if (animator != null && animatedViewWidth == viewWidth) return
+    // Keep the existing animator only when size and duration still match the current request.
+    if (animator != null && animatedViewWidth == viewWidth && animatedDurationMs == durationMs) return
 
     stopShimmer()
 
     // Animate from fully offscreen left to fully offscreen right so the strip enters/exits cleanly.
     val shimmerWidth = (viewWidth * SHIMMER_STRIP_WIDTH_RATIO).coerceAtLeast(1f)
     animatedViewWidth = viewWidth
+    animatedDurationMs = durationMs
     animator = ValueAnimator.ofFloat(-shimmerWidth, viewWidth).apply {
-      duration = SHIMMER_DURATION_MS
+      duration = durationMs
       repeatCount = ValueAnimator.INFINITE
       interpolator = LinearInterpolator()
       addUpdateListener {
@@ -213,6 +224,7 @@ class StreamShimmerFrameLayout @JvmOverloads constructor(
   private fun stopShimmer() {
     animator?.cancel()
     animator = null
+    animatedDurationMs = 0L
     animatedViewWidth = 0f
   }
 
@@ -237,8 +249,8 @@ class StreamShimmerFrameLayout @JvmOverloads constructor(
 
   companion object {
     private const val DEFAULT_BASE_COLOR = 0x00FFFFFF
+    private const val DEFAULT_DURATION_MS = 1200L
     private const val DEFAULT_GRADIENT_COLOR = 0x59FFFFFF
-    private const val SHIMMER_DURATION_MS = 1200L
     private const val SHIMMER_STRIP_WIDTH_RATIO = 1.25f
     private const val EDGE_HIGHLIGHT_ALPHA_FACTOR = 0.1f
     private const val SOFT_HIGHLIGHT_ALPHA_FACTOR = 0.24f

--- a/package/shared-native/android/StreamShimmerViewManager.kt
+++ b/package/shared-native/android/StreamShimmerViewManager.kt
@@ -63,6 +63,10 @@ class StreamShimmerViewManager : ViewGroupManager<StreamShimmerFrameLayout>(),
     view.setBaseColor(color ?: DEFAULT_BASE_COLOR)
   }
 
+  override fun setDuration(view: StreamShimmerFrameLayout, duration: Int) {
+    view.setDuration(duration)
+  }
+
   override fun setGradientColor(view: StreamShimmerFrameLayout, color: Int?) {
     view.setGradientColor(color ?: DEFAULT_GRADIENT_COLOR)
   }

--- a/package/shared-native/ios/StreamShimmerView.swift
+++ b/package/shared-native/ios/StreamShimmerView.swift
@@ -13,8 +13,8 @@ public final class StreamShimmerView: UIView {
   private static let midHighlightAlpha: CGFloat = 0.48
   private static let innerHighlightAlpha: CGFloat = 0.72
   private static let defaultHighlightAlpha: CGFloat = 0.35
+  private static let defaultShimmerDuration: CFTimeInterval = 1.2
   private static let shimmerStripWidthRatio: CGFloat = 1.25
-  private static let shimmerDuration: CFTimeInterval = 1.2
   private static let shimmerAnimationKey = "stream_shimmer_translate_x"
 
   private let baseLayer = CALayer()
@@ -23,6 +23,8 @@ public final class StreamShimmerView: UIView {
   private var baseColor: UIColor = UIColor(white: 1, alpha: 0)
   private var gradientColor: UIColor = UIColor(white: 1, alpha: defaultHighlightAlpha)
   private var enabled = false
+  private var shimmerDuration: CFTimeInterval = defaultShimmerDuration
+  private var lastAnimatedDuration: CFTimeInterval = 0
   private var lastAnimatedSize: CGSize = .zero
   private var isAppActive = true
 
@@ -74,16 +76,19 @@ public final class StreamShimmerView: UIView {
   public func apply(
     baseColor: UIColor,
     gradientColor: UIColor,
+    durationMilliseconds: Double,
     enabled: Bool
   ) {
     self.baseColor = baseColor
     self.gradientColor = gradientColor
+    shimmerDuration = Self.normalizedDuration(milliseconds: durationMilliseconds)
     self.enabled = enabled
     updateLayersForCurrentState()
   }
 
   public func stopAnimation() {
     shimmerLayer.removeAnimation(forKey: Self.shimmerAnimationKey)
+    lastAnimatedDuration = 0
     lastAnimatedSize = .zero
   }
 
@@ -172,7 +177,10 @@ public final class StreamShimmerView: UIView {
     }
 
     // If an animation already exists for the same size, keep it running instead of restarting.
-    if shimmerLayer.animation(forKey: Self.shimmerAnimationKey) != nil, lastAnimatedSize == bounds.size {
+    if shimmerLayer.animation(forKey: Self.shimmerAnimationKey) != nil,
+      lastAnimatedSize == bounds.size,
+      lastAnimatedDuration == shimmerDuration
+    {
       return
     }
 
@@ -183,12 +191,18 @@ public final class StreamShimmerView: UIView {
     let animation = CABasicAnimation(keyPath: "transform.translation.x")
     animation.fromValue = 0
     animation.toValue = bounds.width + shimmerWidth
-    animation.duration = Self.shimmerDuration
+    animation.duration = shimmerDuration
     animation.repeatCount = .infinity
     animation.timingFunction = CAMediaTimingFunction(name: .linear)
     animation.isRemovedOnCompletion = true
     shimmerLayer.add(animation, forKey: Self.shimmerAnimationKey)
+    lastAnimatedDuration = shimmerDuration
     lastAnimatedSize = bounds.size
+  }
+
+  private static func normalizedDuration(milliseconds: Double) -> CFTimeInterval {
+    guard milliseconds > 0 else { return defaultShimmerDuration }
+    return milliseconds / 1000
   }
 
   private func color(_ color: UIColor, alphaFactor: CGFloat) -> UIColor {

--- a/package/shared-native/ios/StreamShimmerViewComponentView.mm
+++ b/package/shared-native/ios/StreamShimmerViewComponentView.mm
@@ -85,6 +85,7 @@ using namespace facebook::react;
 
   [_shimmerView applyWithBaseColor:baseColor
                      gradientColor:gradientColor
+               durationMilliseconds:newProps.duration
                            enabled:newProps.enabled];
 
   [super updateProps:props oldProps:oldProps];

--- a/package/src/components/ChannelList/Skeleton.tsx
+++ b/package/src/components/ChannelList/Skeleton.tsx
@@ -1,154 +1,65 @@
-import React, { useEffect, useMemo } from 'react';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withTiming,
-} from 'react-native-reanimated';
-import Svg, { Path, Rect, Defs, LinearGradient, Stop, ClipPath, G, Mask } from 'react-native-svg';
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
 
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
+import { primitives } from '../../theme';
+import { NativeShimmerView } from '../UIComponents/NativeShimmerView';
+
+const SkeletonBlock = ({ style }: { style: React.ComponentProps<typeof View>['style'] }) => {
+  const {
+    theme: { semantics },
+  } = useTheme();
+
+  return (
+    <View style={style}>
+      <NativeShimmerView
+        baseColor={semantics.backgroundCoreSurface}
+        gradientColor={semantics.skeletonLoadingHighlight}
+        style={StyleSheet.absoluteFillObject}
+      />
+    </View>
+  );
+};
+
+const SkeletonAvatar = () => {
+  const styles = useStyles();
+  return <SkeletonBlock style={styles.avatar} />;
+};
+
+const SkeletonTimestamp = () => {
+  const styles = useStyles();
+  return <SkeletonBlock style={styles.badge} />;
+};
+
+const SkeletonContent = () => {
+  const styles = useStyles();
+  return (
+    <View style={styles.textContainer}>
+      <View style={styles.headerRow}>
+        <SkeletonBlock style={styles.title} />
+        <SkeletonTimestamp />
+      </View>
+
+      <SkeletonBlock style={styles.subtitle} />
+    </View>
+  );
+};
 
 export const Skeleton = () => {
-  const width = useWindowDimensions().width;
-  const startOffset = useSharedValue(-width);
   const styles = useStyles();
 
   const {
     theme: {
-      channelListSkeleton: { animationTime = 1500, container, height = 80 },
-      semantics,
+      channelListSkeleton: { container, height = 80 },
     },
   } = useTheme();
 
-  useEffect(() => {
-    startOffset.value = withRepeat(
-      withTiming(width, {
-        duration: animationTime,
-        easing: Easing.linear,
-      }),
-      -1,
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const animatedStyle = useAnimatedStyle(
-    () => ({
-      transform: [{ translateX: startOffset.value }],
-    }),
-    [],
-  );
-
   return (
     <View style={[styles.container, container]} testID='channel-preview-skeleton'>
-      <Animated.View style={[animatedStyle]}>
-        <Svg width={width} height={height} viewBox='0 0 402 80' fill='none'>
-          {/* Mask */}
-          <Defs>
-            <Mask id='path-1-inside-1_5596_231135'>
-              <Path d='M0 0H402V80H0V0Z' fill='white' />
-            </Mask>
-
-            {/* Gradients */}
-            <LinearGradient
-              id='paint0_linear_5596_231135'
-              x1='48'
-              y1='24'
-              x2='0'
-              y2='24'
-              gradientUnits='userSpaceOnUse'
-            >
-              <Stop stopColor='white' />
-              <Stop offset='1' stopColor='white' stopOpacity='0' />
-            </LinearGradient>
-
-            <LinearGradient
-              id='paint1_linear_5596_231135'
-              x1='242'
-              y1='8'
-              x2='0'
-              y2='8'
-              gradientUnits='userSpaceOnUse'
-            >
-              <Stop stopColor='white' />
-              <Stop offset='1' stopColor='white' stopOpacity='0' />
-            </LinearGradient>
-
-            <LinearGradient
-              id='paint2_linear_5596_231135'
-              x1='48'
-              y1='8'
-              x2='0'
-              y2='8'
-              gradientUnits='userSpaceOnUse'
-            >
-              <Stop stopColor='white' />
-              <Stop offset='1' stopColor='white' stopOpacity='0' />
-            </LinearGradient>
-
-            <LinearGradient
-              id='paint3_linear_5596_231135'
-              x1='199'
-              y1='8'
-              x2='0'
-              y2='8'
-              gradientUnits='userSpaceOnUse'
-            >
-              <Stop stopColor='white' />
-              <Stop offset='1' stopColor='white' stopOpacity='0' />
-            </LinearGradient>
-
-            {/* ClipPaths */}
-            <ClipPath id='clip0_5596_231135'>
-              <Path d='M16 40C16 26.7452 26.7452 16 40 16C53.2548 16 64 26.7452 64 40C64 53.2548 53.2548 64 40 64C26.7452 64 16 53.2548 16 40Z' />
-            </ClipPath>
-
-            <ClipPath id='clip1_5596_231135'>
-              <Path d='M80 28C80 23.5817 83.5817 20 88 20H314C318.418 20 322 23.5817 322 28C322 32.4183 318.418 36 314 36H88C83.5817 60 80 56.4183 80 52Z' />
-            </ClipPath>
-
-            <ClipPath id='clip2_5596_231135'>
-              <Path d='M338 28C338 23.5817 341.582 20 346 20H378C382.418 20 386 23.5817 386 28C386 32.4183 382.418 36 378 36H346C341.582 36 338 32.4183 338 28Z' />
-            </ClipPath>
-          </Defs>
-
-          {/* Avatar */}
-          <G clipPath='url(#clip0_5596_231135)'>
-            <Path
-              d='M16 40C16 26.7452 26.7452 16 40 16C53.2548 16 64 26.7452 64 40C64 53.2548 53.2548 64 40 64C26.7452 64 16 53.2548 16 40Z'
-              fill={semantics.backgroundCoreSurface}
-            />
-            <Rect width='48' height='48' x='16' y='16' fill='url(#paint0_linear_5596_231135)' />
-          </G>
-
-          {/* Title */}
-          <G clipPath='url(#clip1_5596_231135)'>
-            <Path
-              d='M80 28C80 23.5817 83.5817 20 88 20H314C318.418 20 322 23.5817 322 28C322 32.4183 318.418 36 314 36H88C83.5817 36 80 32.4183 80 28Z'
-              fill={semantics.backgroundCoreSurface}
-            />
-            <Rect width='242' height='16' x='80' y='20' fill='url(#paint1_linear_5596_231135)' />
-          </G>
-
-          {/* Badge */}
-          <G clipPath='url(#clip2_5596_231135)'>
-            <Path
-              d='M338 28C338 23.5817 341.582 20 346 20H378C382.418 20 386 23.5817 386 28C386 32.4183 382.418 36 378 36H346C341.582 36 338 32.4183 338 28Z'
-              fill={semantics.backgroundCoreSurface}
-            />
-            <Rect width='48' height='16' x='338' y='20' fill='url(#paint2_linear_5596_231135)' />
-          </G>
-
-          {/* Subtitle */}
-          <Path
-            d='M80 52C80 47.5817 83.5817 44 88 44H272C276.418 44 280 47.5817 280 52C280 56.4183 276.418 60 272 60H88C83.5817 60 80 56.4183 80 52Z'
-            fill={semantics.backgroundCoreSurface}
-          />
-          <Rect width='199' height='16' x='80' y='44' fill='url(#paint3_linear_5596_231135)' />
-        </Svg>
-      </Animated.View>
+      <View style={[styles.content, { height }]}>
+        <SkeletonAvatar />
+        <SkeletonContent />
+      </View>
     </View>
   );
 };
@@ -162,11 +73,53 @@ const useStyles = () => {
 
   return useMemo(() => {
     return StyleSheet.create({
+      avatar: {
+        borderRadius: primitives.radiusMax,
+        height: 48,
+        overflow: 'hidden',
+        width: 48,
+      },
+      badge: {
+        borderRadius: primitives.radiusMax,
+        width: 48,
+        height: 16,
+        minWidth: 0,
+        overflow: 'hidden',
+      },
       container: {
+        borderBottomColor: semantics.borderCoreSubtle,
         borderBottomWidth: 1,
         flexDirection: 'row',
-        borderBottomColor: semantics.borderCoreDefault,
+      },
+      content: {
+        alignItems: 'center',
+        flexDirection: 'row',
+        gap: primitives.spacingMd,
+        padding: primitives.spacingMd,
+        width: '100%',
+      },
+      headerRow: {
+        alignItems: 'center',
+        flexDirection: 'row',
+        gap: primitives.spacingMd,
+        width: '100%',
+      },
+      subtitle: {
+        borderRadius: primitives.radiusMax,
+        height: primitives.spacingMd,
+        overflow: 'hidden',
+        width: '65%',
+      },
+      textContainer: {
+        flex: 1,
+        gap: primitives.spacingXs,
+      },
+      title: {
+        borderRadius: primitives.radiusMax,
+        flex: 1,
+        height: 16,
+        overflow: 'hidden',
       },
     });
-  }, [semantics]);
+  }, [semantics.borderCoreDefault]);
 };

--- a/package/src/components/ChannelList/Skeleton.tsx
+++ b/package/src/components/ChannelList/Skeleton.tsx
@@ -7,13 +7,17 @@ import { NativeShimmerView } from '../UIComponents/NativeShimmerView';
 
 const SkeletonBlock = ({ style }: { style: React.ComponentProps<typeof View>['style'] }) => {
   const {
-    theme: { semantics },
+    theme: {
+      channelListSkeleton: { animationTime },
+      semantics,
+    },
   } = useTheme();
 
   return (
     <View style={style}>
       <NativeShimmerView
         baseColor={semantics.backgroundCoreSurface}
+        duration={animationTime}
         gradientColor={semantics.skeletonLoadingHighlight}
         style={StyleSheet.absoluteFillObject}
       />

--- a/package/src/components/ChannelList/Skeleton.tsx
+++ b/package/src/components/ChannelList/Skeleton.tsx
@@ -48,14 +48,8 @@ const SkeletonContent = () => {
 export const Skeleton = () => {
   const styles = useStyles();
 
-  const {
-    theme: {
-      channelListSkeleton: { container },
-    },
-  } = useTheme();
-
   return (
-    <View style={[styles.container, container]} testID='channel-preview-skeleton'>
+    <View style={styles.container} testID='channel-preview-skeleton'>
       <View style={styles.content}>
         <SkeletonAvatar />
         <SkeletonContent />
@@ -68,7 +62,7 @@ Skeleton.displayName = 'Skeleton{channelListSkeleton}';
 
 const useStyles = () => {
   const {
-    theme: { semantics },
+    theme: { channelListSkeleton, semantics },
   } = useTheme();
 
   return useMemo(() => {
@@ -78,18 +72,21 @@ const useStyles = () => {
         height: 48,
         overflow: 'hidden',
         width: 48,
+        ...channelListSkeleton.avatar,
       },
       badge: {
         borderRadius: primitives.radiusMax,
-        width: 48,
         height: 16,
         minWidth: 0,
         overflow: 'hidden',
+        width: 48,
+        ...channelListSkeleton.badge,
       },
       container: {
         borderBottomColor: semantics.borderCoreSubtle,
         borderBottomWidth: 1,
         flexDirection: 'row',
+        ...channelListSkeleton.container,
       },
       content: {
         alignItems: 'center',
@@ -97,29 +94,34 @@ const useStyles = () => {
         gap: primitives.spacingMd,
         padding: primitives.spacingMd,
         width: '100%',
+        ...channelListSkeleton.content,
       },
       headerRow: {
         alignItems: 'center',
         flexDirection: 'row',
         gap: primitives.spacingMd,
         width: '100%',
+        ...channelListSkeleton.headerRow,
       },
       subtitle: {
         borderRadius: primitives.radiusMax,
         height: primitives.spacingMd,
         overflow: 'hidden',
         width: '65%',
+        ...channelListSkeleton.subtitle,
       },
       textContainer: {
         flex: 1,
         gap: primitives.spacingXs,
+        ...channelListSkeleton.textContainer,
       },
       title: {
         borderRadius: primitives.radiusMax,
         flex: 1,
         height: 16,
         overflow: 'hidden',
+        ...channelListSkeleton.title,
       },
     });
-  }, [semantics.borderCoreSubtle]);
+  }, [channelListSkeleton, semantics.borderCoreSubtle]);
 };

--- a/package/src/components/ChannelList/Skeleton.tsx
+++ b/package/src/components/ChannelList/Skeleton.tsx
@@ -50,13 +50,13 @@ export const Skeleton = () => {
 
   const {
     theme: {
-      channelListSkeleton: { container, height = 80 },
+      channelListSkeleton: { container },
     },
   } = useTheme();
 
   return (
     <View style={[styles.container, container]} testID='channel-preview-skeleton'>
-      <View style={[styles.content, { height }]}>
+      <View style={styles.content}>
         <SkeletonAvatar />
         <SkeletonContent />
       </View>
@@ -121,5 +121,5 @@ const useStyles = () => {
         overflow: 'hidden',
       },
     });
-  }, [semantics.borderCoreDefault]);
+  }, [semantics.borderCoreSubtle]);
 };

--- a/package/src/components/ThreadList/ThreadListItemSkeleton.tsx
+++ b/package/src/components/ThreadList/ThreadListItemSkeleton.tsx
@@ -7,13 +7,17 @@ import { NativeShimmerView } from '../UIComponents/NativeShimmerView';
 
 const SkeletonBlock = ({ style }: { style: React.ComponentProps<typeof View>['style'] }) => {
   const {
-    theme: { semantics },
+    theme: {
+      semantics,
+      threadListSkeleton: { animationTime },
+    },
   } = useTheme();
 
   return (
     <View style={style}>
       <NativeShimmerView
         baseColor={semantics.backgroundCoreSurface}
+        duration={animationTime}
         gradientColor={semantics.skeletonLoadingHighlight}
         style={StyleSheet.absoluteFillObject}
       />

--- a/package/src/components/ThreadList/ThreadListItemSkeleton.tsx
+++ b/package/src/components/ThreadList/ThreadListItemSkeleton.tsx
@@ -1,268 +1,83 @@
-import React, { useEffect, useMemo } from 'react';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withTiming,
-} from 'react-native-reanimated';
-import Svg, { Path, Rect, Defs, LinearGradient, Stop, ClipPath, G, Mask } from 'react-native-svg';
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
 
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
+import { primitives } from '../../theme';
+import { NativeShimmerView } from '../UIComponents/NativeShimmerView';
+
+const SkeletonBlock = ({ style }: { style: React.ComponentProps<typeof View>['style'] }) => {
+  const {
+    theme: { semantics },
+  } = useTheme();
+
+  return (
+    <View style={style}>
+      <NativeShimmerView
+        baseColor={semantics.backgroundCoreSurface}
+        gradientColor={semantics.skeletonLoadingHighlight}
+        style={StyleSheet.absoluteFillObject}
+      />
+    </View>
+  );
+};
+
+const SkeletonAvatar = () => {
+  const styles = useStyles();
+  return <SkeletonBlock style={styles.avatar} />;
+};
+
+const SkeletonTimestamp = () => {
+  const styles = useStyles();
+  return <SkeletonBlock style={styles.timestamp} />;
+};
+
+const SkeletonFooter = () => {
+  const styles = useStyles();
+
+  return (
+    <View style={styles.footerRow}>
+      <SkeletonBlock style={styles.footerIcon} />
+      <SkeletonBlock style={styles.footerPill} />
+      <SkeletonBlock style={styles.footerPill} />
+    </View>
+  );
+};
+
+const SkeletonContent = () => {
+  const styles = useStyles();
+
+  return (
+    <View style={styles.textContainer}>
+      <View style={styles.contentContainer}>
+        <SkeletonBlock style={styles.headerLabel} />
+        <SkeletonBlock style={styles.body} />
+      </View>
+      <SkeletonFooter />
+    </View>
+  );
+};
 
 export const ThreadListItemSkeleton = () => {
-  const width = useWindowDimensions().width;
-  const startOffset = useSharedValue(-width);
   const styles = useStyles();
 
   const {
     theme: {
-      channelListSkeleton: { animationTime = 1500, container, height = 112 },
-      semantics,
+      threadListSkeleton: { container },
     },
   } = useTheme();
 
-  useEffect(() => {
-    startOffset.value = withRepeat(
-      withTiming(width, {
-        duration: animationTime,
-        easing: Easing.linear,
-      }),
-      -1,
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const animatedStyle = useAnimatedStyle(
-    () => ({
-      transform: [{ translateX: startOffset.value }],
-    }),
-    [],
-  );
-
   return (
     <View style={[styles.container, container]} testID='channel-preview-skeleton'>
-      <Animated.View style={[animatedStyle]}>
-        <Svg width={width} height={height} viewBox={`0 0 402 112`} fill='none'>
-          <Mask id='path-1-inside-1_6371_335396'>
-            <Path d='M0 0H402V112H0V0Z' fill='white' />
-          </Mask>
-          <Path
-            d='M402 112V111H0V112V113H402V112Z'
-            fill={semantics.backgroundCoreSurface}
-            mask='url(#path-1-inside-1_6371_335396)'
-          />
-          <G clip-path='url(#clip0_6371_335396)'>
-            <Path
-              d='M16 40C16 26.7452 26.7452 16 40 16C53.2548 16 64 26.7452 64 40C64 53.2548 53.2548 64 40 64C26.7452 64 16 53.2548 16 40Z'
-              fill={semantics.backgroundCoreSurface}
-            />
-            <Rect
-              width='48'
-              height='48'
-              transform='translate(16 16)'
-              fill='url(#paint0_linear_6371_335396)'
-            />
-          </G>
-          <G clip-path='url(#clip1_6371_335396)'>
-            <Path
-              d='M76 26C76 22.6863 78.6863 20 82 20H190C193.314 20 196 22.6863 196 26C196 29.3137 193.314 32 190 32H82C78.6863 32 76 29.3137 76 26Z'
-              fill={semantics.backgroundCoreSurface}
-            />
-            <Rect
-              width='120'
-              height='12'
-              transform='translate(76 20)'
-              fill='url(#paint1_linear_6371_335396)'
-            />
-          </G>
-          <G clip-path='url(#clip2_6371_335396)'>
-            <Path
-              d='M76 50C76 44.4772 80.4772 40 86 40H316C321.523 40 326 44.4772 326 50C326 55.5228 321.523 60 316 60H86C80.4772 60 76 55.5228 76 50Z'
-              fill={semantics.backgroundCoreSurface}
-            />
-            <Rect
-              width='250'
-              height='20'
-              transform='translate(76 40)'
-              fill='url(#paint2_linear_6371_335396)'
-            />
-          </G>
-          <G clip-path='url(#clip3_6371_335396)'>
-            <Path
-              d='M76 84C76 77.3726 81.3726 72 88 72C94.6274 72 100 77.3726 100 84C100 90.6274 94.6274 96 88 96C81.3726 96 76 90.6274 76 84Z'
-              fill={semantics.backgroundCoreSurface}
-            />
-            <Rect
-              width='24'
-              height='24'
-              transform='translate(76 72)'
-              fill='url(#paint3_linear_6371_335396)'
-            />
-          </G>
-          <G clip-path='url(#clip4_6371_335396)'>
-            <Path
-              d='M108 84C108 80.6863 110.686 78 114 78H166C169.314 78 172 80.6863 172 84C172 87.3137 169.314 90 166 90H114C110.686 90 108 87.3137 108 84Z'
-              fill={semantics.backgroundCoreSurface}
-            />
-            <Rect
-              width='64'
-              height='12'
-              transform='translate(108 78)'
-              fill='url(#paint4_linear_6371_335396)'
-            />
-          </G>
-          <G clip-path='url(#clip5_6371_335396)'>
-            <Path
-              d='M180 84C180 80.6863 182.686 78 186 78H238C241.314 78 244 80.6863 244 84C244 87.3137 241.314 90 238 90H186C182.686 90 180 87.3137 180 84Z'
-              fill={semantics.backgroundCoreSurface}
-            />
-            <Rect
-              width='64'
-              height='12'
-              transform='translate(180 78)'
-              fill='url(#paint5_linear_6371_335396)'
-            />
-          </G>
-          <G clip-path='url(#clip6_6371_335396)'>
-            <Path
-              d='M338 24C338 19.5817 341.582 16 346 16H378C382.418 16 386 19.5817 386 24C386 28.4183 382.418 32 378 32H346C341.582 32 338 28.4183 338 24Z'
-              fill={semantics.backgroundCoreSurface}
-            />
-            <Rect
-              width='48'
-              height='16'
-              transform='translate(338 16)'
-              fill='url(#paint6_linear_6371_335396)'
-            />
-          </G>
-          <Defs>
-            <LinearGradient
-              id='paint0_linear_6371_335396'
-              x1='48'
-              y1='24'
-              x2='-1.5262e-07'
-              y2='24'
-              gradientUnits='userSpaceOnUse'
-            >
-              <Stop stopColor='white' />
-              <Stop offset='1' stopColor='white' stopOpacity='0' />
-            </LinearGradient>
-            <LinearGradient
-              id='paint1_linear_6371_335396'
-              x1='120'
-              y1='6'
-              x2='-3.8155e-07'
-              y2='5.99999'
-              gradientUnits='userSpaceOnUse'
-            >
-              <Stop stopColor='white' />
-              <Stop offset='1' stopColor='white' stopOpacity='0' />
-            </LinearGradient>
-            <LinearGradient
-              id='paint2_linear_6371_335396'
-              x1='250'
-              y1='10'
-              x2='-7.94895e-07'
-              y2='9.99998'
-              gradientUnits='userSpaceOnUse'
-            >
-              <Stop stopColor='white' />
-              <Stop offset='1' stopColor='white' stopOpacity='0' />
-            </LinearGradient>
-            <LinearGradient
-              id='paint3_linear_6371_335396'
-              x1='24'
-              y1='12'
-              x2='-7.63101e-08'
-              y2='12'
-              gradientUnits='userSpaceOnUse'
-            >
-              <Stop stopColor='white' />
-              <Stop offset='1' stopColor='white' stopOpacity='0' />
-            </LinearGradient>
-            <LinearGradient
-              id='paint4_linear_6371_335396'
-              x1='64'
-              y1='6'
-              x2='-2.03494e-07'
-              y2='6'
-              gradientUnits='userSpaceOnUse'
-            >
-              <Stop stopColor='white' />
-              <Stop offset='1' stopColor='white' stopOpacity='0' />
-            </LinearGradient>
-            <LinearGradient
-              id='paint5_linear_6371_335396'
-              x1='64'
-              y1='6'
-              x2='-2.03494e-07'
-              y2='6'
-              gradientUnits='userSpaceOnUse'
-            >
-              <Stop stopColor='white' />
-              <Stop offset='1' stopColor='white' stopOpacity='0' />
-            </LinearGradient>
-            <LinearGradient
-              id='paint6_linear_6371_335396'
-              x1='48'
-              y1='8'
-              x2='-1.5262e-07'
-              y2='8'
-              gradientUnits='userSpaceOnUse'
-            >
-              <Stop stopColor='white' />
-              <Stop offset='1' stopColor='white' stopOpacity='0' />
-            </LinearGradient>
-            <ClipPath id='clip0_6371_335396'>
-              <Path
-                d='M16 40C16 26.7452 26.7452 16 40 16C53.2548 16 64 26.7452 64 40C64 53.2548 53.2548 64 40 64C26.7452 64 16 53.2548 16 40Z'
-                fill='white'
-              />
-            </ClipPath>
-            <ClipPath id='clip1_6371_335396'>
-              <Path
-                d='M76 26C76 22.6863 78.6863 20 82 20H190C193.314 20 196 22.6863 196 26C196 29.3137 193.314 32 190 32H82C78.6863 32 76 29.3137 76 26Z'
-                fill='white'
-              />
-            </ClipPath>
-            <ClipPath id='clip2_6371_335396'>
-              <Path
-                d='M76 50C76 44.4772 80.4772 40 86 40H316C321.523 40 326 44.4772 326 50C326 55.5228 321.523 60 316 60H86C80.4772 60 76 55.5228 76 50Z'
-                fill='white'
-              />
-            </ClipPath>
-            <ClipPath id='clip3_6371_335396'>
-              <Path
-                d='M76 84C76 77.3726 81.3726 72 88 72C94.6274 72 100 77.3726 100 84C100 90.6274 94.6274 96 88 96C81.3726 96 76 90.6274 76 84Z'
-                fill='white'
-              />
-            </ClipPath>
-            <ClipPath id='clip4_6371_335396'>
-              <Path
-                d='M108 84C108 80.6863 110.686 78 114 78H166C169.314 78 172 80.6863 172 84C172 87.3137 169.314 90 166 90H114C110.686 90 108 87.3137 108 84Z'
-                fill='white'
-              />
-            </ClipPath>
-            <ClipPath id='clip5_6371_335396'>
-              <Path
-                d='M180 84C180 80.6863 182.686 78 186 78H238C241.314 78 244 80.6863 244 84C244 87.3137 241.314 90 238 90H186C182.686 90 180 87.3137 180 84Z'
-                fill='white'
-              />
-            </ClipPath>
-            <ClipPath id='clip6_6371_335396'>
-              <Path
-                d='M338 24C338 19.5817 341.582 16 346 16H378C382.418 16 386 19.5817 386 24C386 28.4183 382.418 32 378 32H346C341.582 32 338 28.4183 338 24Z'
-                fill='white'
-              />
-            </ClipPath>
-          </Defs>
-        </Svg>
-      </Animated.View>
+      <View style={styles.content}>
+        <SkeletonAvatar />
+        <SkeletonContent />
+        <SkeletonTimestamp />
+      </View>
     </View>
   );
 };
+
+ThreadListItemSkeleton.displayName = 'ThreadListItemSkeleton{threadListSkeleton}';
 
 const useStyles = () => {
   const {
@@ -271,11 +86,66 @@ const useStyles = () => {
 
   return useMemo(() => {
     return StyleSheet.create({
+      avatar: {
+        borderRadius: primitives.radiusMax,
+        height: 48,
+        overflow: 'hidden',
+        width: 48,
+      },
+      body: {
+        borderRadius: primitives.radiusMax,
+        height: 20,
+        overflow: 'hidden',
+      },
       container: {
+        borderBottomColor: semantics.borderCoreSubtle,
         borderBottomWidth: 1,
         flexDirection: 'row',
-        borderBottomColor: semantics.borderCoreDefault,
+      },
+      content: {
+        alignItems: 'flex-start',
+        flexDirection: 'row',
+        gap: primitives.spacingSm,
+        padding: primitives.spacingMd,
+        width: '100%',
+      },
+      footerIcon: {
+        borderRadius: primitives.radiusMax,
+        height: 24,
+        overflow: 'hidden',
+        width: 24,
+      },
+      footerPill: {
+        borderRadius: primitives.radiusMax,
+        width: 64,
+        height: 12,
+        overflow: 'hidden',
+      },
+      footerRow: {
+        alignItems: 'center',
+        flexDirection: 'row',
+        gap: primitives.spacingXs,
+      },
+      headerLabel: {
+        borderRadius: primitives.radiusMax,
+        height: 12,
+        overflow: 'hidden',
+        width: '40%',
+      },
+      textContainer: {
+        flex: 1,
+        gap: primitives.spacingXs,
+      },
+      contentContainer: {
+        paddingVertical: primitives.spacingXxs,
+        gap: primitives.spacingXs,
+      },
+      timestamp: {
+        borderRadius: primitives.radiusMax,
+        height: 16,
+        overflow: 'hidden',
+        width: 48,
       },
     });
-  }, [semantics]);
+  }, [semantics.borderCoreSubtle]);
 };

--- a/package/src/components/ThreadList/ThreadListItemSkeleton.tsx
+++ b/package/src/components/ThreadList/ThreadListItemSkeleton.tsx
@@ -60,14 +60,8 @@ const SkeletonContent = () => {
 export const ThreadListItemSkeleton = () => {
   const styles = useStyles();
 
-  const {
-    theme: {
-      threadListSkeleton: { container },
-    },
-  } = useTheme();
-
   return (
-    <View style={[styles.container, container]} testID='channel-preview-skeleton'>
+    <View style={styles.container} testID='channel-preview-skeleton'>
       <View style={styles.content}>
         <SkeletonAvatar />
         <SkeletonContent />
@@ -81,7 +75,7 @@ ThreadListItemSkeleton.displayName = 'ThreadListItemSkeleton{threadListSkeleton}
 
 const useStyles = () => {
   const {
-    theme: { semantics },
+    theme: { semantics, threadListSkeleton },
   } = useTheme();
 
   return useMemo(() => {
@@ -91,16 +85,19 @@ const useStyles = () => {
         height: 48,
         overflow: 'hidden',
         width: 48,
+        ...threadListSkeleton.avatar,
       },
       body: {
         borderRadius: primitives.radiusMax,
         height: 20,
         overflow: 'hidden',
+        ...threadListSkeleton.body,
       },
       container: {
         borderBottomColor: semantics.borderCoreSubtle,
         borderBottomWidth: 1,
         flexDirection: 'row',
+        ...threadListSkeleton.container,
       },
       content: {
         alignItems: 'flex-start',
@@ -108,44 +105,52 @@ const useStyles = () => {
         gap: primitives.spacingSm,
         padding: primitives.spacingMd,
         width: '100%',
+        ...threadListSkeleton.content,
+      },
+      contentContainer: {
+        gap: primitives.spacingXs,
+        paddingVertical: primitives.spacingXxs,
+        ...threadListSkeleton.contentContainer,
       },
       footerIcon: {
         borderRadius: primitives.radiusMax,
         height: 24,
         overflow: 'hidden',
         width: 24,
+        ...threadListSkeleton.footerIcon,
       },
       footerPill: {
         borderRadius: primitives.radiusMax,
-        width: 64,
         height: 12,
         overflow: 'hidden',
+        width: 64,
+        ...threadListSkeleton.footerPill,
       },
       footerRow: {
         alignItems: 'center',
         flexDirection: 'row',
         gap: primitives.spacingXs,
+        ...threadListSkeleton.footerRow,
       },
       headerLabel: {
         borderRadius: primitives.radiusMax,
         height: 12,
         overflow: 'hidden',
         width: '40%',
+        ...threadListSkeleton.headerLabel,
       },
       textContainer: {
         flex: 1,
         gap: primitives.spacingXs,
-      },
-      contentContainer: {
-        paddingVertical: primitives.spacingXxs,
-        gap: primitives.spacingXs,
+        ...threadListSkeleton.textContainer,
       },
       timestamp: {
         borderRadius: primitives.radiusMax,
         height: 16,
         overflow: 'hidden',
         width: 48,
+        ...threadListSkeleton.timestamp,
       },
     });
-  }, [semantics.borderCoreSubtle]);
+  }, [semantics.borderCoreSubtle, threadListSkeleton]);
 };

--- a/package/src/components/UIComponents/NativeShimmerView.tsx
+++ b/package/src/components/UIComponents/NativeShimmerView.tsx
@@ -5,6 +5,7 @@ import { NativeHandlers } from '../../native';
 
 export type NativeShimmerViewProps = ViewProps & {
   baseColor?: ColorValue;
+  duration?: number;
   enabled?: boolean;
   gradientColor?: ColorValue;
 };

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -183,11 +183,28 @@ export type Theme = {
   };
   channelListSkeleton: {
     animationTime: number;
+    avatar: ViewStyle;
+    badge: ViewStyle;
+    content: ViewStyle;
     container: ViewStyle;
+    headerRow: ViewStyle;
+    subtitle: ViewStyle;
+    textContainer: ViewStyle;
+    title: ViewStyle;
   };
   threadListSkeleton: {
     animationTime: number;
+    avatar: ViewStyle;
+    body: ViewStyle;
+    content: ViewStyle;
+    contentContainer: ViewStyle;
     container: ViewStyle;
+    footerIcon: ViewStyle;
+    footerPill: ViewStyle;
+    footerRow: ViewStyle;
+    headerLabel: ViewStyle;
+    textContainer: ViewStyle;
+    timestamp: ViewStyle;
   };
   colors: typeof Colors;
   channelPreview: {
@@ -1091,11 +1108,28 @@ export const defaultTheme: Theme = {
   },
   channelListSkeleton: {
     animationTime: 1500, // in milliseconds
+    avatar: {},
+    badge: {},
+    content: {},
     container: {},
+    headerRow: {},
+    subtitle: {},
+    textContainer: {},
+    title: {},
   },
   threadListSkeleton: {
     animationTime: 1500, // in milliseconds
+    avatar: {},
+    body: {},
+    content: {},
+    contentContainer: {},
     container: {},
+    footerIcon: {},
+    footerPill: {},
+    footerRow: {},
+    headerLabel: {},
+    textContainer: {},
+    timestamp: {},
   },
   channelPreview: {
     container: {},

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -1107,7 +1107,7 @@ export const defaultTheme: Theme = {
     },
   },
   channelListSkeleton: {
-    animationTime: 1500, // in milliseconds
+    animationTime: 1000, // in milliseconds
     avatar: {},
     badge: {},
     content: {},
@@ -1118,7 +1118,7 @@ export const defaultTheme: Theme = {
     title: {},
   },
   threadListSkeleton: {
-    animationTime: 1500, // in milliseconds
+    animationTime: 1000, // in milliseconds
     avatar: {},
     body: {},
     content: {},

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -184,7 +184,10 @@ export type Theme = {
   channelListSkeleton: {
     animationTime: number;
     container: ViewStyle;
-    height: number;
+  };
+  threadListSkeleton: {
+    animationTime: number;
+    container: ViewStyle;
   };
   colors: typeof Colors;
   channelPreview: {
@@ -1089,7 +1092,10 @@ export const defaultTheme: Theme = {
   channelListSkeleton: {
     animationTime: 1500, // in milliseconds
     container: {},
-    height: 80,
+  },
+  threadListSkeleton: {
+    animationTime: 1500, // in milliseconds
+    container: {},
   },
   channelPreview: {
     container: {},

--- a/package/src/native.ts
+++ b/package/src/native.ts
@@ -295,6 +295,7 @@ export type VideoType = {
 
 export type NativeShimmerViewProps = ViewProps & {
   baseColor?: ColorValue;
+  duration?: number;
   enabled?: boolean;
   gradientColor?: ColorValue;
 };


### PR DESCRIPTION
## 🎯 Goal

This PR introduces the `ChannelList` and `ThreadList` loading indicator `Skeleton`s as actual RN components, rather than SVGs. There is no reason for these to be SVGs nor does it help with anything specific. 

Additionally, we utilize the new `NativeShimmerView` from the SDK in order to apply a nice and performant shimmering effect on the skeletons. To achieve this properly, the `NativeShimmerView` has also been extended with a `duration` prop, which allows customizations in this regard.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


