### PR TITLE
feat: move swipability to full row

### DIFF
--- a/package/src/components/Message/MessageItemView/MessageBubble.tsx
+++ b/package/src/components/Message/MessageItemView/MessageBubble.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode, SetStateAction, useMemo, useState } from 'react';
-import { LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import React, { ReactNode, useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 import Animated, {
@@ -15,7 +15,6 @@ import { MessageItemViewPropsWithContext } from './MessageItemView';
 
 import { MessagesContextValue, useTheme } from '../../../contexts';
 
-import { useStableCallback } from '../../../hooks';
 import { NativeHandlers } from '../../../native';
 import { MessageStatusTypes } from '../../../utils/utils';
 
@@ -34,7 +33,6 @@ export type MessageBubbleProps = Pick<
     | 'messageGroupedSingleOrBottom'
     | 'noBorder'
     | 'message'
-    | 'setMessageContentWidth'
   > &
   Pick<MessageItemViewPropsWithContext, 'alignment'>;
 
@@ -43,7 +41,6 @@ export const MessageBubble = React.memo(
     alignment,
     reactionListPosition,
     reactionListType,
-    setMessageContentWidth,
     MessageContent,
     ReactionListTop,
     backgroundColor,
@@ -70,7 +67,6 @@ export const MessageBubble = React.memo(
             isVeryLastMessage={isVeryLastMessage}
             messageGroupedSingleOrBottom={messageGroupedSingleOrBottom}
             noBorder={noBorder}
-            setMessageContentWidth={setMessageContentWidth}
           />
 
           {isMessageErrorType ? (
@@ -89,9 +85,7 @@ const AnimatedWrapper = Animated.createAnimatedComponent(View);
 type SwipableMessageWrapperProps = Pick<MessagesContextValue, 'MessageSwipeContent'> &
   Pick<MessageItemViewPropsWithContext, 'alignment' | 'messageSwipeToReplyHitSlop'> & {
     children: ReactNode;
-    messageContentWidth: number;
     onSwipe: () => void;
-    setMessageContentWidth: React.Dispatch<SetStateAction<number>>;
   };
 
 export const SwipableMessageWrapper = React.memo((props: SwipableMessageWrapperProps) => {
@@ -108,24 +102,6 @@ export const SwipableMessageWrapper = React.memo((props: SwipableMessageWrapperP
   const MINIMUM_DISTANCE = 8;
 
   const triggerHaptic = NativeHandlers.triggerHaptic;
-
-  const setMessageContentWidth = useStableCallback((valueOrCallback: SetStateAction<number>) => {
-    if (typeof valueOrCallback === 'number') {
-      props.setMessageContentWidth(Math.ceil(valueOrCallback));
-      return;
-    }
-    props.setMessageContentWidth(valueOrCallback);
-  });
-
-  const onLayout = useStableCallback(
-    ({
-      nativeEvent: {
-        layout: { width },
-      },
-    }: LayoutChangeEvent) => {
-      setMessageContentWidth(width);
-    },
-  );
 
   const swipeGesture = useMemo(
     () =>
@@ -199,16 +175,7 @@ export const SwipableMessageWrapper = React.memo((props: SwipableMessageWrapperP
 
   return (
     <GestureDetector gesture={swipeGesture}>
-      <View
-        hitSlop={messageSwipeToReplyHitSlop}
-        onLayout={onLayout}
-        style={[
-          styles.contentWrapper,
-          props.messageContentWidth > 0 && shouldRenderAnimatedWrapper
-            ? { width: props.messageContentWidth }
-            : {},
-        ]}
-      >
+      <View hitSlop={messageSwipeToReplyHitSlop} style={styles.contentWrapper}>
         {shouldRenderAnimatedWrapper ? (
           <AnimatedWrapper style={[styles.swipeContentContainer, swipeContentAnimatedStyle]}>
             {MessageSwipeContent ? <MessageSwipeContent /> : null}

--- a/package/src/components/Message/MessageItemView/MessageBubble.tsx
+++ b/package/src/components/Message/MessageItemView/MessageBubble.tsx
@@ -1,5 +1,5 @@
-import React, { SetStateAction, useMemo, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { ReactNode, SetStateAction, useMemo, useState } from 'react';
+import { LayoutChangeEvent, StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 import Animated, {
@@ -36,9 +36,7 @@ export type MessageBubbleProps = Pick<
     | 'message'
     | 'setMessageContentWidth'
   > &
-  Pick<MessageItemViewPropsWithContext, 'alignment'> & {
-    messageContentWidth: number;
-  };
+  Pick<MessageItemViewPropsWithContext, 'alignment'>;
 
 export const MessageBubble = React.memo(
   ({
@@ -88,130 +86,139 @@ export const MessageBubble = React.memo(
 
 const AnimatedWrapper = Animated.createAnimatedComponent(View);
 
-export const SwipableMessageBubble = React.memo(
-  (
-    props: MessageBubbleProps &
-      Pick<MessagesContextValue, 'MessageSwipeContent'> &
-      Pick<
-        MessageItemViewPropsWithContext,
-        'shouldRenderSwipeableWrapper' | 'messageSwipeToReplyHitSlop'
-      > & { onSwipe: () => void },
-  ) => {
-    const { MessageSwipeContent, messageSwipeToReplyHitSlop, onSwipe, ...messageBubbleProps } =
-      props;
+type SwipableMessageWrapperProps = Pick<MessagesContextValue, 'MessageSwipeContent'> &
+  Pick<MessageItemViewPropsWithContext, 'alignment' | 'messageSwipeToReplyHitSlop'> & {
+    children: ReactNode;
+    messageContentWidth: number;
+    onSwipe: () => void;
+    setMessageContentWidth: React.Dispatch<SetStateAction<number>>;
+  };
 
-    const styles = useStyles({ alignment: props.alignment });
+export const SwipableMessageWrapper = React.memo((props: SwipableMessageWrapperProps) => {
+  const { MessageSwipeContent, children, messageSwipeToReplyHitSlop, onSwipe } = props;
 
-    const translateX = useSharedValue(0);
-    const touchStart = useSharedValue<{ x: number; y: number } | null>(null);
-    const isSwiping = useSharedValue<boolean>(false);
-    const [shouldRenderAnimatedWrapper, setShouldRenderAnimatedWrapper] = useState<boolean>(false);
+  const styles = useStyles({ alignment: props.alignment });
 
-    const SWIPABLE_THRESHOLD = 25;
-    const MINIMUM_DISTANCE = 8;
+  const translateX = useSharedValue(0);
+  const touchStart = useSharedValue<{ x: number; y: number } | null>(null);
+  const isSwiping = useSharedValue<boolean>(false);
+  const [shouldRenderAnimatedWrapper, setShouldRenderAnimatedWrapper] = useState<boolean>(false);
 
-    const triggerHaptic = NativeHandlers.triggerHaptic;
+  const SWIPABLE_THRESHOLD = 25;
+  const MINIMUM_DISTANCE = 8;
 
-    const setMessageContentWidth = useStableCallback((valueOrCallback: SetStateAction<number>) => {
-      if (typeof valueOrCallback === 'number') {
-        props.setMessageContentWidth(Math.ceil(valueOrCallback));
-        return;
-      }
-      props.setMessageContentWidth(valueOrCallback);
-    });
+  const triggerHaptic = NativeHandlers.triggerHaptic;
 
-    const swipeGesture = useMemo(
-      () =>
-        Gesture.Pan()
-          .hitSlop(messageSwipeToReplyHitSlop)
-          .onBegin((event) => {
-            touchStart.value = { x: event.x, y: event.y };
-          })
-          .onTouchesMove((event, state) => {
-            if (!touchStart.value || !event.changedTouches.length) {
-              state.fail();
-              return;
+  const setMessageContentWidth = useStableCallback((valueOrCallback: SetStateAction<number>) => {
+    if (typeof valueOrCallback === 'number') {
+      props.setMessageContentWidth(Math.ceil(valueOrCallback));
+      return;
+    }
+    props.setMessageContentWidth(valueOrCallback);
+  });
+
+  const onLayout = useStableCallback(
+    ({
+      nativeEvent: {
+        layout: { width },
+      },
+    }: LayoutChangeEvent) => {
+      setMessageContentWidth(width);
+    },
+  );
+
+  const swipeGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .hitSlop(messageSwipeToReplyHitSlop)
+        .onBegin((event) => {
+          touchStart.value = { x: event.x, y: event.y };
+        })
+        .onTouchesMove((event, state) => {
+          if (!touchStart.value || !event.changedTouches.length) {
+            state.fail();
+            return;
+          }
+
+          const xDiff = Math.abs(event.changedTouches[0].x - touchStart.value.x);
+          const yDiff = Math.abs(event.changedTouches[0].y - touchStart.value.y);
+          const isHorizontalPanning = xDiff > yDiff;
+          const hasMinimumDistance = xDiff > MINIMUM_DISTANCE || yDiff > MINIMUM_DISTANCE;
+
+          // Only activate if there's significant horizontal movement
+          if (isHorizontalPanning && hasMinimumDistance) {
+            state.activate();
+            if (!isSwiping.value) {
+              runOnJS(setShouldRenderAnimatedWrapper)(true);
             }
-
-            const xDiff = Math.abs(event.changedTouches[0].x - touchStart.value.x);
-            const yDiff = Math.abs(event.changedTouches[0].y - touchStart.value.y);
-            const isHorizontalPanning = xDiff > yDiff;
-            const hasMinimumDistance = xDiff > MINIMUM_DISTANCE || yDiff > MINIMUM_DISTANCE;
-
-            // Only activate if there's significant horizontal movement
-            if (isHorizontalPanning && hasMinimumDistance) {
-              state.activate();
-              if (!isSwiping.value) {
-                runOnJS(setShouldRenderAnimatedWrapper)(true);
-              }
-              isSwiping.value = true;
-            } else if (hasMinimumDistance) {
-              // If there's significant movement but not horizontal, fail the gesture
-              state.fail();
+            isSwiping.value = true;
+          } else if (hasMinimumDistance) {
+            // If there's significant movement but not horizontal, fail the gesture
+            state.fail();
+          }
+        })
+        .onStart(() => {
+          translateX.value = 0;
+        })
+        .onChange(({ translationX }) => {
+          if (translationX > 0) {
+            translateX.value = translationX;
+          }
+        })
+        .onEnd(() => {
+          if (translateX.value >= SWIPABLE_THRESHOLD) {
+            runOnJS(onSwipe)();
+            if (triggerHaptic) {
+              runOnJS(triggerHaptic)('impactMedium');
             }
-          })
-          .onStart(() => {
-            translateX.value = 0;
-          })
-          .onChange(({ translationX }) => {
-            if (translationX > 0) {
-              translateX.value = translationX;
-            }
-          })
-          .onEnd(() => {
-            if (translateX.value >= SWIPABLE_THRESHOLD) {
-              runOnJS(onSwipe)();
-              if (triggerHaptic) {
-                runOnJS(triggerHaptic)('impactMedium');
-              }
-            }
-            isSwiping.value = false;
-            translateX.value = withSpring(
-              0,
-              {
-                dampingRatio: 1,
-                duration: 500,
-                overshootClamping: true,
-                stiffness: 1,
-              },
-              () => {
-                runOnJS(setShouldRenderAnimatedWrapper)(false);
-              },
-            );
-          }),
-      [messageSwipeToReplyHitSlop, touchStart, isSwiping, translateX, onSwipe, triggerHaptic],
-    );
+          }
+          isSwiping.value = false;
+          translateX.value = withSpring(
+            0,
+            {
+              dampingRatio: 1,
+              duration: 500,
+              overshootClamping: true,
+              stiffness: 1,
+            },
+            () => {
+              runOnJS(setShouldRenderAnimatedWrapper)(false);
+            },
+          );
+        }),
+    [messageSwipeToReplyHitSlop, touchStart, isSwiping, translateX, onSwipe, triggerHaptic],
+  );
 
-    const swipeContentAnimatedStyle = useAnimatedStyle(
-      () => ({
-        opacity: interpolate(translateX.value, [0, SWIPABLE_THRESHOLD], [0, 1]),
-        width: translateX.value,
-      }),
-      [],
-    );
+  const swipeContentAnimatedStyle = useAnimatedStyle(
+    () => ({
+      opacity: interpolate(translateX.value, [0, SWIPABLE_THRESHOLD], [0, 1]),
+      width: translateX.value,
+    }),
+    [],
+  );
 
-    return (
-      <GestureDetector gesture={swipeGesture}>
-        <View
-          hitSlop={messageSwipeToReplyHitSlop}
-          style={[
-            styles.contentWrapper,
-            props.messageContentWidth > 0 && shouldRenderAnimatedWrapper
-              ? { width: props.messageContentWidth }
-              : {},
-          ]}
-        >
-          {shouldRenderAnimatedWrapper ? (
-            <AnimatedWrapper style={[styles.swipeContentContainer, swipeContentAnimatedStyle]}>
-              {MessageSwipeContent ? <MessageSwipeContent /> : null}
-            </AnimatedWrapper>
-          ) : null}
-          <MessageBubble {...messageBubbleProps} setMessageContentWidth={setMessageContentWidth} />
-        </View>
-      </GestureDetector>
-    );
-  },
-);
+  return (
+    <GestureDetector gesture={swipeGesture}>
+      <View
+        hitSlop={messageSwipeToReplyHitSlop}
+        onLayout={onLayout}
+        style={[
+          styles.contentWrapper,
+          props.messageContentWidth > 0 && shouldRenderAnimatedWrapper
+            ? { width: props.messageContentWidth }
+            : {},
+        ]}
+      >
+        {shouldRenderAnimatedWrapper ? (
+          <AnimatedWrapper style={[styles.swipeContentContainer, swipeContentAnimatedStyle]}>
+            {MessageSwipeContent ? <MessageSwipeContent /> : null}
+          </AnimatedWrapper>
+        ) : null}
+        {children}
+      </View>
+    </GestureDetector>
+  );
+});
 
 const useStyles = ({ alignment }: { alignment?: 'left' | 'right' }) => {
   const {

--- a/package/src/components/Message/MessageItemView/MessageContent.tsx
+++ b/package/src/components/Message/MessageItemView/MessageContent.tsx
@@ -89,7 +89,7 @@ export type MessageContentPropsWithContext = Pick<
     | 'StreamingMessageView'
   > &
   Pick<TranslationContextValue, 't'> & {
-    setMessageContentWidth: React.Dispatch<React.SetStateAction<number>>;
+    setMessageContentWidth?: React.Dispatch<React.SetStateAction<number>>;
     /**
      * Background color for the message content
      */
@@ -181,13 +181,15 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
     },
   } = useTheme();
 
-  const onLayout: (event: LayoutChangeEvent) => void = ({
-    nativeEvent: {
-      layout: { width },
-    },
-  }) => {
-    setMessageContentWidth(width);
-  };
+  const onLayout: ((event: LayoutChangeEvent) => void) | undefined = setMessageContentWidth
+    ? ({
+        nativeEvent: {
+          layout: { width },
+        },
+      }) => {
+        setMessageContentWidth(width);
+      }
+    : undefined;
 
   const isAIGenerated = useMemo(
     () => isMessageAIGenerated(message),

--- a/package/src/components/Message/MessageItemView/MessageContent.tsx
+++ b/package/src/components/Message/MessageItemView/MessageContent.tsx
@@ -1,12 +1,5 @@
 import React, { useMemo } from 'react';
-import {
-  AnimatableNumericValue,
-  ColorValue,
-  LayoutChangeEvent,
-  Pressable,
-  StyleSheet,
-  View,
-} from 'react-native';
+import { AnimatableNumericValue, ColorValue, Pressable, StyleSheet, View } from 'react-native';
 
 import { MessageTextContainer } from './MessageTextContainer';
 
@@ -89,7 +82,6 @@ export type MessageContentPropsWithContext = Pick<
     | 'StreamingMessageView'
   > &
   Pick<TranslationContextValue, 't'> & {
-    setMessageContentWidth?: React.Dispatch<React.SetStateAction<number>>;
     /**
      * Background color for the message content
      */
@@ -147,7 +139,6 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
     otherAttachments,
     preventPress,
     Reply,
-    setMessageContentWidth,
     StreamingMessageView,
     hidePaddingTop,
     hidePaddingHorizontal,
@@ -180,16 +171,6 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
       },
     },
   } = useTheme();
-
-  const onLayout: ((event: LayoutChangeEvent) => void) | undefined = setMessageContentWidth
-    ? ({
-        nativeEvent: {
-          layout: { width },
-        },
-      }) => {
-        setMessageContentWidth(width);
-      }
-    : undefined;
 
   const isAIGenerated = useMemo(
     () => isMessageAIGenerated(message),
@@ -354,7 +335,7 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
         }
       }}
     >
-      <View onLayout={onLayout} style={wrapper}>
+      <View style={wrapper}>
         <View
           style={[
             styles.containerInner,
@@ -553,10 +534,7 @@ const MemoizedMessageContent = React.memo(
   areEqual,
 ) as typeof MessageContentWithContext;
 
-export type MessageContentProps = Partial<
-  Omit<MessageContentPropsWithContext, 'setMessageContentWidth'>
-> &
-  Pick<MessageContentPropsWithContext, 'setMessageContentWidth'>;
+export type MessageContentProps = Partial<MessageContentPropsWithContext>;
 
 /**
  * Child of MessageItemView that displays a message's content

--- a/package/src/components/Message/MessageItemView/MessageItemView.tsx
+++ b/package/src/components/Message/MessageItemView/MessageItemView.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useMemo, useState } from 'react';
 import { Dimensions, StyleSheet, View, ViewStyle } from 'react-native';
 
-import { MessageBubble, SwipableMessageBubble } from './MessageBubble';
+import { MessageBubble, SwipableMessageWrapper } from './MessageBubble';
 
 import {
   Alignment,
@@ -71,6 +71,7 @@ const useStyles = ({
           alignItems: 'flex-end',
           gap: primitives.spacingXs,
           flexDirection: alignment === 'left' ? 'row' : 'row-reverse',
+          width: '100%',
           ...container,
         },
         contentContainer: {
@@ -190,16 +191,7 @@ export type MessageItemViewPropsWithContext = Pick<
     | 'reactionListPosition'
     | 'reactionListType'
     | 'ReactionListTop'
-  > & {
-    /**
-     * Will determine whether the swipeable wrapper is always rendered for each
-     * message. If set to false, the animated wrapper will be rendered only when
-     * a swiping gesture is active and not otherwise.
-     * Since stateful components would lose their state if we remount them while
-     * an animation is happening, this should always be set to true in those instances.
-     */
-    shouldRenderSwipeableWrapper: boolean;
-  };
+  >;
 
 const MessageItemViewWithContext = forwardRef<View, MessageItemViewPropsWithContext>(
   (props, ref) => {
@@ -230,7 +222,6 @@ const MessageItemViewWithContext = forwardRef<View, MessageItemViewPropsWithCont
       reactionListPosition,
       reactionListType,
       ReactionListTop,
-      shouldRenderSwipeableWrapper,
       setQuotedMessage,
     } = props;
 
@@ -295,72 +286,65 @@ const MessageItemViewWithContext = forwardRef<View, MessageItemViewPropsWithCont
       setQuotedMessage(message);
     });
 
+    const itemViewContent = (
+      <View pointerEvents='box-none' style={styles.container} testID='message-item-view-wrapper'>
+        {alignment === 'left' ? <MessageAuthor /> : null}
+        {isMessageTypeDeleted ? (
+          <MessageDeleted date={message.created_at} groupStyle={groupStyle} />
+        ) : (
+          <View
+            style={[
+              styles.contentContainer,
+              isMyMessage ? styles.rightAlignItems : styles.leftAlignItems,
+              isMessageErrorType ? errorContainer : {},
+            ]}
+            testID='message-components'
+          >
+            <MessageHeader />
+            <MessageBubble
+              alignment={alignment}
+              backgroundColor={backgroundColor}
+              isVeryLastMessage={isVeryLastMessage}
+              MessageContent={MessageContent}
+              MessageError={MessageError}
+              messageGroupedSingleOrBottom={messageGroupedSingleOrBottom}
+              noBorder={noBorder}
+              reactionListPosition={reactionListPosition}
+              ReactionListTop={ReactionListTop}
+              reactionListType={reactionListType}
+              message={message}
+            />
+
+            <View style={styles.repliesContainer}>
+              <MessageReplies />
+            </View>
+
+            {reactionListPosition === 'bottom' && ReactionListBottom ? (
+              <ReactionListBottom type={reactionListType} />
+            ) : null}
+            <MessageFooter date={message.created_at} />
+          </View>
+        )}
+        {MessageSpacer ? <MessageSpacer /> : null}
+      </View>
+    );
+
     return (
       <View ref={ref}>
-        <View pointerEvents='box-none' style={styles.container} testID='message-item-view-wrapper'>
-          {alignment === 'left' ? <MessageAuthor /> : null}
-          {isMessageTypeDeleted ? (
-            <MessageDeleted date={message.created_at} groupStyle={groupStyle} />
-          ) : (
-            <View
-              style={[
-                styles.contentContainer,
-                isMyMessage ? styles.rightAlignItems : styles.leftAlignItems,
-                isMessageErrorType ? errorContainer : {},
-              ]}
-              testID='message-components'
-            >
-              <MessageHeader />
-              {enableSwipeToReply ? (
-                <SwipableMessageBubble
-                  alignment={alignment}
-                  backgroundColor={backgroundColor}
-                  isVeryLastMessage={isVeryLastMessage}
-                  MessageContent={MessageContent}
-                  messageContentWidth={messageContentWidth}
-                  messageGroupedSingleOrBottom={messageGroupedSingleOrBottom}
-                  MessageSwipeContent={MessageSwipeContent}
-                  MessageError={MessageError}
-                  messageSwipeToReplyHitSlop={messageSwipeToReplyHitSlop}
-                  noBorder={noBorder}
-                  onSwipe={onSwipeActionHandler}
-                  reactionListPosition={reactionListPosition}
-                  reactionListType={reactionListType}
-                  ReactionListTop={ReactionListTop}
-                  setMessageContentWidth={setMessageContentWidth}
-                  shouldRenderSwipeableWrapper={shouldRenderSwipeableWrapper}
-                  message={message}
-                />
-              ) : (
-                <MessageBubble
-                  alignment={alignment}
-                  backgroundColor={backgroundColor}
-                  isVeryLastMessage={isVeryLastMessage}
-                  MessageContent={MessageContent}
-                  MessageError={MessageError}
-                  messageContentWidth={messageContentWidth}
-                  messageGroupedSingleOrBottom={messageGroupedSingleOrBottom}
-                  noBorder={noBorder}
-                  reactionListPosition={reactionListPosition}
-                  ReactionListTop={ReactionListTop}
-                  reactionListType={reactionListType}
-                  setMessageContentWidth={setMessageContentWidth}
-                  message={message}
-                />
-              )}
-
-              <View style={styles.repliesContainer}>
-                <MessageReplies />
-              </View>
-
-              {reactionListPosition === 'bottom' && ReactionListBottom ? (
-                <ReactionListBottom type={reactionListType} />
-              ) : null}
-              <MessageFooter date={message.created_at} />
-            </View>
-          )}
-          {MessageSpacer ? <MessageSpacer /> : null}
-        </View>
+        {enableSwipeToReply && !isMessageTypeDeleted ? (
+          <SwipableMessageWrapper
+            alignment={alignment}
+            messageContentWidth={messageContentWidth}
+            MessageSwipeContent={MessageSwipeContent}
+            messageSwipeToReplyHitSlop={messageSwipeToReplyHitSlop}
+            onSwipe={onSwipeActionHandler}
+            setMessageContentWidth={setMessageContentWidth}
+          >
+            {itemViewContent}
+          </SwipableMessageWrapper>
+        ) : (
+          itemViewContent
+        )}
       </View>
     );
   },
@@ -504,7 +488,6 @@ export const MessageItemView = forwardRef<View, MessageItemViewProps>((props, re
     message,
     onlyEmojis,
     otherAttachments,
-    isMessageAIGenerated,
     setQuotedMessage,
     lastGroupMessage,
     members,
@@ -530,11 +513,6 @@ export const MessageItemView = forwardRef<View, MessageItemViewProps>((props, re
     reactionListType,
     ReactionListTop,
   } = useMessagesContext();
-  const isAIGenerated = useMemo(
-    () => isMessageAIGenerated(message),
-    [message, isMessageAIGenerated],
-  );
-  const shouldRenderSwipeableWrapper = (message?.attachments || []).length > 0 || isAIGenerated;
 
   return (
     <MemoizedMessageItemView
@@ -565,7 +543,6 @@ export const MessageItemView = forwardRef<View, MessageItemViewProps>((props, re
         reactionListType,
         ReactionListTop,
         setQuotedMessage,
-        shouldRenderSwipeableWrapper,
         lastGroupMessage,
         members,
       }}

--- a/package/src/components/Message/MessageItemView/MessageItemView.tsx
+++ b/package/src/components/Message/MessageItemView/MessageItemView.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo, useState } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import { Dimensions, StyleSheet, View, ViewStyle } from 'react-native';
 
 import { MessageBubble, SwipableMessageWrapper } from './MessageBubble';
@@ -195,7 +195,6 @@ export type MessageItemViewPropsWithContext = Pick<
 
 const MessageItemViewWithContext = forwardRef<View, MessageItemViewPropsWithContext>(
   (props, ref) => {
-    const [messageContentWidth, setMessageContentWidth] = useState(0);
     const { width } = Dimensions.get('screen');
     const {
       alignment,
@@ -334,11 +333,9 @@ const MessageItemViewWithContext = forwardRef<View, MessageItemViewPropsWithCont
         {enableSwipeToReply && !isMessageTypeDeleted ? (
           <SwipableMessageWrapper
             alignment={alignment}
-            messageContentWidth={messageContentWidth}
             MessageSwipeContent={MessageSwipeContent}
             messageSwipeToReplyHitSlop={messageSwipeToReplyHitSlop}
             onSwipe={onSwipeActionHandler}
-            setMessageContentWidth={setMessageContentWidth}
           >
             {itemViewContent}
           </SwipableMessageWrapper>

--- a/package/src/components/Message/MessageItemView/__tests__/MessageContent.test.js
+++ b/package/src/components/Message/MessageItemView/__tests__/MessageContent.test.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { cleanup, render, screen, waitFor } from '@testing-library/react-native';
@@ -17,8 +17,6 @@ import { getTestClientWithUser } from '../../../../mock-builders/mock';
 import { Channel } from '../../../Channel/Channel';
 import { Chat } from '../../../Chat/Chat';
 import { Message } from '../../Message';
-import { MessageContent } from '../MessageContent';
-
 describe('MessageContent', () => {
   let channel;
   let chatClient;
@@ -359,19 +357,10 @@ describe('MessageContent', () => {
       user,
     });
 
-    // This needs to be mocked like that cause native onLayout on MessageContent would never
-    // trigger.
-    const MessageContentWithMockedMessageContentWidth = (props) => {
-      useEffect(() => {
-        props.setMessageContentWidth(100);
-      }, [props]);
-      return <MessageContent {...props} />;
-    };
-
     render(
       <ChannelsStateProvider>
         <Chat client={chatClient}>
-          <Channel channel={channel} MessageContent={MessageContentWithMockedMessageContentWidth}>
+          <Channel channel={channel}>
             <Message groupStyles={['bottom']} message={message} reactionsEnabled />
           </Channel>
         </Chat>

--- a/package/src/components/Message/MessageItemView/__tests__/MessageItemView.test.js
+++ b/package/src/components/Message/MessageItemView/__tests__/MessageItemView.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Text } from 'react-native';
+import { GestureDetector } from 'react-native-gesture-handler';
 
 import { cleanup, render, screen, waitFor } from '@testing-library/react-native';
 
@@ -104,6 +105,19 @@ describe('MessageItemView', () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId('message-components')).toBeDefined();
+    });
+  });
+
+  it('wraps the full MessageItemView with swipe-to-reply', async () => {
+    const user = generateUser();
+    const message = generateMessage({ user });
+
+    renderMessage({ message });
+
+    await waitFor(() => {
+      const gestureDetector = screen.UNSAFE_getByType(GestureDetector);
+
+      expect(gestureDetector.findByProps({ testID: 'message-item-view-wrapper' })).toBeTruthy();
     });
   });
 

--- a/package/src/components/Message/MessageItemView/__tests__/ReactionListTop.test.js
+++ b/package/src/components/Message/MessageItemView/__tests__/ReactionListTop.test.js
@@ -51,7 +51,6 @@ describe('ReactionListTop', () => {
   it('renders the ReactionListTop component', async () => {
     renderMessage({
       hasReactions: true,
-      messageContentWidth: 100,
       reactions: [{ count: 1, own: true, type: 'love' }],
     });
 
@@ -63,7 +62,6 @@ describe('ReactionListTop', () => {
   it('return null in ReactionListTop component when hasReactions false', async () => {
     renderMessage({
       hasReactions: false,
-      messageContentWidth: 100,
       reactions: [{ count: 1, own: true, type: 'love' }],
     });
 
@@ -76,7 +74,6 @@ describe('ReactionListTop', () => {
     renderMessage(
       {
         hasReactions: false,
-        messageContentWidth: 100,
         reactions: [{ count: 1, own: true, type: 'love' }],
       },
       { supportedReactions: [] },

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -370,101 +370,99 @@ exports[`Thread should match thread snapshot 1`] = `
                   <View>
                     <View>
                       <View
-                        pointerEvents="box-none"
-                        style={
+                        collapsable={false}
+                        hitSlop={
                           {
-                            "alignItems": "flex-end",
-                            "flexDirection": "row",
-                            "gap": 8,
-                            "paddingVertical": 8,
+                            "left": 750,
+                            "right": 750,
                           }
                         }
-                        testID="message-item-view-wrapper"
+                        style={
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "zIndex": 1,
+                          }
+                        }
                       >
                         <View
-                          style={{}}
-                          testID="message-author"
+                          pointerEvents="box-none"
+                          style={
+                            {
+                              "alignItems": "flex-end",
+                              "flexDirection": "row",
+                              "gap": 8,
+                              "paddingVertical": 8,
+                              "width": "100%",
+                            }
+                          }
+                          testID="message-item-view-wrapper"
                         >
                           <View
-                            testID="user-avatar"
+                            style={{}}
+                            testID="message-author"
                           >
                             <View
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "borderRadius": 9999,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                  },
-                                  {
-                                    "height": 32,
-                                    "width": 32,
-                                  },
-                                  {
-                                    "backgroundColor": "#fcd579",
-                                  },
-                                  {
-                                    "borderColor": "rgba(26, 27, 37, 0.1)",
-                                    "borderWidth": 1,
-                                  },
-                                  undefined,
-                                ]
-                              }
-                              testID="avatar-image"
+                              testID="user-avatar"
                             >
-                              <Image
-                                onError={[Function]}
-                                source={
-                                  {
-                                    "uri": "https://i.imgur.com/LuuGvh0.png",
-                                  }
-                                }
+                              <View
                                 style={
                                   [
-                                    {},
+                                    {
+                                      "alignItems": "center",
+                                      "borderRadius": 9999,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                    },
                                     {
                                       "height": 32,
                                       "width": 32,
                                     },
+                                    {
+                                      "backgroundColor": "#fcd579",
+                                    },
+                                    {
+                                      "borderColor": "rgba(26, 27, 37, 0.1)",
+                                      "borderWidth": 1,
+                                    },
+                                    undefined,
                                   ]
                                 }
-                              />
+                                testID="avatar-image"
+                              >
+                                <Image
+                                  onError={[Function]}
+                                  source={
+                                    {
+                                      "uri": "https://i.imgur.com/LuuGvh0.png",
+                                    }
+                                  }
+                                  style={
+                                    [
+                                      {},
+                                      {
+                                        "height": 32,
+                                        "width": 32,
+                                      },
+                                    ]
+                                  }
+                                />
+                              </View>
                             </View>
                           </View>
-                        </View>
-                        <View
-                          style={
-                            [
-                              {
-                                "gap": 4,
-                              },
-                              {
-                                "alignItems": "flex-start",
-                              },
-                              {},
-                            ]
-                          }
-                          testID="message-components"
-                        >
                           <View
-                            collapsable={false}
-                            hitSlop={
-                              {
-                                "left": 750,
-                                "right": 750,
-                              }
-                            }
                             style={
                               [
                                 {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "zIndex": 1,
+                                  "gap": 4,
+                                },
+                                {
+                                  "alignItems": "flex-start",
                                 },
                                 {},
                               ]
                             }
+                            testID="message-components"
                           >
                             <View
                               style={{}}
@@ -516,7 +514,6 @@ exports[`Thread should match thread snapshot 1`] = `
                                   style={{}}
                                 >
                                   <View
-                                    onLayout={[Function]}
                                     style={{}}
                                   >
                                     <View
@@ -608,44 +605,44 @@ exports[`Thread should match thread snapshot 1`] = `
                                 </View>
                               </View>
                             </View>
-                          </View>
-                          <View
-                            style={
-                              {
-                                "marginTop": -4,
-                              }
-                            }
-                          />
-                          <View
-                            style={
-                              [
+                            <View
+                              style={
                                 {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "gap": 8,
-                                  "justifyContent": "center",
-                                  "paddingVertical": 4,
-                                },
-                                {},
-                              ]
-                            }
-                            testID="message-status-time"
-                          >
-                            <Text
+                                  "marginTop": -4,
+                                }
+                              }
+                            />
+                            <View
                               style={
                                 [
                                   {
-                                    "color": "#687385",
-                                    "fontSize": 13,
-                                    "fontWeight": 400,
-                                    "lineHeight": 16,
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                    "gap": 8,
+                                    "justifyContent": "center",
+                                    "paddingVertical": 4,
                                   },
                                   {},
                                 ]
                               }
+                              testID="message-status-time"
                             >
-                              Edited
-                            </Text>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "color": "#687385",
+                                      "fontSize": 13,
+                                      "fontWeight": 400,
+                                      "lineHeight": 16,
+                                    },
+                                    {},
+                                  ]
+                                }
+                              >
+                                Edited
+                              </Text>
+                            </View>
                           </View>
                         </View>
                       </View>
@@ -697,101 +694,99 @@ exports[`Thread should match thread snapshot 1`] = `
                   <View>
                     <View>
                       <View
-                        pointerEvents="box-none"
-                        style={
+                        collapsable={false}
+                        hitSlop={
                           {
-                            "alignItems": "flex-end",
-                            "flexDirection": "row",
-                            "gap": 8,
-                            "paddingVertical": 8,
+                            "left": 750,
+                            "right": 750,
                           }
                         }
-                        testID="message-item-view-wrapper"
+                        style={
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "zIndex": 1,
+                          }
+                        }
                       >
                         <View
-                          style={{}}
-                          testID="message-author"
+                          pointerEvents="box-none"
+                          style={
+                            {
+                              "alignItems": "flex-end",
+                              "flexDirection": "row",
+                              "gap": 8,
+                              "paddingVertical": 8,
+                              "width": "100%",
+                            }
+                          }
+                          testID="message-item-view-wrapper"
                         >
                           <View
-                            testID="user-avatar"
+                            style={{}}
+                            testID="message-author"
                           >
                             <View
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "borderRadius": 9999,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                  },
-                                  {
-                                    "height": 32,
-                                    "width": 32,
-                                  },
-                                  {
-                                    "backgroundColor": "#8febbd",
-                                  },
-                                  {
-                                    "borderColor": "rgba(26, 27, 37, 0.1)",
-                                    "borderWidth": 1,
-                                  },
-                                  undefined,
-                                ]
-                              }
-                              testID="avatar-image"
+                              testID="user-avatar"
                             >
-                              <Image
-                                onError={[Function]}
-                                source={
-                                  {
-                                    "uri": "https://i.imgur.com/spueyAP.png",
-                                  }
-                                }
+                              <View
                                 style={
                                   [
-                                    {},
+                                    {
+                                      "alignItems": "center",
+                                      "borderRadius": 9999,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                    },
                                     {
                                       "height": 32,
                                       "width": 32,
                                     },
+                                    {
+                                      "backgroundColor": "#8febbd",
+                                    },
+                                    {
+                                      "borderColor": "rgba(26, 27, 37, 0.1)",
+                                      "borderWidth": 1,
+                                    },
+                                    undefined,
                                   ]
                                 }
-                              />
+                                testID="avatar-image"
+                              >
+                                <Image
+                                  onError={[Function]}
+                                  source={
+                                    {
+                                      "uri": "https://i.imgur.com/spueyAP.png",
+                                    }
+                                  }
+                                  style={
+                                    [
+                                      {},
+                                      {
+                                        "height": 32,
+                                        "width": 32,
+                                      },
+                                    ]
+                                  }
+                                />
+                              </View>
                             </View>
                           </View>
-                        </View>
-                        <View
-                          style={
-                            [
-                              {
-                                "gap": 4,
-                              },
-                              {
-                                "alignItems": "flex-start",
-                              },
-                              {},
-                            ]
-                          }
-                          testID="message-components"
-                        >
                           <View
-                            collapsable={false}
-                            hitSlop={
-                              {
-                                "left": 750,
-                                "right": 750,
-                              }
-                            }
                             style={
                               [
                                 {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "zIndex": 1,
+                                  "gap": 4,
+                                },
+                                {
+                                  "alignItems": "flex-start",
                                 },
                                 {},
                               ]
                             }
+                            testID="message-components"
                           >
                             <View
                               style={{}}
@@ -843,7 +838,6 @@ exports[`Thread should match thread snapshot 1`] = `
                                   style={{}}
                                 >
                                   <View
-                                    onLayout={[Function]}
                                     style={{}}
                                   >
                                     <View
@@ -935,44 +929,44 @@ exports[`Thread should match thread snapshot 1`] = `
                                 </View>
                               </View>
                             </View>
-                          </View>
-                          <View
-                            style={
-                              {
-                                "marginTop": -4,
-                              }
-                            }
-                          />
-                          <View
-                            style={
-                              [
+                            <View
+                              style={
                                 {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "gap": 8,
-                                  "justifyContent": "center",
-                                  "paddingVertical": 4,
-                                },
-                                {},
-                              ]
-                            }
-                            testID="message-status-time"
-                          >
-                            <Text
+                                  "marginTop": -4,
+                                }
+                              }
+                            />
+                            <View
                               style={
                                 [
                                   {
-                                    "color": "#687385",
-                                    "fontSize": 13,
-                                    "fontWeight": 400,
-                                    "lineHeight": 16,
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                    "gap": 8,
+                                    "justifyContent": "center",
+                                    "paddingVertical": 4,
                                   },
                                   {},
                                 ]
                               }
+                              testID="message-status-time"
                             >
-                              Edited
-                            </Text>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "color": "#687385",
+                                      "fontSize": 13,
+                                      "fontWeight": 400,
+                                      "lineHeight": 16,
+                                    },
+                                    {},
+                                  ]
+                                }
+                              >
+                                Edited
+                              </Text>
+                            </View>
                           </View>
                         </View>
                       </View>
@@ -1057,101 +1051,99 @@ exports[`Thread should match thread snapshot 1`] = `
                   <View>
                     <View>
                       <View
-                        pointerEvents="box-none"
-                        style={
+                        collapsable={false}
+                        hitSlop={
                           {
-                            "alignItems": "flex-end",
-                            "flexDirection": "row",
-                            "gap": 8,
-                            "paddingVertical": 8,
+                            "left": 750,
+                            "right": 750,
                           }
                         }
-                        testID="message-item-view-wrapper"
+                        style={
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "zIndex": 1,
+                          }
+                        }
                       >
                         <View
-                          style={{}}
-                          testID="message-author"
+                          pointerEvents="box-none"
+                          style={
+                            {
+                              "alignItems": "flex-end",
+                              "flexDirection": "row",
+                              "gap": 8,
+                              "paddingVertical": 8,
+                              "width": "100%",
+                            }
+                          }
+                          testID="message-item-view-wrapper"
                         >
                           <View
-                            testID="user-avatar"
+                            style={{}}
+                            testID="message-author"
                           >
                             <View
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "borderRadius": 9999,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                  },
-                                  {
-                                    "height": 32,
-                                    "width": 32,
-                                  },
-                                  {
-                                    "backgroundColor": "#fcd579",
-                                  },
-                                  {
-                                    "borderColor": "rgba(26, 27, 37, 0.1)",
-                                    "borderWidth": 1,
-                                  },
-                                  undefined,
-                                ]
-                              }
-                              testID="avatar-image"
+                              testID="user-avatar"
                             >
-                              <Image
-                                onError={[Function]}
-                                source={
-                                  {
-                                    "uri": "https://i.imgur.com/LuuGvh0.png",
-                                  }
-                                }
+                              <View
                                 style={
                                   [
-                                    {},
+                                    {
+                                      "alignItems": "center",
+                                      "borderRadius": 9999,
+                                      "justifyContent": "center",
+                                      "overflow": "hidden",
+                                    },
                                     {
                                       "height": 32,
                                       "width": 32,
                                     },
+                                    {
+                                      "backgroundColor": "#fcd579",
+                                    },
+                                    {
+                                      "borderColor": "rgba(26, 27, 37, 0.1)",
+                                      "borderWidth": 1,
+                                    },
+                                    undefined,
                                   ]
                                 }
-                              />
+                                testID="avatar-image"
+                              >
+                                <Image
+                                  onError={[Function]}
+                                  source={
+                                    {
+                                      "uri": "https://i.imgur.com/LuuGvh0.png",
+                                    }
+                                  }
+                                  style={
+                                    [
+                                      {},
+                                      {
+                                        "height": 32,
+                                        "width": 32,
+                                      },
+                                    ]
+                                  }
+                                />
+                              </View>
                             </View>
                           </View>
-                        </View>
-                        <View
-                          style={
-                            [
-                              {
-                                "gap": 4,
-                              },
-                              {
-                                "alignItems": "flex-start",
-                              },
-                              {},
-                            ]
-                          }
-                          testID="message-components"
-                        >
                           <View
-                            collapsable={false}
-                            hitSlop={
-                              {
-                                "left": 750,
-                                "right": 750,
-                              }
-                            }
                             style={
                               [
                                 {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "zIndex": 1,
+                                  "gap": 4,
+                                },
+                                {
+                                  "alignItems": "flex-start",
                                 },
                                 {},
                               ]
                             }
+                            testID="message-components"
                           >
                             <View
                               style={{}}
@@ -1203,7 +1195,6 @@ exports[`Thread should match thread snapshot 1`] = `
                                   style={{}}
                                 >
                                   <View
-                                    onLayout={[Function]}
                                     style={{}}
                                   >
                                     <View
@@ -1295,44 +1286,44 @@ exports[`Thread should match thread snapshot 1`] = `
                                 </View>
                               </View>
                             </View>
-                          </View>
-                          <View
-                            style={
-                              {
-                                "marginTop": -4,
-                              }
-                            }
-                          />
-                          <View
-                            style={
-                              [
+                            <View
+                              style={
                                 {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "gap": 8,
-                                  "justifyContent": "center",
-                                  "paddingVertical": 4,
-                                },
-                                {},
-                              ]
-                            }
-                            testID="message-status-time"
-                          >
-                            <Text
+                                  "marginTop": -4,
+                                }
+                              }
+                            />
+                            <View
                               style={
                                 [
                                   {
-                                    "color": "#687385",
-                                    "fontSize": 13,
-                                    "fontWeight": 400,
-                                    "lineHeight": 16,
+                                    "alignItems": "center",
+                                    "flexDirection": "row",
+                                    "gap": 8,
+                                    "justifyContent": "center",
+                                    "paddingVertical": 4,
                                   },
                                   {},
                                 ]
                               }
+                              testID="message-status-time"
                             >
-                              Edited
-                            </Text>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "color": "#687385",
+                                      "fontSize": 13,
+                                      "fontWeight": 400,
+                                      "lineHeight": 16,
+                                    },
+                                    {},
+                                  ]
+                                }
+                              >
+                                Edited
+                              </Text>
+                            </View>
                           </View>
                         </View>
                       </View>
@@ -1374,102 +1365,100 @@ exports[`Thread should match thread snapshot 1`] = `
                 <View>
                   <View>
                     <View
-                      pointerEvents="box-none"
-                      style={
+                      collapsable={false}
+                      hitSlop={
                         {
-                          "alignItems": "flex-end",
-                          "flexDirection": "row",
-                          "gap": 8,
-                          "marginBottom": 12,
-                          "paddingVertical": 8,
+                          "left": 750,
+                          "right": 750,
                         }
                       }
-                      testID="message-item-view-wrapper"
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "zIndex": 1,
+                        }
+                      }
                     >
                       <View
-                        style={{}}
-                        testID="message-author"
+                        pointerEvents="box-none"
+                        style={
+                          {
+                            "alignItems": "flex-end",
+                            "flexDirection": "row",
+                            "gap": 8,
+                            "marginBottom": 12,
+                            "paddingVertical": 8,
+                            "width": "100%",
+                          }
+                        }
+                        testID="message-item-view-wrapper"
                       >
                         <View
-                          testID="user-avatar"
+                          style={{}}
+                          testID="message-author"
                         >
                           <View
-                            style={
-                              [
-                                {
-                                  "alignItems": "center",
-                                  "borderRadius": 9999,
-                                  "justifyContent": "center",
-                                  "overflow": "hidden",
-                                },
-                                {
-                                  "height": 32,
-                                  "width": 32,
-                                },
-                                {
-                                  "backgroundColor": "#8febbd",
-                                },
-                                {
-                                  "borderColor": "rgba(26, 27, 37, 0.1)",
-                                  "borderWidth": 1,
-                                },
-                                undefined,
-                              ]
-                            }
-                            testID="avatar-image"
+                            testID="user-avatar"
                           >
-                            <Image
-                              onError={[Function]}
-                              source={
-                                {
-                                  "uri": "https://i.imgur.com/spueyAP.png",
-                                }
-                              }
+                            <View
                               style={
                                 [
-                                  {},
+                                  {
+                                    "alignItems": "center",
+                                    "borderRadius": 9999,
+                                    "justifyContent": "center",
+                                    "overflow": "hidden",
+                                  },
                                   {
                                     "height": 32,
                                     "width": 32,
                                   },
+                                  {
+                                    "backgroundColor": "#8febbd",
+                                  },
+                                  {
+                                    "borderColor": "rgba(26, 27, 37, 0.1)",
+                                    "borderWidth": 1,
+                                  },
+                                  undefined,
                                 ]
                               }
-                            />
+                              testID="avatar-image"
+                            >
+                              <Image
+                                onError={[Function]}
+                                source={
+                                  {
+                                    "uri": "https://i.imgur.com/spueyAP.png",
+                                  }
+                                }
+                                style={
+                                  [
+                                    {},
+                                    {
+                                      "height": 32,
+                                      "width": 32,
+                                    },
+                                  ]
+                                }
+                              />
+                            </View>
                           </View>
                         </View>
-                      </View>
-                      <View
-                        style={
-                          [
-                            {
-                              "gap": 4,
-                            },
-                            {
-                              "alignItems": "flex-start",
-                            },
-                            {},
-                          ]
-                        }
-                        testID="message-components"
-                      >
                         <View
-                          collapsable={false}
-                          hitSlop={
-                            {
-                              "left": 750,
-                              "right": 750,
-                            }
-                          }
                           style={
                             [
                               {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "zIndex": 1,
+                                "gap": 4,
+                              },
+                              {
+                                "alignItems": "flex-start",
                               },
                               {},
                             ]
                           }
+                          testID="message-components"
                         >
                           <View
                             style={{}}
@@ -1521,7 +1510,6 @@ exports[`Thread should match thread snapshot 1`] = `
                                 style={{}}
                               >
                                 <View
-                                  onLayout={[Function]}
                                   style={{}}
                                 >
                                   <View
@@ -1613,44 +1601,44 @@ exports[`Thread should match thread snapshot 1`] = `
                               </View>
                             </View>
                           </View>
-                        </View>
-                        <View
-                          style={
-                            {
-                              "marginTop": -4,
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            [
+                          <View
+                            style={
                               {
-                                "alignItems": "center",
-                                "flexDirection": "row",
-                                "gap": 8,
-                                "justifyContent": "center",
-                                "paddingVertical": 4,
-                              },
-                              {},
-                            ]
-                          }
-                          testID="message-status-time"
-                        >
-                          <Text
+                                "marginTop": -4,
+                              }
+                            }
+                          />
+                          <View
                             style={
                               [
                                 {
-                                  "color": "#687385",
-                                  "fontSize": 13,
-                                  "fontWeight": 400,
-                                  "lineHeight": 16,
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "gap": 8,
+                                  "justifyContent": "center",
+                                  "paddingVertical": 4,
                                 },
                                 {},
                               ]
                             }
+                            testID="message-status-time"
                           >
-                            Edited
-                          </Text>
+                            <Text
+                              style={
+                                [
+                                  {
+                                    "color": "#687385",
+                                    "fontSize": 13,
+                                    "fontWeight": 400,
+                                    "lineHeight": 16,
+                                  },
+                                  {},
+                                ]
+                              }
+                            >
+                              Edited
+                            </Text>
+                          </View>
                         </View>
                       </View>
                     </View>


### PR DESCRIPTION
## 🎯 Goal

This PR moves swipe-to-reply from the inner MessageBubble to the full MessageItemView, so the entire rendered message row now participates in the swipe interaction instead of only the bubble. The underlying swipe implementation is intentionally unchanged: it keeps the same gesture activation rules, thresholding, haptics, and swipe content behavior.

As part of that change, the old `messageContentWidth` / `setMessageContentWidth` measurement path was removed from `MessageItemView`, `MessageBubble` and `MessageContent`, because that state was no longer used by the UI after the swipe boundary moved. This simplifies the message rendering stack and removes an unnecessary layout driven state update/rerender path.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


