### PR TITLE
fix: remove exif metadata preservation

### DIFF
--- a/package/native-package/android/src/main/java/com/streamchatreactnative/StreamChatReactNative.java
+++ b/package/native-package/android/src/main/java/com/streamchatreactnative/StreamChatReactNative.java
@@ -11,7 +11,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.provider.MediaStore;
 import android.util.Base64;
-import android.util.Log;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -33,108 +32,6 @@ public class StreamChatReactNative {
   private final static String SCHEME_FILE = "file";
   private final static String SCHEME_HTTP = "http";
   private final static String SCHEME_HTTPS = "https";
-
-
-  // List of known EXIF tags we will be copying.
-  // Orientation, width, height, and some others are ignored
-  // TODO: Find any missing tag that might be useful
-  private final static String[] EXIF_TO_COPY_ROTATED = new String[]
-    {
-      ExifInterface.TAG_APERTURE_VALUE,
-      ExifInterface.TAG_MAX_APERTURE_VALUE,
-      ExifInterface.TAG_METERING_MODE,
-      ExifInterface.TAG_ARTIST,
-      ExifInterface.TAG_BITS_PER_SAMPLE,
-      ExifInterface.TAG_COMPRESSION,
-      ExifInterface.TAG_BODY_SERIAL_NUMBER,
-      ExifInterface.TAG_BRIGHTNESS_VALUE,
-      ExifInterface.TAG_CONTRAST,
-      ExifInterface.TAG_CAMERA_OWNER_NAME,
-      ExifInterface.TAG_COLOR_SPACE,
-      ExifInterface.TAG_COPYRIGHT,
-      ExifInterface.TAG_DATETIME,
-      ExifInterface.TAG_DATETIME_DIGITIZED,
-      ExifInterface.TAG_DATETIME_ORIGINAL,
-      ExifInterface.TAG_DEVICE_SETTING_DESCRIPTION,
-      ExifInterface.TAG_DIGITAL_ZOOM_RATIO,
-      ExifInterface.TAG_EXIF_VERSION,
-      ExifInterface.TAG_EXPOSURE_BIAS_VALUE,
-      ExifInterface.TAG_EXPOSURE_INDEX,
-      ExifInterface.TAG_EXPOSURE_MODE,
-      ExifInterface.TAG_EXPOSURE_TIME,
-      ExifInterface.TAG_EXPOSURE_PROGRAM,
-      ExifInterface.TAG_FLASH,
-      ExifInterface.TAG_FLASH_ENERGY,
-      ExifInterface.TAG_FOCAL_LENGTH,
-      ExifInterface.TAG_FOCAL_LENGTH_IN_35MM_FILM,
-      ExifInterface.TAG_FOCAL_PLANE_RESOLUTION_UNIT,
-      ExifInterface.TAG_FOCAL_PLANE_X_RESOLUTION,
-      ExifInterface.TAG_FOCAL_PLANE_Y_RESOLUTION,
-      ExifInterface.TAG_PHOTOMETRIC_INTERPRETATION,
-      ExifInterface.TAG_PLANAR_CONFIGURATION,
-      ExifInterface.TAG_F_NUMBER,
-      ExifInterface.TAG_GAIN_CONTROL,
-      ExifInterface.TAG_GAMMA,
-      ExifInterface.TAG_GPS_ALTITUDE,
-      ExifInterface.TAG_GPS_ALTITUDE_REF,
-      ExifInterface.TAG_GPS_AREA_INFORMATION,
-      ExifInterface.TAG_GPS_DATESTAMP,
-      ExifInterface.TAG_GPS_DOP,
-      ExifInterface.TAG_GPS_LATITUDE,
-      ExifInterface.TAG_GPS_LATITUDE_REF,
-      ExifInterface.TAG_GPS_LONGITUDE,
-      ExifInterface.TAG_GPS_LONGITUDE_REF,
-      ExifInterface.TAG_GPS_STATUS,
-      ExifInterface.TAG_GPS_DEST_BEARING,
-      ExifInterface.TAG_GPS_DEST_BEARING_REF,
-      ExifInterface.TAG_GPS_DEST_DISTANCE,
-      ExifInterface.TAG_GPS_DEST_DISTANCE_REF,
-      ExifInterface.TAG_GPS_DEST_LATITUDE,
-      ExifInterface.TAG_GPS_DEST_LATITUDE_REF,
-      ExifInterface.TAG_GPS_DEST_LONGITUDE,
-      ExifInterface.TAG_GPS_DEST_LONGITUDE_REF,
-      ExifInterface.TAG_GPS_DIFFERENTIAL,
-      ExifInterface.TAG_GPS_IMG_DIRECTION,
-      ExifInterface.TAG_GPS_IMG_DIRECTION_REF,
-      ExifInterface.TAG_GPS_MAP_DATUM,
-      ExifInterface.TAG_GPS_MEASURE_MODE,
-      ExifInterface.TAG_GPS_PROCESSING_METHOD,
-      ExifInterface.TAG_GPS_SATELLITES,
-      ExifInterface.TAG_GPS_SPEED,
-      ExifInterface.TAG_GPS_SPEED_REF,
-      ExifInterface.TAG_GPS_STATUS,
-      ExifInterface.TAG_GPS_TIMESTAMP,
-      ExifInterface.TAG_GPS_TRACK,
-      ExifInterface.TAG_GPS_TRACK_REF,
-      ExifInterface.TAG_GPS_VERSION_ID,
-      ExifInterface.TAG_IMAGE_DESCRIPTION,
-      ExifInterface.TAG_IMAGE_UNIQUE_ID,
-      ExifInterface.TAG_ISO_SPEED,
-      ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY,
-      ExifInterface.TAG_JPEG_INTERCHANGE_FORMAT,
-      ExifInterface.TAG_JPEG_INTERCHANGE_FORMAT_LENGTH,
-      ExifInterface.TAG_LENS_MAKE,
-      ExifInterface.TAG_LENS_MODEL,
-      ExifInterface.TAG_LENS_SERIAL_NUMBER,
-      ExifInterface.TAG_LENS_SPECIFICATION,
-      ExifInterface.TAG_LIGHT_SOURCE,
-      ExifInterface.TAG_MAKE,
-      ExifInterface.TAG_MAKER_NOTE,
-      ExifInterface.TAG_MODEL,
-      // ExifInterface.TAG_ORIENTATION, // removed
-      ExifInterface.TAG_SATURATION,
-      ExifInterface.TAG_SHARPNESS,
-      ExifInterface.TAG_SHUTTER_SPEED_VALUE,
-      ExifInterface.TAG_SOFTWARE,
-      ExifInterface.TAG_SUBJECT_DISTANCE,
-      ExifInterface.TAG_SUBJECT_DISTANCE_RANGE,
-      ExifInterface.TAG_SUBJECT_LOCATION,
-      ExifInterface.TAG_USER_COMMENT,
-      ExifInterface.TAG_WHITE_BALANCE
-    };
-
-
-
   /**
    * Resize the specified bitmap.
    */
@@ -261,55 +158,6 @@ public class StreamChatReactNative {
     }
 
     return file;
-  }
-
-  /**
-   * Attempts to copy exif info from one file to another. Note: orientation, width, and height
-   exif attributes are not copied since those are lost after image rotation.
-
-   * imageUri: original image URI as provided from JS
-   * dstPath: final image output path
-   * Returns true if copy was successful, false otherwise.
-   */
-  public static boolean copyExif(Context context, Uri imageUri, String dstPath){
-    ExifInterface src = null;
-    ExifInterface dst = null;
-
-    try {
-
-      File file = getFileFromUri(context, imageUri);
-      if (!file.exists()) {
-        return false;
-      }
-
-      src = new ExifInterface(file.getAbsolutePath());
-      dst = new ExifInterface(dstPath);
-
-    } catch (Exception ignored) {
-      Log.e("StreamChatReactNative::copyExif", "EXIF read failed", ignored);
-    }
-
-    if(src == null || dst == null){
-      return false;
-    }
-
-    try{
-
-      for (String attr : EXIF_TO_COPY_ROTATED)
-      {
-        String value = src.getAttribute(attr);
-        if (value != null){
-          dst.setAttribute(attr, value);
-        }
-      }
-      dst.saveAttributes();
-
-    } catch (Exception ignored) {
-      Log.e("StreamChatReactNative::copyExif", "EXIF copy failed", ignored);
-      return false;
-    }
-
-    return true;
   }
 
   /**
@@ -591,4 +439,3 @@ public class StreamChatReactNative {
     return scaledImage;
   }
 }
-

--- a/package/native-package/android/src/main/java/com/streamchatreactnative/StreamChatReactNativeModule.java
+++ b/package/native-package/android/src/main/java/com/streamchatreactnative/StreamChatReactNativeModule.java
@@ -4,8 +4,6 @@ import android.annotation.SuppressLint;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.util.Log;
-
 import androidx.annotation.Nullable;
 import androidx.annotation.NonNull;
 
@@ -36,7 +34,7 @@ public class StreamChatReactNativeModule extends StreamChatReactNativeSpec {
   }
 
   @ReactMethod
-  public void createResizedImage(String uri, double width, double height, String format, double quality, String mode, boolean onlyScaleDown, Double rotation, @Nullable String outputPath, Boolean keepMeta, Promise promise) {
+  public void createResizedImage(String uri, double width, double height, String format, double quality, String mode, boolean onlyScaleDown, Double rotation, @Nullable String outputPath, Promise promise) {
     WritableMap options = Arguments.createMap();
     options.putString("mode", mode);
     options.putBoolean("onlyScaleDown", onlyScaleDown);
@@ -46,7 +44,7 @@ public class StreamChatReactNativeModule extends StreamChatReactNativeSpec {
       @Override
       protected void doInBackgroundGuarded(Void... params) {
         try {
-          Object response = createResizedImageWithExceptions(uri, (int) width, (int) height, format, (int) quality, rotation.intValue(), outputPath, keepMeta, options);
+          Object response = createResizedImageWithExceptions(uri, (int) width, (int) height, format, (int) quality, rotation.intValue(), outputPath, options);
           promise.resolve(response);
         }
         catch (IOException e) {
@@ -59,7 +57,6 @@ public class StreamChatReactNativeModule extends StreamChatReactNativeSpec {
   @SuppressLint("LongLogTag")
   private Object createResizedImageWithExceptions(String imagePath, int newWidth, int newHeight,
                                                   String compressFormatString, int quality, int rotation, String outputPath,
-                                                  final boolean keepMeta,
                                                   final ReadableMap options) throws IOException {
 
     Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.valueOf(compressFormatString);
@@ -89,16 +86,6 @@ public class StreamChatReactNativeModule extends StreamChatReactNativeSpec {
       response.putDouble("size", resizedImage.length());
       response.putDouble("width", scaledImage.getWidth());
       response.putDouble("height", scaledImage.getHeight());
-
-      // Copy file's metadata/exif info if required
-      if(keepMeta){
-        try{
-          StreamChatReactNative.copyExif(this.getReactApplicationContext(), imageUri, resizedImage.getAbsolutePath());
-        }
-        catch(Exception ignored){
-          Log.e("StreamChatReactNative::createResizedImageWithExceptions", "EXIF copy failed", ignored);
-        }
-      }
     } else {
       throw new IOException("Error getting resized image path");
     }

--- a/package/native-package/android/src/oldarch/com/streamchatreactnative/StreamChatReactNative.java
+++ b/package/native-package/android/src/oldarch/com/streamchatreactnative/StreamChatReactNative.java
@@ -12,5 +12,5 @@ abstract class StreamChatReactNativeSpec extends ReactContextBaseJavaModule {
     super(context);
   }
 
-  public abstract void createResizedImage(String uri, double width, double height, String format, double quality, String mode, boolean onlyScaleDown, Double rotation, @Nullable String outputPath, Boolean keepMeta, Promise promise);
+  public abstract void createResizedImage(String uri, double width, double height, String format, double quality, String mode, boolean onlyScaleDown, Double rotation, @Nullable String outputPath, Promise promise);
 }

--- a/package/native-package/ios/StreamChatReactNative.mm
+++ b/package/native-package/ios/StreamChatReactNative.mm
@@ -1,7 +1,5 @@
 #import "StreamChatReactNative.h"
 #import <React/RCTLog.h>
-#import <AssetsLibrary/AssetsLibrary.h>
-#import <MobileCoreServices/MobileCoreServices.h>
 
 #if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
@@ -19,12 +17,12 @@ NSString *moduleName = @"StreamChatReactNative";
 
 RCT_EXPORT_MODULE()
 
-RCT_REMAP_METHOD(createResizedImage, uri:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality mode:(NSString *)mode onlyScaleDown:(BOOL)onlyScaleDown rotation:(nonnull NSNumber *)rotation outputPath:(NSString *)outputPath keepMeta:(nonnull NSNumber *)keepMeta resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_REMAP_METHOD(createResizedImage, uri:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality mode:(NSString *)mode onlyScaleDown:(BOOL)onlyScaleDown rotation:(nonnull NSNumber *)rotation outputPath:(NSString *)outputPath resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
-    [self createResizedImage:uri width:width height:height format:format quality:quality mode:mode onlyScaleDown:onlyScaleDown rotation:rotation outputPath:outputPath keepMeta:keepMeta resolve:resolve reject:reject];
+    [self createResizedImage:uri width:width height:height format:format quality:quality mode:mode onlyScaleDown:onlyScaleDown rotation:rotation outputPath:outputPath resolve:resolve reject:reject];
 }
 
-- (void)createResizedImage:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality mode:(NSString *)mode onlyScaleDown:(BOOL)onlyScaleDown rotation:(nonnull NSNumber *)rotation outputPath:(NSString *)outputPath keepMeta:(nonnull NSNumber *)keepMeta resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+- (void)createResizedImage:(NSString *)uri width:(double)width height:(double)height format:(NSString *)format quality:(double)quality mode:(NSString *)mode onlyScaleDown:(BOOL)onlyScaleDown rotation:(nonnull NSNumber *)rotation outputPath:(NSString *)outputPath resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         @try {
             CGSize newSize = CGSizeMake(width, height);
@@ -57,7 +55,7 @@ RCT_REMAP_METHOD(createResizedImage, uri:(NSString *)uri width:(double)width hei
                     reject([NSString stringWithFormat: @"%ld", (long)error.code], error.description, nil);
                     return;
                 }
-                NSDictionary * response =  transformImage(image, uri, [rotation integerValue], newSize, fullPath, format, (int)quality, [keepMeta boolValue], @{@"mode": mode, @"onlyScaleDown": [NSNumber numberWithBool:onlyScaleDown]});
+                NSDictionary * response =  transformImage(image, [rotation integerValue], newSize, fullPath, format, (int)quality, @{@"mode": mode, @"onlyScaleDown": [NSNumber numberWithBool:onlyScaleDown]});
                 resolve(response);
             }];
         } @catch (NSException *exception) {
@@ -69,65 +67,21 @@ RCT_REMAP_METHOD(createResizedImage, uri:(NSString *)uri width:(double)width hei
 
 
 
-bool saveImage(NSString * fullPath, UIImage * image, NSString * format, float quality, NSMutableDictionary *metadata)
+bool saveImage(NSString * fullPath, UIImage * image, NSString * format, float quality)
 {
-    if(metadata == nil){
-        NSData* data = nil;
-        if ([format isEqualToString:@"JPEG"]) {
-            data = UIImageJPEGRepresentation(image, quality / 100.0);
-        } else if ([format isEqualToString:@"PNG"]) {
-            data = UIImagePNGRepresentation(image);
-        }
-
-        if (data == nil) {
-            return NO;
-        }
-
-        NSFileManager* fileManager = [NSFileManager defaultManager];
-        return [fileManager createFileAtPath:fullPath contents:data attributes:nil];
+    NSData* data = nil;
+    if ([format isEqualToString:@"JPEG"]) {
+        data = UIImageJPEGRepresentation(image, quality / 100.0);
+    } else if ([format isEqualToString:@"PNG"]) {
+        data = UIImagePNGRepresentation(image);
     }
 
-    // process / write metadata together with image data
-    else{
-
-        CFStringRef imgType = kUTTypeJPEG;
-
-        if ([format isEqualToString:@"JPEG"]) {
-            [metadata setObject:@(quality / 100.0) forKey:(__bridge NSString *)kCGImageDestinationLossyCompressionQuality];
-        }
-        else if([format isEqualToString:@"PNG"]){
-            imgType = kUTTypePNG;
-        }
-        else{
-            return NO;
-        }
-
-        NSMutableData * destData = [NSMutableData data];
-
-        CGImageDestinationRef destination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)destData, imgType, 1, NULL);
-
-        @try{
-            CGImageDestinationAddImage(destination, image.CGImage, (__bridge CFDictionaryRef) metadata);
-
-            // write final image data with metadata to our destination
-            if (CGImageDestinationFinalize(destination)){
-
-                NSFileManager* fileManager = [NSFileManager defaultManager];
-                return [fileManager createFileAtPath:fullPath contents:destData attributes:nil];
-            }
-            else{
-                return NO;
-            }
-        }
-        @finally{
-            @try{
-                CFRelease(destination);
-            }
-            @catch(NSException *exception){
-                NSLog(@"Failed to release CGImageDestinationRef: %@", exception);
-            }
-        }
+    if (data == nil) {
+        return NO;
     }
+
+    NSFileManager* fileManager = [NSFileManager defaultManager];
+    return [fileManager createFileAtPath:fullPath contents:data attributes:nil];
 }
 
 NSString * generateFilePath(NSString * ext, NSString * outputPath)
@@ -268,81 +222,12 @@ UIImage* scaleImage (UIImage* image, CGSize toSize, NSString* mode, bool onlySca
     return newImage;
 }
 
-// Returns the image's metadata, or nil if failed to retrieve it.
-NSMutableDictionary * getImageMeta(NSString * path)
-{
-    if([path hasPrefix:@"assets-library"]) {
-
-        __block NSMutableDictionary* res = nil;
-
-        ALAssetsLibraryAssetForURLResultBlock resultblock = ^(ALAsset *myasset)
-        {
-
-            NSDictionary *exif = [[myasset defaultRepresentation] metadata];
-            res = [exif mutableCopy];
-
-        };
-
-        ALAssetsLibrary* assetslibrary = [[ALAssetsLibrary alloc] init];
-        NSURL *url = [NSURL URLWithString:[path stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
-
-        [assetslibrary assetForURL:url resultBlock:resultblock failureBlock:^(NSError *error) { NSLog(@"error couldn't image from assets library"); }];
-
-        return res;
-
-    } else {
-
-        NSData* imageData = nil;
-
-        if ([path hasPrefix:@"data:"] || [path hasPrefix:@"file:"]) {
-            NSURL *imageUrl = [[NSURL alloc] initWithString:path];
-            imageData = [NSData dataWithContentsOfURL:imageUrl];
-
-        } else {
-            imageData = [NSData dataWithContentsOfFile:path];
-        }
-
-        if(imageData == nil){
-            NSLog(@"Could not get image file data to extract metadata.");
-            return nil;
-        }
-
-        CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-
-
-        if(source != nil){
-
-            CFDictionaryRef metaRef = CGImageSourceCopyPropertiesAtIndex(source, 0, NULL);
-
-            // release CF image
-            CFRelease(source);
-
-            CFMutableDictionaryRef metaRefMutable = CFDictionaryCreateMutableCopy(NULL, 0, metaRef);
-
-            // release the source meta ref now that we've copie it
-            CFRelease(metaRef);
-
-            // bridge CF object so it auto releases
-            NSMutableDictionary* res = (NSMutableDictionary *)CFBridgingRelease(metaRefMutable);
-
-            return res;
-
-        }
-        else{
-            return nil;
-        }
-
-    }
-}
-
 NSDictionary * transformImage(UIImage *image,
-                              NSString * originalPath,
                               int rotation,
                               CGSize newSize,
                               NSString* fullPath,
                               NSString* format,
                               int quality,
-                              BOOL keepMeta,
                               NSDictionary* options)
 {
     if (image == nil) {
@@ -368,25 +253,8 @@ NSDictionary * transformImage(UIImage *image,
     if (scaledImage == nil) {
         [NSException raise:moduleName format:@"Can't resize the image."];
     }
-
-
-    NSMutableDictionary *metadata = nil;
-
-    // to be consistent with Android, we will only allow JPEG
-    // to do this.
-    if(keepMeta && [format isEqualToString:@"JPEG"]){
-
-        metadata = getImageMeta(originalPath);
-
-        // remove orientation (since we fix it)
-        // width/height meta is adjusted automatically
-        // NOTE: This might still leave some stale values due to resize
-        metadata[(NSString*)kCGImagePropertyOrientation] = @(1);
-
-    }
-
     // Compress and save the image
-    if (!saveImage(fullPath, scaledImage, format, quality, metadata)) {
+    if (!saveImage(fullPath, scaledImage, format, quality)) {
         [NSException raise:moduleName format:@"Can't save the image. Check your compression format and your output path"];
     }
 

--- a/package/native-package/src/handlers/compressImage.ts
+++ b/package/native-package/src/handlers/compressImage.ts
@@ -22,7 +22,6 @@ export const compressImage = async ({
       Math.min(Math.max(0, compressImageQuality), 1) * 100,
       0,
       undefined,
-      false,
       { mode: 'cover' },
     );
     return compressedUri;

--- a/package/native-package/src/native/NativeStreamChatReactNative.ts
+++ b/package/native-package/src/native/NativeStreamChatReactNative.ts
@@ -13,7 +13,6 @@ export interface Spec extends TurboModule {
     onlyScaleDown: boolean,
     rotation?: number,
     outputPath?: string | null,
-    keepMeta?: boolean,
   ): Promise<{
     base64: string;
     height: number;

--- a/package/native-package/src/native/index.tsx
+++ b/package/native-package/src/native/index.tsx
@@ -24,7 +24,6 @@ async function createResizedImage(
   quality: number,
   rotation: number = 0,
   outputPath?: string | null,
-  keepMeta = false,
   options: Options = defaultOptions,
 ): Promise<Response> {
   const { mode, onlyScaleDown } = { ...defaultOptions, ...options };
@@ -39,7 +38,6 @@ async function createResizedImage(
     onlyScaleDown,
     rotation,
     outputPath,
-    keepMeta,
   );
 }
 


### PR DESCRIPTION
## 🎯 Goal

This PR addresses a crash on later RN versions (`0.84` that we're aware of specifically). The reason is the deprecation/removal of `assets-library` on iOS. One important point here is the fact that we've never used this anyway and while it could technically be invoked by various integrations there is no reason for the lightweight implementation SDK side to expose this kind of API. 

The native handlers can still be registered in a way that allows for data preservation through other libraries.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


