### PR TITLE
fix: ui redesign bugs

### DIFF
--- a/package/src/components/Attachment/Audio/AudioAttachment.tsx
+++ b/package/src/components/Attachment/Audio/AudioAttachment.tsx
@@ -168,7 +168,6 @@ export const AudioAttachment = (props: AudioAttachmentProps) => {
   const dragEnd = async (currentProgress: number) => {
     const positionInSeconds = (currentProgress * duration) / ONE_SECOND_IN_MILLISECONDS;
     await audioPlayer.seek(positionInSeconds);
-    audioPlayer.play();
   };
 
   const onSpeedChangeHandler = async () => {

--- a/package/src/components/Message/MessageItemView/MessageFooter.tsx
+++ b/package/src/components/Message/MessageItemView/MessageFooter.tsx
@@ -37,7 +37,7 @@ type MessageFooterPropsWithContext = Pick<
   | 'lastGroupMessage'
   | 'isMessageAIGenerated'
 > &
-  Pick<MessagesContextValue, 'MessageStatus'> &
+  Pick<MessagesContextValue, 'MessageStatus' | 'MessageTimestamp'> &
   MessageFooterComponentProps;
 
 const MessageFooterWithContext = (props: MessageFooterPropsWithContext) => {
@@ -50,6 +50,7 @@ const MessageFooterWithContext = (props: MessageFooterPropsWithContext) => {
     members,
     message,
     MessageStatus,
+    MessageTimestamp,
     showMessageStatus,
   } = props;
   const styles = useStyles();
@@ -77,9 +78,12 @@ const MessageFooterWithContext = (props: MessageFooterPropsWithContext) => {
   return (
     <View style={[styles.container, container]} testID='message-status-time'>
       {Object.keys(members).length > 2 && alignment === 'left' && message.user?.name ? (
-        <Text style={[styles.name, name]}>{message.user.name}</Text>
+        <Text numberOfLines={1} ellipsizeMode='tail' style={[styles.name, name]}>
+          {message.user.name}
+        </Text>
       ) : null}
-      {showMessageStatus && <MessageStatus formattedDate={formattedDate} timestamp={date} />}
+      {showMessageStatus ? <MessageStatus /> : null}
+      <MessageTimestamp formattedDate={formattedDate} timestamp={date} />
       {isEdited ? <Text style={[styles.editedText, editedText]}>{t('Edited')}</Text> : null}
     </View>
   );
@@ -201,6 +205,7 @@ const useStyles = () => {
   return useMemo(() => {
     return StyleSheet.create({
       container: {
+        maxWidth: '100%',
         alignItems: 'center',
         flexDirection: 'row',
         justifyContent: 'center',
@@ -208,6 +213,7 @@ const useStyles = () => {
         gap: primitives.spacingXs,
       },
       name: {
+        flexShrink: 1,
         color: shouldUseOverlayStyles ? semantics.textOnAccent : semantics.chatTextUsername,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightSemiBold,

--- a/package/src/components/Message/MessageItemView/MessageStatus.tsx
+++ b/package/src/components/Message/MessageItemView/MessageStatus.tsx
@@ -6,10 +6,6 @@ import {
   MessageContextValue,
   useMessageContext,
 } from '../../../contexts/messageContext/MessageContext';
-import {
-  MessagesContextValue,
-  useMessagesContext,
-} from '../../../contexts/messagesContext/MessagesContext';
 import { useTheme } from '../../../contexts/themeContext/ThemeContext';
 import { Check } from '../../../icons/Check';
 import { CheckAll } from '../../../icons/CheckAll';
@@ -21,14 +17,10 @@ import { useShouldUseOverlayStyles } from '../hooks/useShouldUseOverlayStyles';
 export type MessageStatusPropsWithContext = Pick<
   MessageContextValue,
   'deliveredToCount' | 'message' | 'readBy'
-> &
-  Pick<MessagesContextValue, 'MessageTimestamp'> & {
-    formattedDate?: string | Date;
-    timestamp?: string | Date;
-  };
+>;
 
 const MessageStatusWithContext = (props: MessageStatusPropsWithContext) => {
-  const { deliveredToCount, formattedDate, message, readBy, timestamp, MessageTimestamp } = props;
+  const { deliveredToCount, message, readBy } = props;
 
   const styles = useStyles();
 
@@ -92,7 +84,6 @@ const MessageStatusWithContext = (props: MessageStatusPropsWithContext) => {
           {...checkIcon}
         />
       ) : null}
-      <MessageTimestamp formattedDate={formattedDate} timestamp={timestamp} />
     </View>
   );
 };
@@ -101,20 +92,8 @@ const areEqual = (
   prevProps: MessageStatusPropsWithContext,
   nextProps: MessageStatusPropsWithContext,
 ) => {
-  const {
-    deliveredToCount: prevDeliveredBy,
-    message: prevMessage,
-    readBy: prevReadBy,
-    formattedDate: prevFormattedDate,
-    timestamp: prevTimestamp,
-  } = prevProps;
-  const {
-    deliveredToCount: nextDeliveredBy,
-    message: nextMessage,
-    readBy: nextReadBy,
-    formattedDate: nextFormattedDate,
-    timestamp: nextTimestamp,
-  } = nextProps;
+  const { deliveredToCount: prevDeliveredBy, message: prevMessage, readBy: prevReadBy } = prevProps;
+  const { deliveredToCount: nextDeliveredBy, message: nextMessage, readBy: nextReadBy } = nextProps;
 
   const deliveredByEqual = prevDeliveredBy === nextDeliveredBy;
   if (!deliveredByEqual) {
@@ -132,16 +111,6 @@ const areEqual = (
     return false;
   }
 
-  const timestampEqual = prevTimestamp === nextTimestamp;
-  if (!timestampEqual) {
-    return false;
-  }
-
-  const formattedDateEqual = prevFormattedDate === nextFormattedDate;
-  if (!formattedDateEqual) {
-    return false;
-  }
-
   return true;
 };
 
@@ -155,7 +124,6 @@ export type MessageStatusProps = Partial<MessageStatusPropsWithContext>;
 export const MessageStatus = (props: MessageStatusProps) => {
   const { channel } = useChannelContext();
   const { deliveredToCount, message, readBy } = useMessageContext();
-  const { MessageTimestamp } = useMessagesContext();
 
   const channelMembersCount = Object.keys(channel?.state.members).length;
 
@@ -167,7 +135,6 @@ export const MessageStatus = (props: MessageStatusProps) => {
         deliveredToCount,
         message,
         readBy,
-        MessageTimestamp,
       }}
       {...props}
     />

--- a/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingPreview.tsx
+++ b/package/src/components/MessageInput/components/AudioRecorder/AudioRecordingPreview.tsx
@@ -108,7 +108,6 @@ export const AudioRecordingPreview = () => {
   const dragEnd = useStableCallback(async (currentProgress: number) => {
     const positionInSeconds = (currentProgress * duration) / ONE_SECOND_IN_MILLISECONDS;
     await audioPlayer.seek(positionInSeconds);
-    audioPlayer.play();
   });
 
   return (

--- a/package/src/components/MessageInput/hooks/useAudioRecorder.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioRecorder.tsx
@@ -12,8 +12,6 @@ import { resampleWaveformData } from '../utils/audioSampling';
 
 /**
  * The hook that controls all the async audio core features including start/stop or recording, player, upload/delete of the recorded audio.
- *
- * FIXME: Change the name to `useAudioRecorder` in the next major version as the hook will only be used for audio recording.
  */
 export const useAudioRecorder = ({
   audioRecorderManager,

--- a/package/src/components/MessageInput/hooks/useAudioRecorder.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioRecorder.tsx
@@ -114,7 +114,7 @@ export const useAudioRecorder = ({
         console.log('Error uploading voice recording: ', error);
       }
     },
-    [audioRecorderManager, attachmentManager, stopVoiceRecording],
+    [audioRecorderManager, attachmentManager, sendMessage, stopVoiceRecording],
   );
 
   return {

--- a/package/src/components/MessageInput/hooks/useAudioRecorder.tsx
+++ b/package/src/components/MessageInput/hooks/useAudioRecorder.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { LocalVoiceRecordingAttachment } from 'stream-chat';
 
@@ -19,7 +19,6 @@ export const useAudioRecorder = ({
   audioRecorderManager,
   sendMessage,
 }: Pick<MessageInputContextValue, 'audioRecorderManager' | 'sendMessage'>) => {
-  const [isScheduledForSubmit, setIsScheduleForSubmit] = useState(false);
   const { attachmentManager } = useMessageComposer();
 
   /**
@@ -42,13 +41,6 @@ export const useAudioRecorder = ({
     },
     [stopVoiceRecording],
   );
-
-  useEffect(() => {
-    if (isScheduledForSubmit) {
-      sendMessage();
-      setIsScheduleForSubmit(false);
-    }
-  }, [isScheduledForSubmit, sendMessage]);
 
   /**
    * Function to start voice recording. Will return whether access is granted
@@ -113,8 +105,8 @@ export const useAudioRecorder = ({
         audioRecorderManager.reset();
 
         if (sendOnComplete) {
-          await attachmentManager.uploadAttachment(audioFile);
-          setIsScheduleForSubmit(true);
+          attachmentManager.upsertAttachments([audioFile]);
+          sendMessage();
         } else {
           await attachmentManager.uploadAttachment(audioFile);
         }

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -620,6 +620,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                     "flexDirection": "row",
                                     "gap": 8,
                                     "justifyContent": "center",
+                                    "maxWidth": "100%",
                                     "paddingVertical": 4,
                                   },
                                   {},
@@ -627,6 +628,18 @@ exports[`Thread should match thread snapshot 1`] = `
                               }
                               testID="message-status-time"
                             >
+                              <Text
+                                style={
+                                  {
+                                    "color": "#687385",
+                                    "fontSize": 13,
+                                    "fontWeight": 400,
+                                    "lineHeight": 16,
+                                  }
+                                }
+                              >
+                                2:50 PM
+                              </Text>
                               <Text
                                 style={
                                   [
@@ -944,6 +957,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                     "flexDirection": "row",
                                     "gap": 8,
                                     "justifyContent": "center",
+                                    "maxWidth": "100%",
                                     "paddingVertical": 4,
                                   },
                                   {},
@@ -951,6 +965,18 @@ exports[`Thread should match thread snapshot 1`] = `
                               }
                               testID="message-status-time"
                             >
+                              <Text
+                                style={
+                                  {
+                                    "color": "#687385",
+                                    "fontSize": 13,
+                                    "fontWeight": 400,
+                                    "lineHeight": 16,
+                                  }
+                                }
+                              >
+                                2:50 PM
+                              </Text>
                               <Text
                                 style={
                                   [
@@ -1301,6 +1327,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                     "flexDirection": "row",
                                     "gap": 8,
                                     "justifyContent": "center",
+                                    "maxWidth": "100%",
                                     "paddingVertical": 4,
                                   },
                                   {},
@@ -1308,6 +1335,18 @@ exports[`Thread should match thread snapshot 1`] = `
                               }
                               testID="message-status-time"
                             >
+                              <Text
+                                style={
+                                  {
+                                    "color": "#687385",
+                                    "fontSize": 13,
+                                    "fontWeight": 400,
+                                    "lineHeight": 16,
+                                  }
+                                }
+                              >
+                                2:50 PM
+                              </Text>
                               <Text
                                 style={
                                   [
@@ -1616,6 +1655,7 @@ exports[`Thread should match thread snapshot 1`] = `
                                   "flexDirection": "row",
                                   "gap": 8,
                                   "justifyContent": "center",
+                                  "maxWidth": "100%",
                                   "paddingVertical": 4,
                                 },
                                 {},
@@ -1623,6 +1663,18 @@ exports[`Thread should match thread snapshot 1`] = `
                             }
                             testID="message-status-time"
                           >
+                            <Text
+                              style={
+                                {
+                                  "color": "#687385",
+                                  "fontSize": 13,
+                                  "fontWeight": 400,
+                                  "lineHeight": 16,
+                                }
+                              }
+                            >
+                              2:50 PM
+                            </Text>
                             <Text
                               style={
                                 [

--- a/package/src/components/ThreadList/ThreadListItem.tsx
+++ b/package/src/components/ThreadList/ThreadListItem.tsx
@@ -1,7 +1,14 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
-import { LocalMessage, Thread, ThreadState } from 'stream-chat';
+import {
+  AttachmentManagerState,
+  DraftMessage,
+  LocalMessage,
+  TextComposerState,
+  Thread,
+  ThreadState,
+} from 'stream-chat';
 
 import { ThreadListItemMessagePreview as ThreadListItemMessagePreviewDefault } from './ThreadListItemMessagePreview';
 
@@ -34,11 +41,20 @@ export const attachmentTypeIconMap = {
   voiceRecording: '🎙️',
 } as const;
 
+const textComposerStateSelector = (state: TextComposerState) => ({
+  text: state.text,
+});
+
+const attachmentManagerStateSelector = (state: AttachmentManagerState) => ({
+  attachments: state.attachments,
+});
+
 export const ThreadListItemComponent = () => {
   const {
     channel,
     dateString,
     deletedAtDateString,
+    draftMessage,
     lastReply,
     ownUnreadMessageCount,
     parentMessage,
@@ -57,10 +73,7 @@ export const ThreadListItemComponent = () => {
   const styles = useStyles();
   const { t } = useTranslationContext();
 
-  useEffect(() => {
-    const unsubscribe = thread.messageComposer.registerDraftEventSubscriptions();
-    return () => unsubscribe();
-  }, [thread.messageComposer]);
+  const shouldRenderPreview = !!draftMessage || !!lastReply;
 
   return (
     <View style={styles.wrapper}>
@@ -87,12 +100,14 @@ export const ThreadListItemComponent = () => {
           <Text numberOfLines={1} style={styles.channelName}>
             {displayName || 'N/A'}
           </Text>
-          {lastReply ? (
+          {shouldRenderPreview ? (
             <View style={styles.previewMessageContainer}>
-              <ThreadMessagePreviewDeliveryStatus
-                channel={channel}
-                message={parentMessage as LocalMessage}
-              />
+              {!draftMessage ? (
+                <ThreadMessagePreviewDeliveryStatus
+                  channel={channel}
+                  message={parentMessage as LocalMessage}
+                />
+              ) : null}
               <ThreadListItemMessagePreview message={parentMessage as LocalMessage} />
             </View>
           ) : null}
@@ -129,6 +144,14 @@ export const ThreadListItem = (props: ThreadListItemProps) => {
   const { t, tDateTimeParser } = useTranslationContext();
   const { thread, timestampTranslationKey = 'timestamp/ThreadListItem' } = props;
   const { ThreadListItem = ThreadListItemComponent } = useThreadsContext();
+  const { text: draftText } = useStateStore(
+    thread.messageComposer.textComposer.state,
+    textComposerStateSelector,
+  );
+  const { attachments } = useStateStore(
+    thread.messageComposer.attachmentManager.state,
+    attachmentManagerStateSelector,
+  );
 
   const selector = useCallback(
     (nextValue: ThreadState) =>
@@ -149,6 +172,27 @@ export const ThreadListItem = (props: ThreadListItemProps) => {
   );
 
   const timestamp = lastReply?.created_at;
+
+  useEffect(() => {
+    const unsubscribe = thread.messageComposer.registerDraftEventSubscriptions();
+    return () => unsubscribe();
+  }, [thread.messageComposer]);
+
+  const draftMessage = useMemo<DraftMessage | undefined>(() => {
+    if (thread.messageComposer.compositionIsEmpty) {
+      return undefined;
+    }
+
+    if (!draftText && !attachments?.length) {
+      return undefined;
+    }
+
+    return {
+      attachments,
+      id: thread.messageComposer.id,
+      text: draftText ?? '',
+    };
+  }, [attachments, draftText, thread.messageComposer]);
 
   // TODO: Please rethink this, we have the same line of code in about 5 places in the SDK.
   const dateString = useMemo(
@@ -178,6 +222,7 @@ export const ThreadListItem = (props: ThreadListItemProps) => {
         channel,
         dateString,
         deletedAtDateString,
+        draftMessage,
         lastReply,
         ownUnreadMessageCount,
         parentMessage,
@@ -224,6 +269,7 @@ const useStyles = () => {
         },
         previewMessageContainer: {
           flexDirection: 'row',
+          alignItems: 'center',
           gap: primitives.spacingXxs,
           ...threadListItem.previewMessageContainer,
         },

--- a/package/src/components/ThreadList/ThreadListItemMessagePreview.tsx
+++ b/package/src/components/ThreadList/ThreadListItemMessagePreview.tsx
@@ -4,6 +4,8 @@ import { View, Text, StyleSheet } from 'react-native';
 import { DraftMessage, LocalMessage, MessageResponse } from 'stream-chat';
 
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
+import { useThreadListItemContext } from '../../contexts/threadsContext/ThreadListItemContext';
+import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
 import { useMessagePreviewIcon, useMessagePreviewText } from '../../hooks';
 import { primitives } from '../../theme';
 
@@ -12,15 +14,20 @@ export type ThreadListItemMessagePreviewProps = {
 };
 
 export const ThreadListItemMessagePreview = ({ message }: ThreadListItemMessagePreviewProps) => {
+  const { draftMessage } = useThreadListItemContext();
   const {
     theme: { semantics },
   } = useTheme();
   const styles = useStyles();
-  const MessagePreviewIcon = useMessagePreviewIcon({ message });
-  const messagePreviewTitle = useMessagePreviewText({ message });
+  const { t } = useTranslationContext();
+  const previewMessage = draftMessage ?? message;
+  const MessagePreviewIcon = useMessagePreviewIcon({ message: previewMessage });
+  const messagePreviewTitle = useMessagePreviewText({ message: previewMessage });
+  const isDraft = !!draftMessage;
 
   return (
     <View style={[styles.container]}>
+      {isDraft ? <Text style={styles.draftText}>{t('Draft')}:</Text> : null}
       {MessagePreviewIcon ? (
         <MessagePreviewIcon height={20} stroke={semantics.textPrimary} width={20} />
       ) : null}
@@ -56,6 +63,14 @@ const useStyles = () => {
         flexShrink: 1,
         ...messagePreview.subtitle,
       },
+      draftText: {
+        color: semantics.accentPrimary,
+        fontSize: primitives.typographyFontSizeMd,
+        fontWeight: primitives.typographyFontWeightSemiBold,
+        includeFontPadding: false,
+        lineHeight: primitives.typographyLineHeightNormal,
+        ...messagePreview.draftText,
+      },
     });
-  }, [messagePreview.container, messagePreview.subtitle, semantics.textPrimary]);
+  }, [messagePreview.container, messagePreview.draftText, messagePreview.subtitle, semantics]);
 };

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -238,6 +238,7 @@ export type Theme = {
     };
     messagePreview: {
       container: ViewStyle;
+      draftText: TextStyle;
       subtitle: TextStyle;
     };
   };
@@ -989,6 +990,7 @@ export type Theme = {
     unreadBubbleWrapper: ViewStyle;
     messagePreview: {
       container: ViewStyle;
+      draftText: TextStyle;
       subtitle: TextStyle;
     };
     messagePreviewDeliveryStatus: {
@@ -1167,6 +1169,7 @@ export const defaultTheme: Theme = {
     wrapper: {},
     messagePreview: {
       container: {},
+      draftText: {},
       subtitle: {},
     },
   },
@@ -1893,6 +1896,7 @@ export const defaultTheme: Theme = {
     messageRepliesText: {},
     messagePreview: {
       container: {},
+      draftText: {},
       subtitle: {},
     },
     messagePreviewDeliveryStatus: {

--- a/package/src/contexts/threadsContext/ThreadListItemContext.tsx
+++ b/package/src/contexts/threadsContext/ThreadListItemContext.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, useContext } from 'react';
 
-import { Channel, LocalMessage, Thread } from 'stream-chat';
+import { Channel, DraftMessage, LocalMessage, Thread } from 'stream-chat';
 
 import { DEFAULT_BASE_CONTEXT_VALUE } from '../utils/defaultBaseContextValue';
 
@@ -8,6 +8,7 @@ export type ThreadListItemContextValue = {
   channel: Channel;
   dateString: string | number | undefined;
   deletedAtDateString: string | number | undefined;
+  draftMessage?: DraftMessage;
   lastReply: LocalMessage | undefined;
   ownUnreadMessageCount: number;
   parentMessage: LocalMessage | undefined;


### PR DESCRIPTION
## 🎯 Goal

This PR restores a few message and audio UX behaviours that regressed from develop. It brings thread-list draft previews back, moves message timestamps into the footer next to status, stops audio from auto-resuming after seek in both message attachments and composer previews, and slightly tightens the voice recording autosend path.

  Included changes:

  - Restore thread draft previews in `ThreadListItem`
  - Move `MessageTimestamp` out of `MessageStatus` and render it in `MessageFooter`
  - Stop autoplay after seeking in `AudioAttachment` and `AudioRecordingPreview`
  - Reduce voice-recording autosend overhead in `useAudioRecorder`
  - Add the thread-list draft preview theming/context support and update the related thread snapshot/test coverage

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


