### PR TITLE
fix: general redesign UI fixes

### DIFF
--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -540,8 +540,8 @@ export const Gallery = (props: GalleryProps) => {
   } = useMessagesContext();
   const { setOverlay: contextSetOverlay } = useOverlayContext();
 
-  const images = propImages || contextImages;
-  const videos = propVideos || contextVideos;
+  const images = propImages ?? contextImages ?? [];
+  const videos = propVideos ?? contextVideos ?? [];
   const imagesAndVideos = [...images, ...videos];
   const message = propMessage || contextMessage;
   const alignment = propAlignment || contextAlignment;

--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -64,7 +64,7 @@ export type GalleryPropsWithContext = Pick<ImageGalleryContextValue, 'imageGalle
   > &
   Pick<OverlayContextValue, 'setOverlay'> & {
     channelId: string | undefined;
-    messageHasOnlyOneImage: boolean;
+    messageHasOnlyOneMedia: boolean;
   };
 
 const GalleryWithContext = (props: GalleryPropsWithContext) => {
@@ -83,7 +83,7 @@ const GalleryWithContext = (props: GalleryPropsWithContext) => {
     setOverlay,
     videos,
     VideoThumbnail,
-    messageHasOnlyOneImage = false,
+    messageHasOnlyOneMedia = false,
   } = props;
 
   const { resizableCDNHosts } = useChatConfigContext();
@@ -144,7 +144,7 @@ const GalleryWithContext = (props: GalleryPropsWithContext) => {
           flexDirection: invertedDirections ? 'column' : 'row',
           alignSelf: alignment === 'right' ? 'flex-end' : 'flex-start',
         },
-        images.length !== 1
+        imagesAndVideos.length !== 1
           ? { width: gridWidth, height: gridHeight }
           : {
               minHeight: height,
@@ -178,7 +178,7 @@ const GalleryWithContext = (props: GalleryPropsWithContext) => {
                 rowIndex,
                 sizeConfig,
                 width,
-                messageHasOnlyOneImage,
+                messageHasOnlyOneMedia,
               });
 
               if (!message) {
@@ -542,6 +542,7 @@ export const Gallery = (props: GalleryProps) => {
 
   const images = propImages || contextImages;
   const videos = propVideos || contextVideos;
+  const imagesAndVideos = [...images, ...videos];
   const message = propMessage || contextMessage;
   const alignment = propAlignment || contextAlignment;
   if (!images.length && !videos.length) {
@@ -562,10 +563,10 @@ export const Gallery = (props: GalleryProps) => {
   const myMessageTheme = propMyMessageTheme || contextMyMessageTheme;
   const messageContentOrder = propMessageContentOrder || contextMessageContentOrder;
 
-  const messageHasOnlyOneImage =
+  const messageHasOnlyOneMedia =
     messageContentOrder?.length === 1 &&
     messageContentOrder?.includes('gallery') &&
-    images.length === 1;
+    imagesAndVideos.length === 1;
 
   return (
     <MemoizedGallery
@@ -586,7 +587,7 @@ export const Gallery = (props: GalleryProps) => {
         setOverlay,
         videos,
         VideoThumbnail,
-        messageHasOnlyOneImage,
+        messageHasOnlyOneMedia,
         messageContentOrder,
       }}
     />

--- a/package/src/components/Attachment/Giphy/Giphy.tsx
+++ b/package/src/components/Attachment/Giphy/Giphy.tsx
@@ -5,12 +5,6 @@ import type { Attachment } from 'stream-chat';
 
 import { GiphyImage } from './GiphyImage';
 
-import { ChatContextValue, useChatContext } from '../../../contexts/chatContext/ChatContext';
-
-import {
-  ImageGalleryContextValue,
-  useImageGalleryContext,
-} from '../../../contexts/imageGalleryContext/ImageGalleryContext';
 import {
   MessageContextValue,
   useMessageContext,
@@ -19,25 +13,19 @@ import {
   MessagesContextValue,
   useMessagesContext,
 } from '../../../contexts/messagesContext/MessagesContext';
-import {
-  OverlayContextValue,
-  useOverlayContext,
-} from '../../../contexts/overlayContext/OverlayContext';
 import { useTheme } from '../../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../../contexts/translationContext/TranslationContext';
 
 import { EyeOpen } from '../../../icons/EyeOpen';
 import { primitives } from '../../../theme';
 
-export type GiphyPropsWithContext = Pick<ImageGalleryContextValue, 'imageGalleryStateStore'> &
-  Pick<
-    MessageContextValue,
-    'handleAction' | 'message' | 'onLongPress' | 'onPress' | 'onPressIn' | 'preventPress'
-  > &
-  Pick<ChatContextValue, 'ImageComponent'> &
+export type GiphyPropsWithContext = Pick<
+  MessageContextValue,
+  'handleAction' | 'onLongPress' | 'onPress' | 'onPressIn' | 'preventPress'
+> &
   Pick<MessagesContextValue, 'additionalPressableProps' | 'giphyVersion'> & {
     attachment: Attachment;
-  } & Pick<OverlayContextValue, 'setOverlay'>;
+  };
 
 const GiphyWithContext = (props: GiphyPropsWithContext) => {
   const {
@@ -45,13 +33,10 @@ const GiphyWithContext = (props: GiphyPropsWithContext) => {
     attachment,
     giphyVersion,
     handleAction,
-    imageGalleryStateStore,
-    message,
     onLongPress,
     onPress,
     onPressIn,
     preventPress,
-    setOverlay,
   } = props;
 
   const { actions, image_url, thumb_url } = attachment;
@@ -77,14 +62,6 @@ const GiphyWithContext = (props: GiphyPropsWithContext) => {
   const styles = useStyles();
 
   const uri = image_url || thumb_url;
-
-  const defaultOnPress = () => {
-    if (!uri) {
-      return;
-    }
-    imageGalleryStateStore.openImageGallery({ messages: [message], selectedAttachmentUrl: uri });
-    setOverlay('gallery');
-  };
 
   if (!uri) {
     return null;
@@ -144,7 +121,6 @@ const GiphyWithContext = (props: GiphyPropsWithContext) => {
       onPress={(event) => {
         if (onPress) {
           onPress({
-            defaultHandler: defaultOnPress,
             emitter: 'giphy',
             event,
           });
@@ -171,12 +147,10 @@ const areEqual = (prevProps: GiphyPropsWithContext, nextProps: GiphyPropsWithCon
   const {
     attachment: { actions: prevActions, image_url: prevImageUrl, thumb_url: prevThumbUrl },
     giphyVersion: prevGiphyVersion,
-    message: prevMessage,
   } = prevProps;
   const {
     attachment: { actions: nextActions, image_url: nextImageUrl, thumb_url: nextThumbUrl },
     giphyVersion: nextGiphyVersion,
-    message: nextMessage,
   } = nextProps;
 
   const imageUrlEqual = prevImageUrl === nextImageUrl;
@@ -204,13 +178,6 @@ const areEqual = (prevProps: GiphyPropsWithContext, nextProps: GiphyPropsWithCon
     return false;
   }
 
-  const messageEqual =
-    prevMessage?.id === nextMessage?.id &&
-    `${prevMessage?.updated_at}` === `${nextMessage?.updated_at}`;
-
-  if (!messageEqual) {
-    return false;
-  }
   return true;
 };
 
@@ -224,12 +191,8 @@ export type GiphyProps = Partial<GiphyPropsWithContext> & {
  * UI component for card in attachments.
  */
 export const Giphy = (props: GiphyProps) => {
-  const { handleAction, message, onLongPress, onPress, onPressIn, preventPress } =
-    useMessageContext();
-  const { ImageComponent } = useChatContext();
+  const { handleAction, onLongPress, onPress, onPressIn, preventPress } = useMessageContext();
   const { additionalPressableProps, giphyVersion } = useMessagesContext();
-  const { imageGalleryStateStore } = useImageGalleryContext();
-  const { setOverlay } = useOverlayContext();
 
   return (
     <MemoizedGiphy
@@ -237,14 +200,10 @@ export const Giphy = (props: GiphyProps) => {
         additionalPressableProps,
         giphyVersion,
         handleAction,
-        ImageComponent,
-        imageGalleryStateStore,
-        message,
         onLongPress,
         onPress,
         onPressIn,
         preventPress,
-        setOverlay,
       }}
       {...props}
     />

--- a/package/src/components/Attachment/ImageLoadingFailedIndicator.tsx
+++ b/package/src/components/Attachment/ImageLoadingFailedIndicator.tsx
@@ -1,7 +1,9 @@
 import React, { useMemo } from 'react';
-import { Pressable, StyleSheet, ViewProps } from 'react-native';
+import { GestureResponderEvent, Pressable, StyleSheet, ViewProps } from 'react-native';
 
+import { useMessageContext } from '../../contexts/messageContext/MessageContext';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
+import { useStableCallback } from '../../hooks';
 import { RetryBadge } from '../ui/Badge/RetryBadge';
 
 export type ImageLoadingFailedIndicatorProps = ViewProps & {
@@ -16,10 +18,21 @@ export const ImageLoadingFailedIndicator = ({
   onReloadImage,
 }: ImageLoadingFailedIndicatorProps) => {
   const styles = useStyles();
+  const { onLongPress: longPressHandler } = useMessageContext();
+
+  const onLongPress = useStableCallback((event: GestureResponderEvent) => {
+    if (longPressHandler) {
+      longPressHandler({
+        emitter: 'failed-image',
+        event,
+      });
+    }
+  });
 
   return (
     <Pressable
       accessibilityLabel='Image Loading Error Indicator'
+      onLongPress={onLongPress}
       onPress={onReloadImage}
       style={styles.imageLoadingErrorIndicatorStyle}
     >

--- a/package/src/components/Attachment/__tests__/Gallery.test.js
+++ b/package/src/components/Attachment/__tests__/Gallery.test.js
@@ -31,7 +31,7 @@ describe('Gallery', () => {
 
   const user1 = generateUser();
 
-  const getComponent = async (attachments = []) => {
+  const getComponent = async (attachments = [], channelProps = {}) => {
     const chatClient = await getTestClientWithUser({ id: 'testID' });
 
     const mockedChannel = generateChannelResponse({
@@ -45,7 +45,7 @@ describe('Gallery', () => {
     return (
       <OverlayProvider>
         <Chat client={chatClient}>
-          <Channel channel={channel}>
+          <Channel channel={channel} {...channelProps}>
             <MessageList />
           </Channel>
         </Chat>
@@ -276,6 +276,40 @@ describe('Gallery', () => {
       nativeEvent: { error: 'error loading image' },
     });
     expect(screen.getByLabelText('Image Loading Error Indicator')).toBeTruthy();
+  });
+
+  it('should trigger long press on a failed image indicator', async () => {
+    const onLongPressMessage = jest.fn();
+    const image1 = generateImageAttachment({
+      original_height: 300,
+      original_width: 600,
+    });
+
+    const component = await getComponent([image1], { onLongPressMessage });
+    render(component);
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('gallery-container').length).toBe(1);
+    });
+
+    fireEvent(screen.getByLabelText('Gallery Image'), 'error', {
+      nativeEvent: { error: 'error loading image' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Image Loading Error Indicator')).toBeTruthy();
+    });
+
+    fireEvent(screen.getByLabelText('Image Loading Error Indicator'), 'longPress');
+
+    await waitFor(() => {
+      expect(onLongPressMessage).toHaveBeenCalledTimes(1);
+      expect(onLongPressMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emitter: 'failed-image',
+        }),
+      );
+    });
   });
 
   it('should render a loading indicator and when successful render the image', async () => {

--- a/package/src/components/Attachment/__tests__/Gallery.test.js
+++ b/package/src/components/Attachment/__tests__/Gallery.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 

--- a/package/src/components/Attachment/__tests__/Gallery.test.js
+++ b/package/src/components/Attachment/__tests__/Gallery.test.js
@@ -100,27 +100,6 @@ describe('Gallery', () => {
     });
   });
 
-  it('should use single-media sizing for a single video attachment', async () => {
-    const attachment = generateVideoAttachment({
-      original_height: 300,
-      original_width: 600,
-    });
-    const component = await getComponent([attachment]);
-    render(component);
-
-    await waitFor(() => {
-      expect(screen.queryAllByTestId('gallery-container').length).toBe(1);
-      expect(screen.getAllByLabelText('Video Thumbnail').length).toBe(1);
-    });
-
-    const containerStyle = StyleSheet.flatten(screen.getByTestId('gallery-container').props.style);
-
-    expect(containerStyle.width).toBeUndefined();
-    expect(containerStyle.height).toBeUndefined();
-    expect(containerStyle.minWidth).toBe(256);
-    expect(containerStyle.minHeight).toBe(128);
-  });
-
   it('should render portrait and landscape image in two rows', async () => {
     const attachment1 = generateImageAttachment({
       original_height: 600,

--- a/package/src/components/Attachment/__tests__/Gallery.test.js
+++ b/package/src/components/Attachment/__tests__/Gallery.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 
@@ -97,6 +98,27 @@ describe('Gallery', () => {
       expect(screen.queryAllByTestId('gallery-row-0-item-0').length).toBe(1);
       expect(screen.getAllByLabelText('Video Thumbnail').length).toBe(1);
     });
+  });
+
+  it('should use single-media sizing for a single video attachment', async () => {
+    const attachment = generateVideoAttachment({
+      original_height: 300,
+      original_width: 600,
+    });
+    const component = await getComponent([attachment]);
+    render(component);
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('gallery-container').length).toBe(1);
+      expect(screen.getAllByLabelText('Video Thumbnail').length).toBe(1);
+    });
+
+    const containerStyle = StyleSheet.flatten(screen.getByTestId('gallery-container').props.style);
+
+    expect(containerStyle.width).toBeUndefined();
+    expect(containerStyle.height).toBeUndefined();
+    expect(containerStyle.minWidth).toBe(256);
+    expect(containerStyle.minHeight).toBe(128);
   });
 
   it('should render portrait and landscape image in two rows', async () => {

--- a/package/src/components/Attachment/__tests__/Giphy.test.js
+++ b/package/src/components/Attachment/__tests__/Giphy.test.js
@@ -36,12 +36,12 @@ const streami18n = new Streami18n({
 });
 
 describe('Giphy', () => {
-  const getAttachmentComponent = (props) => {
+  const getAttachmentComponent = (props, messageContextValue = {}) => {
     const message = generateMessage();
     return (
       <ThemeProvider>
         <MessagesProvider value={{ ImageLoadingFailedIndicator, ImageLoadingIndicator }}>
-          <MessageProvider value={{ message }}>
+          <MessageProvider value={{ message, ...messageContextValue }}>
             <Giphy {...props} />
           </MessageProvider>
         </MessagesProvider>
@@ -321,6 +321,37 @@ describe('Giphy', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText('Image Loading Error Indicator')).toBeTruthy();
+    });
+  });
+
+  it('should trigger long press on a failed giphy image indicator', async () => {
+    const onLongPress = jest.fn();
+
+    render(getAttachmentComponent({ attachment }, { onLongPress }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('giphy-attachment')).toBeTruthy();
+    });
+
+    act(() => {
+      fireEvent(screen.getByLabelText('Giphy Attachment Image'), 'error');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Image Loading Error Indicator')).toBeTruthy();
+    });
+
+    act(() => {
+      fireEvent(screen.getByLabelText('Image Loading Error Indicator'), 'longPress');
+    });
+
+    await waitFor(() => {
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+      expect(onLongPress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emitter: 'failed-image',
+        }),
+      );
     });
   });
 

--- a/package/src/components/Attachment/utils/getGalleryImageBorderRadius.ts
+++ b/package/src/components/Attachment/utils/getGalleryImageBorderRadius.ts
@@ -18,7 +18,7 @@ type Params = {
   height?: number;
   invertedDirections?: boolean;
   width?: number;
-  messageHasOnlyOneImage?: boolean;
+  messageHasOnlyOneMedia?: boolean;
 };
 
 export function getGalleryImageBorderRadius({
@@ -30,7 +30,7 @@ export function getGalleryImageBorderRadius({
   rowIndex,
   sizeConfig,
   width,
-  messageHasOnlyOneImage = false,
+  messageHasOnlyOneMedia = false,
 }: Params) {
   const isSingleImage = numOfColumns === 1 && numOfRows === 1;
   const isImageSmallerThanMinContainerSize =
@@ -51,12 +51,12 @@ export function getGalleryImageBorderRadius({
   return {
     borderTopLeftRadius: !isImageSmallerThanMinContainerSize && topLeftEdgeExposed ? 12 : 8,
     borderTopRightRadius: !isImageSmallerThanMinContainerSize && topRightEdgeExposed ? 12 : 8,
-    borderBottomLeftRadius: messageHasOnlyOneImage
+    borderBottomLeftRadius: messageHasOnlyOneMedia
       ? primitives.radiusNone
       : !isImageSmallerThanMinContainerSize && bottomLeftEdgeExposed
         ? primitives.radiusLg
         : primitives.radiusMd,
-    borderBottomRightRadius: messageHasOnlyOneImage
+    borderBottomRightRadius: messageHasOnlyOneMedia
       ? primitives.radiusNone
       : !isImageSmallerThanMinContainerSize && bottomRightEdgeExposed
         ? primitives.radiusLg

--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   I18nManager,
+  Platform,
   TextInput as RNTextInput,
   StyleSheet,
   TextInputProps,
@@ -69,7 +70,7 @@ const configStateSelector = (state: MessageComposerConfig) => ({
 
 const MAX_NUMBER_OF_LINES = 5;
 const LINE_HEIGHT = 20;
-const PADDING_VERTICAL = 12;
+const INPUT_VERTICAL_PADDING = Platform.OS === 'ios' ? 7 : 12;
 
 const commandPlaceHolders: Record<string, string> = {
   giphy: 'Search GIFs',
@@ -164,7 +165,7 @@ const AutoCompleteInputWithContext = (props: AutoCompleteInputPropsWithContext) 
       style={[
         styles.inputBox,
         {
-          maxHeight: LINE_HEIGHT * numberOfLines + PADDING_VERTICAL * 2,
+          maxHeight: LINE_HEIGHT * numberOfLines + INPUT_VERTICAL_PADDING * 2,
           paddingLeft: command ? 0 : 16,
           paddingRight: command ? 4 : 8,
           textAlign: I18nManager.isRTL ? 'right' : 'left',

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -438,6 +438,7 @@ const MessageWithContext = (props: MessagePropsWithContext) => {
               isVideoPlayerAvailable()
             ) {
               acc.videos.push({
+                ...cur,
                 image_url: cur.asset_url,
                 thumb_url: cur.thumb_url,
                 type: FileTypes.Video,

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -72,6 +72,7 @@ import { dismissKeyboard } from '../KeyboardCompatibleView/KeyboardControllerAvo
 import { BottomSheetModal } from '../UIComponents';
 
 export type TouchableEmitter =
+  | 'failed-image'
   | 'fileAttachment'
   | 'gallery'
   | 'giphy'

--- a/package/src/components/Message/MessageSimple/MessageContent.tsx
+++ b/package/src/components/Message/MessageSimple/MessageContent.tsx
@@ -546,6 +546,7 @@ export const MessageContent = (props: MessageContentProps) => {
     threadList,
     files,
     images,
+    videos,
   } = useMessageContext();
   const {
     additionalPressableProps,
@@ -562,10 +563,10 @@ export const MessageContent = (props: MessageContentProps) => {
   const { t } = useTranslationContext();
   const isSingleFile = files.length === 1;
   const messageHasPoll = messageContentOrder.includes('poll');
-  const messageHasSingleImage =
+  const messageHasSingleMedia =
     messageContentOrder.length === 1 &&
     messageContentOrder.includes('gallery') &&
-    images.length === 1;
+    images.length + videos.length === 1;
   const messageHasSingleFile =
     messageContentOrder.length === 1 && messageContentOrder[0] === 'files' && isSingleFile;
   const messageHasOnlyText = messageContentOrder.length === 1 && messageContentOrder[0] === 'text';
@@ -576,17 +577,17 @@ export const MessageContent = (props: MessageContentProps) => {
 
   const hidePaddingTop =
     messageHasPoll ||
-    messageHasSingleImage ||
+    messageHasSingleMedia ||
     messageHasSingleFile ||
     messageHasOnlyText ||
     messageHasGiphyOrImgur;
 
   const hidePaddingHorizontal =
-    messageHasPoll || messageHasSingleImage || messageHasSingleFile || messageHasGiphyOrImgur;
+    messageHasPoll || messageHasSingleMedia || messageHasSingleFile || messageHasGiphyOrImgur;
 
   const hidePaddingBottom =
     messageHasPoll ||
-    messageHasSingleImage ||
+    messageHasSingleMedia ||
     messageHasSingleFile ||
     messageHasOnlyText ||
     messageHasGiphyOrImgur ||

--- a/package/src/components/Message/MessageSimple/__tests__/MessageContent.test.js
+++ b/package/src/components/Message/MessageSimple/__tests__/MessageContent.test.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import { cleanup, render, screen, waitFor } from '@testing-library/react-native';
 
@@ -7,6 +7,7 @@ import { ChannelsStateProvider } from '../../../../contexts/channelsStateContext
 
 import { getOrCreateChannelApi } from '../../../../mock-builders/api/getOrCreateChannel';
 import { useMockedApis } from '../../../../mock-builders/api/useMockedApis';
+import { generateVideoAttachment } from '../../../../mock-builders/generator/attachment';
 import { generateChannelResponse } from '../../../../mock-builders/generator/channel';
 import { generateMember } from '../../../../mock-builders/generator/member';
 import { generateMessage } from '../../../../mock-builders/generator/message';
@@ -180,6 +181,51 @@ describe('MessageContent', () => {
       expect(screen.getByTestId('message-content-wrapper')).toBeTruthy();
       expect(screen.getByTestId('gallery-container')).toBeTruthy();
     });
+  });
+
+  it('removes content padding for a single video attachment', async () => {
+    const user = generateUser();
+    const message = generateMessage({
+      attachments: [
+        generateVideoAttachment({
+          original_height: 300,
+          original_width: 600,
+        }),
+      ],
+      html: '',
+      text: '',
+      user,
+    });
+
+    renderMessage({ message });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('message-content-wrapper')).toBeTruthy();
+      expect(screen.getByTestId('gallery-container')).toBeTruthy();
+    });
+
+    const galleryContainer = screen.getByTestId('gallery-container');
+    let ancestor = galleryContainer.parent;
+    let contentContainerStyle;
+
+    while (ancestor && !contentContainerStyle) {
+      const flattenedStyle = StyleSheet.flatten(ancestor.props.style);
+      if (
+        flattenedStyle &&
+        'paddingTop' in flattenedStyle &&
+        'paddingHorizontal' in flattenedStyle &&
+        'paddingBottom' in flattenedStyle
+      ) {
+        contentContainerStyle = flattenedStyle;
+        break;
+      }
+      ancestor = ancestor.parent;
+    }
+
+    expect(contentContainerStyle).toBeTruthy();
+    expect(contentContainerStyle.paddingTop).toBe(0);
+    expect(contentContainerStyle.paddingHorizontal).toBe(0);
+    expect(contentContainerStyle.paddingBottom).toBe(0);
   });
 
   it('renders the FileAttachment component when a file attachment exists', async () => {

--- a/package/src/components/MessageInput/MessageInputLeadingView.tsx
+++ b/package/src/components/MessageInput/MessageInputLeadingView.tsx
@@ -35,7 +35,7 @@ export const MessageInputLeadingView = () => {
 
 const styles = StyleSheet.create({
   giphyContainer: {
-    padding: primitives.spacingXs,
+    padding: primitives.spacingSm,
     alignSelf: 'flex-end',
   },
 });

--- a/package/src/components/MessageInput/components/InputButtons/index.tsx
+++ b/package/src/components/MessageInput/components/InputButtons/index.tsx
@@ -10,6 +10,7 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import { OwnCapabilitiesContextValue } from '../../../../contexts';
+import { useActiveCommand } from '../../../../contexts/messageInputContext/hooks/useActiveCommand';
 import {
   MessageInputContextValue,
   useMessageInputContext,
@@ -37,6 +38,7 @@ export const InputButtonsWithContext = (props: InputButtonsWithContextProps) => 
   } = props;
   const { selectedPicker } = useAttachmentPickerState();
   const rotation = useSharedValue(0);
+  const command = useActiveCommand();
 
   const {
     theme: {
@@ -59,7 +61,7 @@ export const InputButtonsWithContext = (props: InputButtonsWithContextProps) => 
     return null;
   }
 
-  return hasAttachmentUploadCapabilities ? (
+  return hasAttachmentUploadCapabilities && !command ? (
     <Animated.View entering={ZoomIn.duration(200)} exiting={ZoomOut.duration(200)}>
       <Animated.View style={[styles.attachButtonContainer, attachButtonContainer, animatedStyle]}>
         <AttachButton />

--- a/package/src/components/Reply/Reply.tsx
+++ b/package/src/components/Reply/Reply.tsx
@@ -156,17 +156,23 @@ export const ReplyWithContext = (props: ReplyPropsWithContext) => {
 
 const areEqual = (prevProps: ReplyPropsWithContext, nextProps: ReplyPropsWithContext) => {
   const {
+    styles: prevStyles,
     isMyMessage: prevIsMyMessage,
     mode: prevMode,
     quotedMessage: prevQuotedMessage,
     onDismiss: prevOnDismiss,
   } = prevProps;
   const {
+    styles: nextStyles,
     isMyMessage: nextIsMyMessage,
     mode: nextMode,
     quotedMessage: nextQuotedMessage,
     onDismiss: nextOnDismiss,
   } = nextProps;
+
+  if (prevStyles !== nextStyles) {
+    return false;
+  }
 
   const isMyMessageEqual = prevIsMyMessage === nextIsMyMessage;
 

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -2009,7 +2009,7 @@ exports[`Thread should match thread snapshot 1`] = `
                             "textAlignVertical": "center",
                           },
                           {
-                            "maxHeight": 124,
+                            "maxHeight": 114,
                             "paddingLeft": 16,
                             "paddingRight": 8,
                             "textAlign": "left",

--- a/package/src/components/ui/GiphyChip.tsx
+++ b/package/src/components/ui/GiphyChip.tsx
@@ -54,8 +54,9 @@ const useStyles = () => {
           borderRadius: primitives.radiusMax,
           flexDirection: 'row',
           paddingHorizontal: primitives.spacingXs,
-          paddingVertical: primitives.spacingXxs,
+          paddingVertical: primitives.spacingXxxs,
           gap: primitives.spacingXxs,
+          height: 24,
         },
         text: {
           color: semantics.textInverse,

--- a/package/src/contexts/messageInputContext/hooks/useActiveCommand.ts
+++ b/package/src/contexts/messageInputContext/hooks/useActiveCommand.ts
@@ -1,0 +1,16 @@
+import { TextComposerState } from 'stream-chat';
+
+import { useMessageComposer } from './useMessageComposer';
+
+import { useStateStore } from '../../../hooks/useStateStore';
+
+const activeCommandSelector = (state: TextComposerState) => ({
+  command: state.command,
+});
+
+export const useActiveCommand = () => {
+  const { textComposer } = useMessageComposer();
+  const state = useStateStore(textComposer.state, activeCommandSelector);
+
+  return state.command;
+};


### PR DESCRIPTION
## 🎯 Goal

This PR provides further fixes of our SDK's UI based on the redesign.

Specifically, it addresses:

  - Hide attach during commands
  - Fix failed-image long press
  - Prevent Giphy tap action
  - Single video full width
  - iOS input line cap
  - Reply theme color updates
  - Adjust Giphy badge spacing

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


