### PR TITLE
feat: introduce rudimentary RTL support to the RN SDK

### DIFF
--- a/examples/SampleApp/App.tsx
+++ b/examples/SampleApp/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { DevSettings, LogBox, Platform, StyleSheet, useColorScheme, View } from 'react-native';
+import { DevSettings, I18nManager, LogBox, Platform, StyleSheet, useColorScheme, View } from 'react-native';
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -99,6 +99,7 @@ notifee.onBackgroundEvent(async ({ detail, type }) => {
 const Drawer = createDrawerNavigator();
 const Stack = createNativeStackNavigator<StackNavigatorParamList>();
 const UserSelectorStack = createNativeStackNavigator<UserSelectorParamList>();
+const RTL_STORAGE_KEY = '@stream-rn-sampleapp-rtl-enabled';
 
 const MessageOverlayBlurBackground = () => {
   const {
@@ -131,6 +132,7 @@ const MessageOverlayBlurBackground = () => {
 
 const App = () => {
   const { chatClient, isConnecting, loginUser, logout, switchUser } = useChatClient();
+  const [rtlEnabled, setRtlEnabled] = useState<boolean | undefined>(undefined);
   const [messageListImplementation, setMessageListImplementation] = useState<
     MessageListImplementationConfigItem['id'] | undefined
   >(undefined);
@@ -149,6 +151,15 @@ const App = () => {
   const colorScheme = useColorScheme();
   const streamChatTheme = useStreamChatTheme();
   const streami18n = new Streami18n();
+
+  const setRTLEnabled = React.useCallback(async (enabled: boolean) => {
+    await AsyncStore.setItem(RTL_STORAGE_KEY, enabled);
+    I18nManager.allowRTL(enabled);
+    I18nManager.forceRTL(enabled);
+    I18nManager.swapLeftAndRightInRTL(enabled);
+    setRtlEnabled(enabled);
+    DevSettings.reload();
+  }, []);
 
   useEffect(() => {
     const messaging = getMessaging();
@@ -188,7 +199,21 @@ const App = () => {
         }
       }
     });
-    const getMessageListConfig = async () => {
+    const getAppConfig = async () => {
+      const storedRTLEnabled = await AsyncStore.getItem<boolean>(RTL_STORAGE_KEY, false);
+      const nextRTLEnabled = !!storedRTLEnabled;
+
+      I18nManager.allowRTL(nextRTLEnabled);
+      I18nManager.forceRTL(nextRTLEnabled);
+      I18nManager.swapLeftAndRightInRTL(nextRTLEnabled);
+
+      if (I18nManager.isRTL !== nextRTLEnabled) {
+        DevSettings.reload();
+        return;
+      }
+
+      setRtlEnabled(nextRTLEnabled);
+
       const messageListImplementationStoredValue = await AsyncStore.getItem(
         '@stream-rn-sampleapp-messagelist-implementation',
         { id: 'flatlist' },
@@ -223,7 +248,7 @@ const App = () => {
         messageOverlayBackdropStoredValue?.value as MessageOverlayBackdropConfigItem['value'],
       );
     };
-    getMessageListConfig();
+    getAppConfig();
     return () => {
       unsubscribeOnNotificationOpen();
       unsubscribeForegroundEvent();
@@ -258,7 +283,7 @@ const App = () => {
     });
   }, [chatClient]);
 
-  if (!messageListImplementation || !messageListMode) {
+  if (rtlEnabled === undefined || !messageListImplementation || !messageListMode) {
     return;
   }
 
@@ -294,6 +319,8 @@ const App = () => {
                   loginUser,
                   logout,
                   switchUser,
+                  rtlEnabled,
+                  setRTLEnabled,
                   messageListImplementation,
                   messageInputFloating: messageInputFloating ?? false,
                   messageListMode,

--- a/examples/SampleApp/src/components/MenuDrawer.tsx
+++ b/examples/SampleApp/src/components/MenuDrawer.tsx
@@ -1,5 +1,14 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Image, StyleSheet, Text, TouchableOpacity, Pressable, View } from 'react-native';
+import {
+  I18nManager,
+  Image,
+  Pressable,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { Edit, useTheme } from 'stream-chat-react-native';
 
 import { useAppContext } from '../context/AppContext';
@@ -31,15 +40,39 @@ export const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
   },
+  menuItemContent: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+  },
   menuTitle: {
     fontSize: 14,
     fontWeight: '500',
-    marginLeft: 16,
+    marginStart: 16,
+  },
+  rtlDescription: {
+    fontSize: 12,
+    marginStart: 16,
+    marginTop: 2,
+  },
+  rtlMenuItem: {
+    justifyContent: 'space-between',
+  },
+  rtlMenuItemContent: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+  },
+  rtlTextContainer: {
+    flex: 1,
+  },
+  rowReverse: {
+    flexDirection: 'row-reverse',
   },
   userName: {
     fontSize: 16,
     fontWeight: '600',
-    marginLeft: 16,
+    marginStart: 16,
   },
   userRow: {
     alignItems: 'center',
@@ -51,6 +84,7 @@ export const styles = StyleSheet.create({
 export const MenuDrawer = ({ navigation }: DrawerContentComponentProps) => {
   const [secretMenuPressCounter, setSecretMenuPressCounter] = useState(0);
   const [secretMenuVisible, setSecretMenuVisible] = useState(false);
+  const isRTL = I18nManager.isRTL;
   useTheme();
   const { black, grey, white } = useLegacyColors();
 
@@ -65,7 +99,7 @@ export const MenuDrawer = ({ navigation }: DrawerContentComponentProps) => {
     setSecretMenuVisible(false);
   }, []);
 
-  const { chatClient, logout } = useAppContext();
+  const { chatClient, logout, rtlEnabled, setRTLEnabled } = useAppContext();
 
   if (!chatClient) {
     return null;
@@ -74,7 +108,10 @@ export const MenuDrawer = ({ navigation }: DrawerContentComponentProps) => {
   return (
     <View style={[styles.container, { backgroundColor: white }]}>
       <SafeAreaView style={{ flex: 1 }}>
-        <Pressable onPress={() => setSecretMenuPressCounter((c) => c + 1)} style={[styles.userRow]}>
+        <Pressable
+          onPress={() => setSecretMenuPressCounter((c) => c + 1)}
+          style={[styles.userRow, isRTL && styles.rowReverse]}
+        >
           <Image
             source={{
               uri: chatClient.user?.image,
@@ -84,6 +121,7 @@ export const MenuDrawer = ({ navigation }: DrawerContentComponentProps) => {
           <Text
             style={[
               styles.userName,
+              isRTL && { textAlign: 'right' },
               {
                 color: black,
               },
@@ -105,12 +143,13 @@ export const MenuDrawer = ({ navigation }: DrawerContentComponentProps) => {
                   screen: 'NewDirectMessagingScreen',
                 })
               }
-              style={styles.menuItem}
+              style={[styles.menuItem, isRTL && styles.rowReverse]}
             >
               <Edit height={24} stroke={grey} width={24} />
               <Text
                 style={[
                   styles.menuTitle,
+                  isRTL && { textAlign: 'right' },
                   {
                     color: black,
                   },
@@ -125,12 +164,13 @@ export const MenuDrawer = ({ navigation }: DrawerContentComponentProps) => {
                   screen: 'NewGroupChannelAddMemberScreen',
                 })
               }
-              style={styles.menuItem}
+              style={[styles.menuItem, isRTL && styles.rowReverse]}
             >
               <Group height={24} pathFill={grey} width={24} />
               <Text
                 style={[
                   styles.menuTitle,
+                  isRTL && { textAlign: 'right' },
                   {
                     color: black,
                   },
@@ -139,17 +179,67 @@ export const MenuDrawer = ({ navigation }: DrawerContentComponentProps) => {
                 New Group
               </Text>
             </TouchableOpacity>
+            <View
+              style={[
+                styles.menuItem,
+                styles.rtlMenuItem,
+                isRTL && styles.rowReverse,
+              ]}
+            >
+              <View
+                style={[
+                  styles.rtlMenuItemContent,
+                  isRTL && styles.rowReverse,
+                ]}
+              >
+                <User height={24} pathFill={grey} width={24} />
+                <View style={styles.rtlTextContainer}>
+                  <Text
+                    style={[
+                      styles.menuTitle,
+                      isRTL && { textAlign: 'right' },
+                      {
+                        color: black,
+                      },
+                    ]}
+                  >
+                    RTL Layout
+                  </Text>
+                  <Text
+                    style={[
+                      styles.rtlDescription,
+                      isRTL && { textAlign: 'right' },
+                      {
+                        color: grey,
+                      },
+                    ]}
+                  >
+                    Enable RTL layout
+                  </Text>
+                </View>
+              </View>
+              <Switch
+                onValueChange={setRTLEnabled}
+                thumbColor={white}
+                trackColor={{
+                  false: grey,
+                  true: black,
+                }}
+                value={rtlEnabled}
+              />
+            </View>
           </View>
           <TouchableOpacity
             onPress={() => {
               logout();
             }}
-            style={styles.menuItem}
+            style={[styles.menuItem, isRTL && styles.rowReverse]}
           >
             <User height={24} pathFill={grey} width={24} />
             <Text
               style={[
                 styles.menuTitle,
+                isRTL && { textAlign: 'right' },
                 {
                   color: black,
                 },

--- a/examples/SampleApp/src/context/AppContext.ts
+++ b/examples/SampleApp/src/context/AppContext.ts
@@ -15,6 +15,8 @@ type AppContextType = {
   loginUser: (config: LoginConfig) => void;
   logout: () => void;
   switchUser: (userId?: string) => void;
+  rtlEnabled: boolean;
+  setRTLEnabled: (enabled: boolean) => Promise<void>;
   messageListImplementation: MessageListImplementationConfigItem['id'];
   messageInputFloating: MessageInputFloatingConfigItem['value'];
   messageListMode: MessageListModeConfigItem['mode'];

--- a/package/src/components/AttachmentPicker/AttachmentPicker.tsx
+++ b/package/src/components/AttachmentPicker/AttachmentPicker.tsx
@@ -13,6 +13,7 @@ import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 
 import { useAttachmentPickerContext } from '../../contexts/attachmentPickerContext/AttachmentPickerContext';
+import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useStableCallback } from '../../hooks';
 import { BottomSheet } from '../BottomSheetCompatibility/BottomSheet';
 import { KeyboardControllerPackage } from '../KeyboardCompatibleView/KeyboardControllerAvoidingView';
@@ -38,6 +39,9 @@ export const AttachmentPicker = () => {
     bottomSheetRef: ref,
     disableAttachmentPicker,
   } = useAttachmentPickerContext();
+  const {
+    theme: { semantics },
+  } = useTheme();
 
   const [currentIndex, setCurrentIndexInternal] = useState(-1);
   const currentIndexRef = useRef<number>(currentIndex);
@@ -105,9 +109,19 @@ export const AttachmentPicker = () => {
   });
 
   const animationConfigs = useBottomSheetSpringConfigs(SPRING_CONFIG);
+  const backgroundStyle = useMemo(
+    () => ({
+      backgroundColor: semantics.backgroundCoreElevation1,
+      borderTopWidth: 0,
+      elevation: Platform.OS === 'android' ? 0 : undefined,
+      shadowOpacity: Platform.OS === 'android' ? 0 : undefined,
+    }),
+    [semantics.backgroundCoreElevation1],
+  );
 
   return (
     <BottomSheet
+      backgroundStyle={backgroundStyle}
       enablePanDownToClose={false}
       enableContentPanningGesture={false}
       enableDynamicSizing={false}

--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -284,7 +284,10 @@ export const ImageGalleryWithContext = (props: ImageGalleryWithContextProps) => 
       <Animated.View style={[StyleSheet.absoluteFillObject, containerBackground]} />
       <GestureDetector gesture={Gesture.Simultaneous(singleTap, doubleTap, pinch, pan)}>
         <Animated.View style={StyleSheet.absoluteFillObject}>
-          <Animated.View style={[styles.animatedContainer, pagerStyle, pager]}>
+          <Animated.View
+            testID='image-gallery-pager'
+            style={[styles.animatedContainer, pagerStyle, pager]}
+          >
             {assets.map((photo, i) =>
               photo.type === FileTypes.Video ? (
                 <AnimatedGalleryVideo
@@ -399,6 +402,7 @@ export const clamp = (value: number, lowerBound: number, upperBound: number) => 
 const styles = StyleSheet.create({
   animatedContainer: {
     alignItems: 'center',
+    direction: 'ltr',
     flexDirection: 'row',
   },
 });

--- a/package/src/components/ImageGallery/__tests__/ImageGallery.test.tsx
+++ b/package/src/components/ImageGallery/__tests__/ImageGallery.test.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { I18nManager, StyleSheet } from 'react-native';
 
 import type { SharedValue } from 'react-native-reanimated';
 
@@ -79,6 +80,19 @@ const ImageGalleryComponent = (props: ImageGalleryProps & { message: LocalMessag
 };
 
 describe('ImageGallery', () => {
+  const originalIsRTL = I18nManager.isRTL;
+
+  const setRTL = (value: boolean) => {
+    Object.defineProperty(I18nManager, 'isRTL', {
+      configurable: true,
+      value,
+    });
+  };
+
+  afterEach(() => {
+    setRTL(originalIsRTL);
+  });
+
   it('render image gallery component', async () => {
     render(
       <ImageGalleryComponent
@@ -97,6 +111,25 @@ describe('ImageGallery', () => {
     await waitFor(() => {
       expect(screen.queryAllByLabelText('Image Item')).toHaveLength(2);
       expect(screen.queryAllByLabelText('Image Gallery Video')).toHaveLength(1);
+    });
+  });
+
+  it('keeps the pager in ltr coordinates when rtl is enabled', async () => {
+    setRTL(true);
+
+    render(
+      <ImageGalleryComponent
+        message={
+          generateMessage({
+            attachments: [generateImageAttachment()],
+          }) as unknown as LocalMessage
+        }
+      />,
+    );
+
+    await waitFor(() => {
+      const pagerStyle = StyleSheet.flatten(screen.getByTestId('image-gallery-pager').props.style);
+      expect(pagerStyle.direction).toBe('ltr');
     });
   });
 });

--- a/package/src/components/Message/Message.tsx
+++ b/package/src/components/Message/Message.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { GestureResponderEvent, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+import {
+  GestureResponderEvent,
+  I18nManager,
+  StyleProp,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from 'react-native';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Portal } from 'react-native-teleport';
@@ -415,6 +422,11 @@ const MessageWithContext = (props: MessagePropsWithContext) => {
       : isMyMessage
         ? 'right'
         : 'left';
+  const overlayItemAlignment = I18nManager.isRTL
+    ? alignment === 'right'
+      ? 'left'
+      : 'right'
+    : alignment;
 
   /**
    * attachments contain files/images or other attachments
@@ -847,7 +859,7 @@ const MessageWithContext = (props: MessagePropsWithContext) => {
                   h,
                   w,
                   x:
-                    alignment === 'right'
+                    overlayItemAlignment === 'right'
                       ? overlayItemsAnchorRect.x + overlayItemsAnchorRect.w - w
                       : overlayItemsAnchorRect.x,
                   y: rect.y - h,
@@ -893,7 +905,7 @@ const MessageWithContext = (props: MessagePropsWithContext) => {
                   h,
                   w,
                   x:
-                    alignment === 'right'
+                    overlayItemAlignment === 'right'
                       ? overlayItemsAnchorRect.x + overlayItemsAnchorRect.w - w
                       : overlayItemsAnchorRect.x,
                   y: rect.y + rect.h,

--- a/package/src/components/Message/MessageItemView/MessageBubble.tsx
+++ b/package/src/components/Message/MessageItemView/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useMemo, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { I18nManager, StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 import Animated, {
@@ -26,6 +26,8 @@ type SwipableMessageWrapperProps = Pick<MessagesContextValue, 'MessageSwipeConte
 
 export const SwipableMessageWrapper = React.memo((props: SwipableMessageWrapperProps) => {
   const { MessageSwipeContent, children, messageSwipeToReplyHitSlop, onSwipe } = props;
+  const isRTL = I18nManager.isRTL;
+  const swipeDirectionMultiplier = isRTL ? -1 : 1;
 
   const styles = useStyles();
 
@@ -73,8 +75,9 @@ export const SwipableMessageWrapper = React.memo((props: SwipableMessageWrapperP
           translateX.value = 0;
         })
         .onChange(({ translationX }) => {
-          if (translationX > 0) {
-            translateX.value = translationX;
+          const swipeDistance = translationX * swipeDirectionMultiplier;
+          if (swipeDistance > 0) {
+            translateX.value = swipeDistance;
           }
         })
         .onEnd(() => {
@@ -98,7 +101,15 @@ export const SwipableMessageWrapper = React.memo((props: SwipableMessageWrapperP
             },
           );
         }),
-    [messageSwipeToReplyHitSlop, touchStart, isSwiping, translateX, onSwipe, triggerHaptic],
+    [
+      messageSwipeToReplyHitSlop,
+      onSwipe,
+      swipeDirectionMultiplier,
+      touchStart,
+      isSwiping,
+      translateX,
+      triggerHaptic,
+    ],
   );
 
   const swipeContentAnimatedStyle = useAnimatedStyle(

--- a/package/src/components/Message/MessageItemView/MessageReplies.tsx
+++ b/package/src/components/Message/MessageItemView/MessageReplies.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { I18nManager, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import {
   MessageContextValue,
@@ -22,6 +22,7 @@ import { useShouldUseOverlayStyles } from '../hooks/useShouldUseOverlayStyles';
 export type MessageRepliesPropsWithContext = Pick<
   MessageContextValue,
   | 'alignment'
+  | 'isMyMessage'
   | 'message'
   | 'onLongPress'
   | 'onPress'
@@ -36,6 +37,7 @@ export type MessageRepliesPropsWithContext = Pick<
 const MessageRepliesWithContext = (props: MessageRepliesPropsWithContext) => {
   const {
     alignment,
+    isMyMessage,
     message,
     MessageRepliesAvatars,
     onLongPress,
@@ -57,15 +59,29 @@ const MessageRepliesWithContext = (props: MessageRepliesPropsWithContext) => {
   } = useTheme();
   const styles = useStyles();
 
+  const physicalAlignment = I18nManager.isRTL
+    ? alignment === 'left'
+      ? 'right'
+      : 'left'
+    : alignment;
+  const connectorStroke = isMyMessage
+    ? semantics.chatThreadConnectorOutgoing
+    : semantics.chatThreadConnectorIncoming;
+
+  const connector =
+    physicalAlignment === 'left' ? (
+      <ReplyConnectorLeft height={48} width={16} stroke={connectorStroke} />
+    ) : (
+      <ReplyConnectorRight height={48} width={16} stroke={connectorStroke} />
+    );
+
   if (threadList || !message.reply_count) {
     return null;
   }
 
   return (
     <View style={[styles.container, container]}>
-      {alignment === 'left' && (
-        <ReplyConnectorLeft height={48} width={16} stroke={semantics.chatThreadConnectorIncoming} />
-      )}
+      {alignment === 'left' ? connector : null}
       <Pressable
         disabled={preventPress}
         onLongPress={(event) => {
@@ -96,7 +112,7 @@ const MessageRepliesWithContext = (props: MessageRepliesPropsWithContext) => {
         }}
         style={[
           styles.content,
-          { flexDirection: alignment === 'left' ? 'row' : 'row-reverse' },
+          { flexDirection: physicalAlignment === 'left' ? 'row' : 'row-reverse' },
           content,
         ]}
         testID='message-replies'
@@ -110,13 +126,7 @@ const MessageRepliesWithContext = (props: MessageRepliesPropsWithContext) => {
               })}
         </Text>
       </Pressable>
-      {alignment === 'right' && (
-        <ReplyConnectorRight
-          height={48}
-          width={16}
-          stroke={semantics.chatThreadConnectorOutgoing}
-        />
-      )}
+      {alignment === 'right' ? connector : null}
     </View>
   );
 };
@@ -171,6 +181,7 @@ export type MessageRepliesProps = Partial<MessageRepliesPropsWithContext>;
 export const MessageReplies = (props: MessageRepliesProps) => {
   const {
     alignment,
+    isMyMessage,
     message,
     onLongPress,
     onOpenThread,
@@ -186,6 +197,7 @@ export const MessageReplies = (props: MessageRepliesProps) => {
     <MemoizedMessageReplies
       {...{
         alignment,
+        isMyMessage,
         message,
         MessageRepliesAvatars,
         onLongPress,

--- a/package/src/components/MessageInput/components/AttachmentPreview/AttachmentUploadPreviewList.tsx
+++ b/package/src/components/MessageInput/components/AttachmentPreview/AttachmentUploadPreviewList.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import {
   FlatList,
+  I18nManager,
   LayoutChangeEvent,
   NativeScrollEvent,
   NativeSyntheticEvent,
@@ -111,6 +112,7 @@ const UnMemoizedAttachmentUploadPreviewList = (
   const nonAudioAttachments = previewAttachments.filter(
     (attachment) => !isAudioAttachmentPreview(attachment),
   );
+  const data = I18nManager.isRTL ? nonAudioAttachments.toReversed() : nonAudioAttachments;
 
   const {
     theme: {
@@ -290,7 +292,7 @@ const UnMemoizedAttachmentUploadPreviewList = (
         </Animated.View>
       ) : null}
 
-      {nonAudioAttachments.length ? (
+      {data.length ? (
         <Animated.View
           entering={ZoomIn.duration(200)}
           exiting={ZoomOut.duration(200)}
@@ -298,7 +300,7 @@ const UnMemoizedAttachmentUploadPreviewList = (
         >
           <Animated.View style={animatedListWrapperStyle}>
             <FlatList
-              data={nonAudioAttachments}
+              data={data}
               horizontal
               ItemSeparatorComponent={ItemSeparatorComponent}
               keyExtractor={(item) => item.localMetadata.id}
@@ -357,6 +359,7 @@ const styles = StyleSheet.create({
   },
   flatList: {
     overflow: 'visible',
+    direction: 'ltr',
   },
   itemSeparator: {
     width: primitives.spacingXs,

--- a/package/src/components/MessageInput/components/AttachmentPreview/AttachmentUploadPreviewList.tsx
+++ b/package/src/components/MessageInput/components/AttachmentPreview/AttachmentUploadPreviewList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   FlatList,
   I18nManager,
@@ -97,14 +97,18 @@ const UnMemoizedAttachmentUploadPreviewList = (
   const { audioRecordingSendOnComplete } = useMessageInputContext();
   const { attachmentManager } = useMessageComposer();
   const { attachments } = useAttachmentManagerState();
+  const isRTL = I18nManager.isRTL;
   const attachmentListRef = useRef<FlatList<LocalAttachment>>(null);
   const soundPackageAvailable = isSoundPackageAvailable();
   const isAudioAttachmentPreview = getIsAudioAttachmentPreview(soundPackageAvailable);
   const previousNonAudioAttachmentsLengthRef = useRef(0);
   const contentWidthRef = useRef(0);
+  const itemsContentWidthRef = useRef(0);
   const viewportWidthRef = useRef(0);
   const scrollOffsetXRef = useRef(0);
+  const rtlLeadingSpacerWidthRef = useRef(0);
   const endShrinkCompensationX = useSharedValue(0);
+  const [rtlLeadingSpacerWidth, setRtlLeadingSpacerWidth] = useState(0);
   const previewAttachments = attachments.filter(
     (attachment) => !(audioRecordingSendOnComplete && isLocalVoiceRecordingAttachment(attachment)),
   );
@@ -112,7 +116,7 @@ const UnMemoizedAttachmentUploadPreviewList = (
   const nonAudioAttachments = previewAttachments.filter(
     (attachment) => !isAudioAttachmentPreview(attachment),
   );
-  const data = I18nManager.isRTL ? nonAudioAttachments.toReversed() : nonAudioAttachments;
+  const data = isRTL ? nonAudioAttachments.toReversed() : nonAudioAttachments;
 
   const {
     theme: {
@@ -121,6 +125,27 @@ const UnMemoizedAttachmentUploadPreviewList = (
       },
     },
   } = useTheme();
+
+  const updateRtlLeadingSpacerWidth = useCallback(
+    (itemsWidth: number, viewportWidth: number) => {
+      if (!isRTL || !viewportWidth) {
+        if (rtlLeadingSpacerWidthRef.current !== 0) {
+          rtlLeadingSpacerWidthRef.current = 0;
+          setRtlLeadingSpacerWidth(0);
+        }
+        return;
+      }
+
+      const nextSpacerWidth = Math.max(0, viewportWidth - itemsWidth);
+      if (rtlLeadingSpacerWidthRef.current === nextSpacerWidth) {
+        return;
+      }
+
+      rtlLeadingSpacerWidthRef.current = nextSpacerWidth;
+      setRtlLeadingSpacerWidth(nextSpacerWidth);
+    },
+    [isRTL],
+  );
 
   const renderItem = useCallback(
     ({ item }: { item: LocalAttachment }) => {
@@ -202,21 +227,31 @@ const UnMemoizedAttachmentUploadPreviewList = (
     scrollOffsetXRef.current = event.nativeEvent.contentOffset.x;
   }, []);
 
-  const onLayoutHandler = useCallback((event: LayoutChangeEvent) => {
-    viewportWidthRef.current = event.nativeEvent.layout.width;
-  }, []);
+  const onLayoutHandler = useCallback(
+    (event: LayoutChangeEvent) => {
+      const viewportWidth = event.nativeEvent.layout.width;
+      viewportWidthRef.current = viewportWidth;
+      updateRtlLeadingSpacerWidth(itemsContentWidthRef.current, viewportWidth);
+    },
+    [updateRtlLeadingSpacerWidth],
+  );
 
   const onContentSizeChangeHandler = useCallback(
     (width: number) => {
+      const itemsContentWidth = isRTL
+        ? Math.max(0, width - rtlLeadingSpacerWidthRef.current)
+        : width;
       const previousContentWidth = contentWidthRef.current;
-      contentWidthRef.current = width;
+      contentWidthRef.current = itemsContentWidth;
+      itemsContentWidthRef.current = itemsContentWidth;
+      updateRtlLeadingSpacerWidth(itemsContentWidth, viewportWidthRef.current);
 
-      if (!previousContentWidth || width >= previousContentWidth) {
+      if (!previousContentWidth || itemsContentWidth >= previousContentWidth) {
         return;
       }
 
       const oldMaxOffset = Math.max(0, previousContentWidth - viewportWidthRef.current);
-      const newMaxOffset = Math.max(0, width - viewportWidthRef.current);
+      const newMaxOffset = Math.max(0, itemsContentWidth - viewportWidthRef.current);
       const offsetBefore = scrollOffsetXRef.current;
       const wasNearEnd = oldMaxOffset - offsetBefore <= END_ANCHOR_THRESHOLD;
       const overshoot = Math.max(0, offsetBefore - newMaxOffset);
@@ -243,7 +278,7 @@ const UnMemoizedAttachmentUploadPreviewList = (
         });
       }
     },
-    [endShrinkCompensationX],
+    [endShrinkCompensationX, isRTL, updateRtlLeadingSpacerWidth],
   );
 
   useEffect(() => {
@@ -304,6 +339,11 @@ const UnMemoizedAttachmentUploadPreviewList = (
               horizontal
               ItemSeparatorComponent={ItemSeparatorComponent}
               keyExtractor={(item) => item.localMetadata.id}
+              ListHeaderComponent={
+                isRTL && rtlLeadingSpacerWidth > 0 ? (
+                  <View style={{ width: rtlLeadingSpacerWidth }} />
+                ) : null
+              }
               onContentSizeChange={onContentSizeChangeHandler}
               onLayout={onLayoutHandler}
               onScroll={onScrollHandler}

--- a/package/src/components/MessageInput/components/AttachmentPreview/AttachmentUploadPreviewList.tsx
+++ b/package/src/components/MessageInput/components/AttachmentPreview/AttachmentUploadPreviewList.tsx
@@ -269,6 +269,10 @@ const UnMemoizedAttachmentUploadPreviewList = (
         scrollOffsetXRef.current = newMaxOffset;
       }
 
+      if (isRTL) {
+        return;
+      }
+
       const compensation = newMaxOffset - oldMaxOffset;
       if (compensation !== 0) {
         cancelAnimation(endShrinkCompensationX);
@@ -294,9 +298,13 @@ const UnMemoizedAttachmentUploadPreviewList = (
     cancelAnimation(endShrinkCompensationX);
     endShrinkCompensationX.value = 0;
     requestAnimationFrame(() => {
+      if (isRTL) {
+        return;
+      }
+
       attachmentListRef.current?.scrollToEnd({ animated: true });
     });
-  }, [endShrinkCompensationX, nonAudioAttachments.length]);
+  }, [endShrinkCompensationX, isRTL, nonAudioAttachments.length]);
 
   const animatedListWrapperStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: endShrinkCompensationX.value }],

--- a/package/src/components/Poll/CreatePollContent.tsx
+++ b/package/src/components/Poll/CreatePollContent.tsx
@@ -281,10 +281,14 @@ const useStyles = () => {
     return StyleSheet.create({
       scrollView: {
         flex: 1,
-        padding: primitives.spacingMd,
         backgroundColor: semantics.backgroundCoreElevation1,
       },
-      contentContainerStyle: { paddingBottom: 70 },
+      contentContainerStyle: {
+        alignItems: 'stretch',
+        padding: primitives.spacingMd,
+        paddingBottom: 70,
+        width: '100%',
+      },
       title: {
         color: semantics.textPrimary,
         fontSize: primitives.typographyFontSizeMd,

--- a/package/src/components/Poll/CreatePollContent.tsx
+++ b/package/src/components/Poll/CreatePollContent.tsx
@@ -294,15 +294,19 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeMd,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightNormal,
+        textAlign: 'left',
       },
       description: {
         color: semantics.textTertiary,
         fontSize: primitives.typographyFontSizeSm,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightNormal,
+        textAlign: 'left',
       },
       optionCardContent: {
         gap: primitives.spacingXxs,
+        flex: 1,
+        alignItems: 'flex-start',
       },
       optionCard: {
         flex: 1,

--- a/package/src/components/Poll/Poll.tsx
+++ b/package/src/components/Poll/Poll.tsx
@@ -119,12 +119,14 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeSm,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightTight,
+        textAlign: 'left',
       },
       headerTitle: {
         color: semantics.chatTextIncoming,
         fontSize: primitives.typographyFontSizeMd,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightNormal,
+        textAlign: 'left',
       },
       optionsWrapper: {
         gap: primitives.spacingMd,

--- a/package/src/components/Poll/components/CreatePollOptions.tsx
+++ b/package/src/components/Poll/components/CreatePollOptions.tsx
@@ -1,5 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { LayoutChangeEvent, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import {
+  I18nManager,
+  LayoutChangeEvent,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   interpolate,
@@ -746,6 +754,7 @@ const useStyles = () => {
         fontWeight: primitives.typographyFontWeightRegular,
         color: semantics.inputTextDefault,
         paddingVertical: 0, // android is adding extra padding so we remove it
+        textAlign: I18nManager.isRTL ? 'right' : 'left',
       },
       optionValidationErrorContainer: {
         flexDirection: 'row',
@@ -759,6 +768,7 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeSm,
         lineHeight: primitives.typographyLineHeightNormal,
         fontWeight: primitives.typographyFontWeightRegular,
+        textAlign: 'left',
       },
       optionWrapper: {
         width: '100%',
@@ -778,6 +788,7 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeMd,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightNormal,
+        textAlign: 'left',
       },
     });
   }, [semantics]);

--- a/package/src/components/Poll/components/MultipleAnswersField.tsx
+++ b/package/src/components/Poll/components/MultipleAnswersField.tsx
@@ -74,15 +74,19 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeMd,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightNormal,
+        textAlign: 'left',
       },
       description: {
         color: semantics.textTertiary,
         fontSize: primitives.typographyFontSizeSm,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightNormal,
+        textAlign: 'left',
       },
       optionCardContent: {
         gap: primitives.spacingXxs,
+        flex: 1,
+        alignItems: 'flex-start',
       },
       optionCard: {
         alignItems: 'center',

--- a/package/src/components/Poll/components/MultipleVotesSettings.tsx
+++ b/package/src/components/Poll/components/MultipleVotesSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Platform, StyleSheet, Switch, Text, TextInput, View } from 'react-native';
+import { I18nManager, Platform, StyleSheet, Switch, Text, TextInput, View } from 'react-native';
 
 import Animated, { LinearTransition, StretchInY, StretchOutY } from 'react-native-reanimated';
 
@@ -200,15 +200,19 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeMd,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightNormal,
+        textAlign: 'left',
       },
       description: {
         color: semantics.textTertiary,
         fontSize: primitives.typographyFontSizeSm,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightNormal,
+        textAlign: 'left',
       },
       optionCardContent: {
         gap: primitives.spacingXxs,
+        flex: 1,
+        alignItems: 'flex-start',
       },
       optionCard: {
         alignItems: 'center',
@@ -229,6 +233,7 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeMd,
         paddingHorizontal: primitives.spacingSm,
         paddingVertical: primitives.spacingMd,
+        textAlign: I18nManager.isRTL ? 'right' : 'left',
       },
     });
   }, [semantics]);

--- a/package/src/components/Poll/components/PollAnswersList.tsx
+++ b/package/src/components/Poll/components/PollAnswersList.tsx
@@ -175,10 +175,9 @@ const useStyles = () => {
   return useMemo(
     () =>
       StyleSheet.create({
-        contentContainer: { gap: primitives.spacingMd },
+        contentContainer: { gap: primitives.spacingMd, padding: primitives.spacingMd },
         container: {
           flex: 1,
-          padding: primitives.spacingMd,
           backgroundColor: semantics.backgroundCoreElevation1,
         },
         listItemAnswerText: {

--- a/package/src/components/Poll/components/PollInputDialog.tsx
+++ b/package/src/components/Poll/components/PollInputDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import {
+  I18nManager,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -136,6 +137,7 @@ const useStyles = () => {
           fontSize: primitives.typographyFontSizeMd,
           padding: primitives.spacingSm,
           color: semantics.textPrimary,
+          textAlign: I18nManager.isRTL ? 'right' : 'left',
         },
         title: {
           color: semantics.textPrimary,

--- a/package/src/components/Poll/components/PollOption.tsx
+++ b/package/src/components/Poll/components/PollOption.tsx
@@ -51,7 +51,11 @@ export const PollAllOptionsContent = ({
   const styles = useAllOptionStyles();
 
   return (
-    <ScrollView style={[styles.allOptionsWrapper, wrapper]} {...additionalScrollViewProps}>
+    <ScrollView
+      contentContainerStyle={styles.allOptionsContentContainer}
+      style={[styles.allOptionsWrapper, wrapper]}
+      {...additionalScrollViewProps}
+    >
       <View style={[styles.allOptionsTitleContainer, titleContainer]}>
         <Text style={styles.allOptionsTitleMeta}>{t('Question')}</Text>
         <Text style={[styles.allOptionsTitleText, titleText]}>{name}</Text>
@@ -259,6 +263,9 @@ const useAllOptionStyles = () => {
   return useMemo(
     () =>
       StyleSheet.create({
+        allOptionsContentContainer: {
+          padding: primitives.spacingMd,
+        },
         allOptionsListContainer: {
           borderRadius: primitives.radiusLg,
           padding: primitives.spacingMd,
@@ -285,7 +292,6 @@ const useAllOptionStyles = () => {
         },
         allOptionsWrapper: {
           flex: 1,
-          padding: primitives.spacingMd,
           backgroundColor: semantics.backgroundCoreElevation1,
         },
         optionWrapper: {

--- a/package/src/components/Poll/components/PollOption.tsx
+++ b/package/src/components/Poll/components/PollOption.tsx
@@ -230,6 +230,7 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeSm,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightTight,
+        textAlign: 'left',
       },
       info: {
         flexGrow: 1,
@@ -241,6 +242,7 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightTight,
+        textAlign: 'left',
       },
       progressBarContainer: {
         flex: 1,
@@ -260,44 +262,44 @@ const useAllOptionStyles = () => {
   const {
     theme: { semantics },
   } = useTheme();
-  return useMemo(
-    () =>
-      StyleSheet.create({
-        allOptionsContentContainer: {
-          padding: primitives.spacingMd,
-        },
-        allOptionsListContainer: {
-          borderRadius: primitives.radiusLg,
-          padding: primitives.spacingMd,
-          backgroundColor: semantics.backgroundCoreSurfaceCard,
-          marginTop: primitives.spacing2xl,
-        },
-        allOptionsTitleContainer: {
-          borderRadius: primitives.radiusLg,
-          padding: primitives.spacingMd,
-          backgroundColor: semantics.backgroundCoreSurfaceCard,
-        },
-        allOptionsTitleText: {
-          fontSize: primitives.typographyFontSizeLg,
-          lineHeight: primitives.typographyLineHeightRelaxed,
-          fontWeight: primitives.typographyFontWeightSemiBold,
-          color: semantics.textPrimary,
-          paddingTop: primitives.spacingXs,
-        },
-        allOptionsTitleMeta: {
-          fontSize: primitives.typographyFontSizeSm,
-          color: semantics.textTertiary,
-          lineHeight: primitives.typographyLineHeightNormal,
-          fontWeight: primitives.typographyFontWeightMedium,
-        },
-        allOptionsWrapper: {
-          flex: 1,
-          backgroundColor: semantics.backgroundCoreElevation1,
-        },
-        optionWrapper: {
-          paddingVertical: primitives.spacingMd,
-        },
-      }),
-    [semantics],
-  );
+  return useMemo(() => {
+    return StyleSheet.create({
+      allOptionsContentContainer: {
+        padding: primitives.spacingMd,
+      },
+      allOptionsListContainer: {
+        borderRadius: primitives.radiusLg,
+        padding: primitives.spacingMd,
+        backgroundColor: semantics.backgroundCoreSurfaceCard,
+        marginTop: primitives.spacing2xl,
+      },
+      allOptionsTitleContainer: {
+        borderRadius: primitives.radiusLg,
+        padding: primitives.spacingMd,
+        backgroundColor: semantics.backgroundCoreSurfaceCard,
+      },
+      allOptionsTitleText: {
+        fontSize: primitives.typographyFontSizeLg,
+        lineHeight: primitives.typographyLineHeightRelaxed,
+        fontWeight: primitives.typographyFontWeightSemiBold,
+        color: semantics.textPrimary,
+        paddingTop: primitives.spacingXs,
+        textAlign: 'left',
+      },
+      allOptionsTitleMeta: {
+        fontSize: primitives.typographyFontSizeSm,
+        color: semantics.textTertiary,
+        lineHeight: primitives.typographyLineHeightNormal,
+        fontWeight: primitives.typographyFontWeightMedium,
+        textAlign: 'left',
+      },
+      allOptionsWrapper: {
+        flex: 1,
+        backgroundColor: semantics.backgroundCoreElevation1,
+      },
+      optionWrapper: {
+        paddingVertical: primitives.spacingMd,
+      },
+    });
+  }, [semantics]);
 };

--- a/package/src/components/Poll/components/PollResults/PollOptionFullResults.tsx
+++ b/package/src/components/Poll/components/PollResults/PollOptionFullResults.tsx
@@ -107,11 +107,11 @@ const useStyles = () => {
   return useMemo(
     () =>
       StyleSheet.create({
-        container: { flex: 1, padding: primitives.spacingMd },
+        container: { flex: 1, backgroundColor: semantics.backgroundCoreElevation1 },
         contentContainer: {
+          margin: primitives.spacingMd,
           backgroundColor: semantics.backgroundCoreSurfaceCard,
           borderRadius: primitives.radiusLg,
-          marginBottom: primitives.spacingMd,
           paddingHorizontal: primitives.spacingMd,
           paddingTop: primitives.spacingMd,
           paddingBottom: primitives.spacingXs,
@@ -139,6 +139,10 @@ const useStyles = () => {
           marginLeft: primitives.spacingMd,
         },
       }),
-    [semantics.backgroundCoreSurfaceCard, semantics.textPrimary],
+    [
+      semantics.backgroundCoreElevation1,
+      semantics.backgroundCoreSurfaceCard,
+      semantics.textPrimary,
+    ],
   );
 };

--- a/package/src/components/Poll/components/PollResults/PollOptionFullResults.tsx
+++ b/package/src/components/Poll/components/PollResults/PollOptionFullResults.tsx
@@ -104,45 +104,45 @@ const useStyles = () => {
   const {
     theme: { semantics },
   } = useTheme();
-  return useMemo(
-    () =>
-      StyleSheet.create({
-        container: { flex: 1, backgroundColor: semantics.backgroundCoreElevation1 },
-        contentContainer: {
-          margin: primitives.spacingMd,
-          backgroundColor: semantics.backgroundCoreSurfaceCard,
-          borderRadius: primitives.radiusLg,
-          paddingHorizontal: primitives.spacingMd,
-          paddingTop: primitives.spacingMd,
-          paddingBottom: primitives.spacingXs,
-        },
-        headerContainer: {
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          paddingBottom: primitives.spacingXs,
-        },
-        headerTitle: {
-          flex: 1,
-          fontSize: primitives.typographyFontSizeLg,
-          lineHeight: primitives.typographyLineHeightRelaxed,
-          fontWeight: primitives.typographyFontWeightSemiBold,
-          color: semantics.textPrimary,
-          paddingTop: primitives.spacingXs,
-        },
-        headerText: {
-          fontSize: primitives.typographyFontSizeMd,
-          lineHeight: primitives.typographyLineHeightNormal,
-          fontWeight: primitives.typographyFontWeightSemiBold,
-          color: semantics.textPrimary,
-          paddingTop: primitives.spacingXs,
-          marginLeft: primitives.spacingMd,
-        },
-      }),
-    [
-      semantics.backgroundCoreElevation1,
-      semantics.backgroundCoreSurfaceCard,
-      semantics.textPrimary,
-    ],
-  );
+  return useMemo(() => {
+    return StyleSheet.create({
+      container: { flex: 1, backgroundColor: semantics.backgroundCoreElevation1 },
+      contentContainer: {
+        margin: primitives.spacingMd,
+        backgroundColor: semantics.backgroundCoreSurfaceCard,
+        borderRadius: primitives.radiusLg,
+        paddingHorizontal: primitives.spacingMd,
+        paddingTop: primitives.spacingMd,
+        paddingBottom: primitives.spacingXs,
+      },
+      headerContainer: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingBottom: primitives.spacingXs,
+      },
+      headerTitle: {
+        flex: 1,
+        fontSize: primitives.typographyFontSizeLg,
+        lineHeight: primitives.typographyLineHeightRelaxed,
+        fontWeight: primitives.typographyFontWeightSemiBold,
+        color: semantics.textPrimary,
+        paddingTop: primitives.spacingXs,
+        textAlign: 'left',
+      },
+      headerText: {
+        fontSize: primitives.typographyFontSizeMd,
+        lineHeight: primitives.typographyLineHeightNormal,
+        fontWeight: primitives.typographyFontWeightSemiBold,
+        color: semantics.textPrimary,
+        paddingTop: primitives.spacingXs,
+        marginStart: primitives.spacingMd,
+        textAlign: 'left',
+      },
+    });
+  }, [
+    semantics.backgroundCoreElevation1,
+    semantics.backgroundCoreSurfaceCard,
+    semantics.textPrimary,
+  ]);
 };

--- a/package/src/components/Poll/components/PollResults/PollResultItem.tsx
+++ b/package/src/components/Poll/components/PollResults/PollResultItem.tsx
@@ -132,66 +132,67 @@ const useStyles = () => {
   const {
     theme: { semantics },
   } = useTheme();
-  return useMemo(
-    () =>
-      StyleSheet.create({
-        spacer: {
-          paddingBottom: primitives.spacingXs,
-        },
-        container: {
-          backgroundColor: semantics.backgroundCoreSurfaceCard,
-          borderRadius: primitives.radiusLg,
-          marginBottom: primitives.spacingMd,
-        },
-        metaContainer: {
-          paddingTop: primitives.spacingMd,
-          paddingHorizontal: primitives.spacingMd,
-        },
-        votesContainer: {
-          paddingHorizontal: primitives.spacingMd,
-          paddingVertical: primitives.spacingXs,
-        },
-        headerContainer: {
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          paddingBottom: primitives.spacingXs,
-        },
-        modalRoot: {
-          flex: 1,
-        },
-        title: {
-          flex: 1,
-          fontSize: primitives.typographyFontSizeLg,
-          lineHeight: primitives.typographyLineHeightRelaxed,
-          fontWeight: primitives.typographyFontWeightSemiBold,
-          color: semantics.textPrimary,
-          paddingTop: primitives.spacingXs,
-        },
-        titleMeta: {
-          fontSize: primitives.typographyFontSizeSm,
-          color: semantics.textTertiary,
-          lineHeight: primitives.typographyLineHeightNormal,
-          fontWeight: primitives.typographyFontWeightMedium,
-        },
-        voteCount: {
-          fontSize: primitives.typographyFontSizeMd,
-          lineHeight: primitives.typographyLineHeightNormal,
-          fontWeight: primitives.typographyFontWeightSemiBold,
-          color: semantics.textPrimary,
-          marginLeft: primitives.spacingMd,
-        },
-        safeArea: {
-          backgroundColor: semantics.backgroundCoreElevation1,
-          flex: 1,
-        },
-        inlineButton: {
-          borderColor: semantics.borderCoreDefault,
-          borderTopWidth: 1,
-          paddingHorizontal: primitives.spacingMd,
-          paddingVertical: primitives.spacingXs,
-        },
-      }),
-    [semantics],
-  );
+  return useMemo(() => {
+    return StyleSheet.create({
+      spacer: {
+        paddingBottom: primitives.spacingXs,
+      },
+      container: {
+        backgroundColor: semantics.backgroundCoreSurfaceCard,
+        borderRadius: primitives.radiusLg,
+        marginBottom: primitives.spacingMd,
+      },
+      metaContainer: {
+        paddingTop: primitives.spacingMd,
+        paddingHorizontal: primitives.spacingMd,
+      },
+      votesContainer: {
+        paddingHorizontal: primitives.spacingMd,
+        paddingVertical: primitives.spacingXs,
+      },
+      headerContainer: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingBottom: primitives.spacingXs,
+      },
+      modalRoot: {
+        flex: 1,
+      },
+      title: {
+        flex: 1,
+        fontSize: primitives.typographyFontSizeLg,
+        lineHeight: primitives.typographyLineHeightRelaxed,
+        fontWeight: primitives.typographyFontWeightSemiBold,
+        color: semantics.textPrimary,
+        paddingTop: primitives.spacingXs,
+        textAlign: 'left',
+      },
+      titleMeta: {
+        fontSize: primitives.typographyFontSizeSm,
+        color: semantics.textTertiary,
+        lineHeight: primitives.typographyLineHeightNormal,
+        fontWeight: primitives.typographyFontWeightMedium,
+        textAlign: 'left',
+      },
+      voteCount: {
+        fontSize: primitives.typographyFontSizeMd,
+        lineHeight: primitives.typographyLineHeightNormal,
+        fontWeight: primitives.typographyFontWeightSemiBold,
+        color: semantics.textPrimary,
+        marginStart: primitives.spacingMd,
+        textAlign: 'left',
+      },
+      safeArea: {
+        backgroundColor: semantics.backgroundCoreElevation1,
+        flex: 1,
+      },
+      inlineButton: {
+        borderColor: semantics.borderCoreDefault,
+        borderTopWidth: 1,
+        paddingHorizontal: primitives.spacingMd,
+        paddingVertical: primitives.spacingXs,
+      },
+    });
+  }, [semantics]);
 };

--- a/package/src/components/Poll/components/PollResults/PollResults.tsx
+++ b/package/src/components/Poll/components/PollResults/PollResults.tsx
@@ -44,7 +44,11 @@ export const PollResultsContent = ({
   const styles = useStyles();
 
   return (
-    <ScrollView style={[styles.scrollView, scrollView]} {...additionalScrollViewProps}>
+    <ScrollView
+      contentContainerStyle={styles.contentContainer}
+      style={[styles.scrollView, scrollView]}
+      {...additionalScrollViewProps}
+    >
       <View style={[styles.container, container]}>
         <Text style={[styles.titleMeta, titleMeta]}>{t('Question')}</Text>
         <Text style={[styles.title, title]}>{name}</Text>
@@ -80,6 +84,9 @@ const useStyles = () => {
   return useMemo(
     () =>
       StyleSheet.create({
+        contentContainer: {
+          padding: primitives.spacingMd,
+        },
         container: {
           borderRadius: primitives.radiusLg,
           padding: primitives.spacingMd,
@@ -87,7 +94,6 @@ const useStyles = () => {
         },
         scrollView: {
           flex: 1,
-          padding: primitives.spacingMd,
           backgroundColor: semantics.backgroundCoreElevation1,
         },
         resultsContainer: {

--- a/package/src/components/Poll/components/PollResults/PollResults.tsx
+++ b/package/src/components/Poll/components/PollResults/PollResults.tsx
@@ -81,38 +81,38 @@ const useStyles = () => {
   const {
     theme: { semantics },
   } = useTheme();
-  return useMemo(
-    () =>
-      StyleSheet.create({
-        contentContainer: {
-          padding: primitives.spacingMd,
-        },
-        container: {
-          borderRadius: primitives.radiusLg,
-          padding: primitives.spacingMd,
-          backgroundColor: semantics.backgroundCoreSurfaceCard,
-        },
-        scrollView: {
-          flex: 1,
-          backgroundColor: semantics.backgroundCoreElevation1,
-        },
-        resultsContainer: {
-          paddingVertical: primitives.spacing2xl,
-        },
-        title: {
-          fontSize: primitives.typographyFontSizeLg,
-          lineHeight: primitives.typographyLineHeightRelaxed,
-          fontWeight: primitives.typographyFontWeightSemiBold,
-          color: semantics.textPrimary,
-          paddingTop: primitives.spacingXs,
-        },
-        titleMeta: {
-          fontSize: primitives.typographyFontSizeSm,
-          color: semantics.textTertiary,
-          lineHeight: primitives.typographyLineHeightNormal,
-          fontWeight: primitives.typographyFontWeightMedium,
-        },
-      }),
-    [semantics],
-  );
+  return useMemo(() => {
+    return StyleSheet.create({
+      contentContainer: {
+        padding: primitives.spacingMd,
+      },
+      container: {
+        borderRadius: primitives.radiusLg,
+        padding: primitives.spacingMd,
+        backgroundColor: semantics.backgroundCoreSurfaceCard,
+      },
+      scrollView: {
+        flex: 1,
+        backgroundColor: semantics.backgroundCoreElevation1,
+      },
+      resultsContainer: {
+        paddingVertical: primitives.spacing2xl,
+      },
+      title: {
+        fontSize: primitives.typographyFontSizeLg,
+        lineHeight: primitives.typographyLineHeightRelaxed,
+        fontWeight: primitives.typographyFontWeightSemiBold,
+        color: semantics.textPrimary,
+        paddingTop: primitives.spacingXs,
+        textAlign: 'left',
+      },
+      titleMeta: {
+        fontSize: primitives.typographyFontSizeSm,
+        color: semantics.textTertiary,
+        lineHeight: primitives.typographyLineHeightNormal,
+        fontWeight: primitives.typographyFontWeightMedium,
+        textAlign: 'left',
+      },
+    });
+  }, [semantics]);
 };

--- a/package/src/components/Poll/components/PollResults/PollVote.tsx
+++ b/package/src/components/Poll/components/PollResults/PollVote.tsx
@@ -58,31 +58,31 @@ const useStyles = () => {
   const {
     theme: { semantics },
   } = useTheme();
-  return useMemo(
-    () =>
-      StyleSheet.create({
-        voteContainer: {
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          paddingVertical: primitives.spacingXs,
-        },
-        voteDate: {
-          fontSize: primitives.typographyFontSizeMd,
-          lineHeight: primitives.typographyLineHeightNormal,
-          color: semantics.textTertiary,
-        },
-        voteUserName: {
-          fontSize: primitives.typographyFontSizeMd,
-          lineHeight: primitives.typographyLineHeightNormal,
-          color: semantics.textPrimary,
-          paddingLeft: primitives.spacingXs,
-        },
-        userContainer: {
-          flexDirection: 'row',
-          alignItems: 'center',
-        },
-      }),
-    [semantics],
-  );
+  return useMemo(() => {
+    return StyleSheet.create({
+      voteContainer: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingVertical: primitives.spacingXs,
+      },
+      voteDate: {
+        fontSize: primitives.typographyFontSizeMd,
+        lineHeight: primitives.typographyLineHeightNormal,
+        color: semantics.textTertiary,
+        textAlign: 'left',
+      },
+      voteUserName: {
+        fontSize: primitives.typographyFontSizeMd,
+        lineHeight: primitives.typographyLineHeightNormal,
+        color: semantics.textPrimary,
+        paddingStart: primitives.spacingXs,
+        textAlign: 'left',
+      },
+      userContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+      },
+    });
+  }, [semantics]);
 };

--- a/package/src/components/ProgressControl/ProgressControl.tsx
+++ b/package/src/components/ProgressControl/ProgressControl.tsx
@@ -84,7 +84,7 @@ export const ProgressControl = (props: ProgressControlProps) => {
           }
         })
         .withTestId(testID),
-    [onEndDrag, onStartDrag, state, testID, widthInNumbers],
+    [isRTL, onEndDrag, onStartDrag, state, testID, widthInNumbers],
   );
 
   const thumbStyles = useAnimatedStyle(

--- a/package/src/components/ProgressControl/ProgressControl.tsx
+++ b/package/src/components/ProgressControl/ProgressControl.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { I18nManager, StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   interpolate,
@@ -47,6 +47,8 @@ export const ProgressControl = (props: ProgressControlProps) => {
   const { isPlaying, onEndDrag, onStartDrag, progress, testID } = props;
   const styles = useStyles();
   const [widthInNumbers, setWidthInNumbers] = useState<number>(0);
+  const isRTL = I18nManager.isRTL;
+  const thumbDirectionMultiplier = isRTL ? -1 : 1;
 
   const state = useSharedValue(progress);
   const {
@@ -73,8 +75,8 @@ export const ProgressControl = (props: ProgressControlProps) => {
           }
         })
         .onUpdate((event) => {
-          const newProgress = Math.max(0, Math.min(event.x / widthInNumbers, 1));
-          state.value = newProgress;
+          const nextProgress = isRTL ? 1 - event.x / widthInNumbers : event.x / widthInNumbers;
+          state.value = Math.max(0, Math.min(nextProgress, 1));
         })
         .onEnd(() => {
           if (onEndDrag) {
@@ -92,13 +94,13 @@ export const ProgressControl = (props: ProgressControlProps) => {
           translateX: interpolate(
             state.value,
             [0, 1],
-            [0, widthInNumbers - PROGRESS_THUMB_WIDTH / 2],
+            [0, (widthInNumbers - PROGRESS_THUMB_WIDTH / 2) * thumbDirectionMultiplier],
           ),
         },
       ],
       position: 'absolute',
     }),
-    [widthInNumbers],
+    [thumbDirectionMultiplier, widthInNumbers],
   );
 
   const animatedFilledStyles = useAnimatedStyle(

--- a/package/src/components/ProgressControl/WaveProgressBar.tsx
+++ b/package/src/components/ProgressControl/WaveProgressBar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { I18nManager, StyleSheet, View } from 'react-native';
 import type { ColorValue, StyleProp, ViewStyle } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { runOnJS, useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
@@ -98,6 +98,8 @@ export const WaveProgressBar = React.memo(
     const [showInteractiveLayer, setShowInteractiveLayer] = useState(
       () => progress > 0 || isPlaying,
     );
+    const isRTL = I18nManager.isRTL;
+    const thumbDirectionMultiplier = isRTL ? -1 : 1;
     const eachWaveformWidth = WAVEFORM_WIDTH + WAVEFORM_GAP;
     const fullWidth = (amplitudesCount - 1) * eachWaveformWidth;
     const maxThumbTranslateX = Math.max(fullWidth - eachWaveformWidth, 0);
@@ -163,7 +165,8 @@ export const WaveProgressBar = React.memo(
               return;
             }
             const nextProgress = clampProgress(
-              dragStartProgress.value + event.translationX / fullWidth,
+              dragStartProgress.value +
+                (event.translationX * thumbDirectionMultiplier) / fullWidth,
             );
             visualProgress.value = nextProgress;
             if (onProgressDrag) {
@@ -186,6 +189,7 @@ export const WaveProgressBar = React.memo(
         onEndDrag,
         onProgressDrag,
         onStartDrag,
+        thumbDirectionMultiplier,
         visualProgress,
       ],
     );
@@ -220,14 +224,13 @@ export const WaveProgressBar = React.memo(
         position: 'absolute',
         transform: [
           {
-            translateX: Math.min(
-              clampProgress(visualProgress.value) * fullWidth,
-              maxThumbTranslateX,
-            ),
+            translateX:
+              Math.min(clampProgress(visualProgress.value) * fullWidth, maxThumbTranslateX) *
+              thumbDirectionMultiplier,
           },
         ],
       }),
-      [fullWidth, maxThumbTranslateX],
+      [fullWidth, maxThumbTranslateX, thumbDirectionMultiplier],
     );
 
     return (

--- a/package/src/components/ProgressControl/WaveProgressBar.tsx
+++ b/package/src/components/ProgressControl/WaveProgressBar.tsx
@@ -165,8 +165,7 @@ export const WaveProgressBar = React.memo(
               return;
             }
             const nextProgress = clampProgress(
-              dragStartProgress.value +
-                (event.translationX * thumbDirectionMultiplier) / fullWidth,
+              dragStartProgress.value + (event.translationX * thumbDirectionMultiplier) / fullWidth,
             );
             visualProgress.value = nextProgress;
             if (onProgressDrag) {

--- a/package/src/components/Reply/Reply.tsx
+++ b/package/src/components/Reply/Reply.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Image, StyleSheet, Text, TextStyle, View, ViewStyle } from 'react-native';
+import { I18nManager, Image, StyleSheet, Text, TextStyle, View, ViewStyle } from 'react-native';
 
 import {
   isFileAttachment,
@@ -251,6 +251,7 @@ const useStyles = () => {
   const { client } = useChatContext();
 
   const isMyMessage = client.user?.id === quotedMessageFromComposer?.user?.id;
+  const isRTL = I18nManager.isRTL;
 
   return useMemo(
     () =>
@@ -262,7 +263,7 @@ const useStyles = () => {
         },
         container: {
           borderRadius: primitives.radiusLg,
-          flexDirection: 'row',
+          flexDirection: isRTL ? 'row-reverse' : 'row',
           padding: primitives.spacingXs,
           backgroundColor: isMyMessage ? semantics.chatBgOutgoing : semantics.chatBgIncoming,
         },
@@ -282,14 +283,24 @@ const useStyles = () => {
           top: 0,
         },
         leftContainer: {
-          borderLeftWidth: 2,
           flex: 1,
           justifyContent: 'center',
           paddingHorizontal: primitives.spacingXs,
-          borderLeftColor: isMyMessage
-            ? semantics.chatReplyIndicatorOutgoing
-            : semantics.chatReplyIndicatorIncoming,
           gap: primitives.spacingXxxs,
+          alignItems: 'flex-start',
+          ...(isRTL
+            ? {
+                borderRightColor: isMyMessage
+                  ? semantics.chatReplyIndicatorOutgoing
+                  : semantics.chatReplyIndicatorIncoming,
+                borderRightWidth: 2,
+              }
+            : {
+                borderLeftColor: isMyMessage
+                  ? semantics.chatReplyIndicatorOutgoing
+                  : semantics.chatReplyIndicatorIncoming,
+                borderLeftWidth: 2,
+              }),
         },
         rightContainer: {},
         title: {
@@ -298,11 +309,12 @@ const useStyles = () => {
           fontWeight: primitives.typographyFontWeightSemiBold,
           includeFontPadding: false,
           lineHeight: primitives.typographyLineHeightTight,
+          textAlign: isRTL ? 'right' : 'left',
         },
         wrapper: {
           padding: primitives.spacingXxs,
         },
       }),
-    [isMyMessage, semantics],
+    [isMyMessage, isRTL, semantics],
   );
 };

--- a/package/src/components/Reply/ReplyMessageView.tsx
+++ b/package/src/components/Reply/ReplyMessageView.tsx
@@ -50,6 +50,7 @@ const useStyles = ({ isMyMessage = false }: { isMyMessage?: boolean }) => {
         alignItems: 'center',
         gap: primitives.spacingXxs,
         flexShrink: 1,
+        alignSelf: 'flex-start',
         ...messagePreview.container,
       },
       subtitle: {

--- a/package/src/components/ThreadList/ThreadListItem.tsx
+++ b/package/src/components/ThreadList/ThreadListItem.tsx
@@ -260,6 +260,7 @@ const useStyles = () => {
           fontSize: primitives.typographyFontSizeSm,
           fontWeight: primitives.typographyFontWeightSemiBold,
           lineHeight: primitives.typographyLineHeightNormal,
+          textAlign: 'left',
           ...threadListItem.channelName,
         },
         content: {

--- a/package/src/components/UIComponents/SwipableWrapper.tsx
+++ b/package/src/components/UIComponents/SwipableWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren, useEffect, useMemo, useRef } from 'react';
-import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+import { I18nManager, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 
 import { Pressable } from 'react-native-gesture-handler';
 import Animated, {
@@ -42,6 +42,8 @@ export type SwipableWrapperProps = PropsWithChildren<{
   swipableProps?: SwipeableProps;
 }>;
 
+type ActionSide = 'left' | 'right';
+
 export const getRightActionsLayout = (itemCount: number) => {
   if (!itemCount) {
     return { containerWidth: 0, itemWidth: 0 };
@@ -55,19 +57,27 @@ export const getRightActionsLayout = (itemCount: number) => {
 
 export const RightActions = ({
   items,
+  side,
   translation,
 }: {
   items: SwipableActionItem[];
+  side?: ActionSide;
   translation: SharedValue<number>;
 }) => {
+  const resolvedSide = side ?? (I18nManager.isRTL ? 'left' : 'right');
   const { containerWidth, itemWidth } = useMemo(
     () => getRightActionsLayout(items.length),
     [items.length],
   );
+  const actionItems = useMemo(
+    () => (resolvedSide === 'left' ? [...items].reverse() : items),
+    [items, resolvedSide],
+  );
+  const translationDirection = resolvedSide === 'right' ? -1 : 1;
 
   const animatedActionWidthStyle = useAnimatedStyle(() => ({
     width: interpolate(
-      -translation.value,
+      translationDirection * translation.value,
       [0, containerWidth, containerWidth + 40],
       [0, itemWidth, itemWidth + 8],
       Extrapolation.CLAMP,
@@ -78,7 +88,7 @@ export const RightActions = ({
     transform: [
       {
         scale: interpolate(
-          -translation.value,
+          translationDirection * translation.value,
           [0, containerWidth, containerWidth + 40],
           [0, 1, 1],
           Extrapolation.CLAMP,
@@ -88,8 +98,13 @@ export const RightActions = ({
   }));
 
   return (
-    <Animated.View style={[styles.rightActionsContainer, { width: containerWidth }]}>
-      {items.map((item) => {
+    <Animated.View
+      style={[
+        resolvedSide === 'left' ? styles.leftActionsContainer : styles.rightActionsContainer,
+        { width: containerWidth },
+      ]}
+    >
+      {actionItems.map((item) => {
         const Content = item.Content;
         return (
           <AnimatedPressable
@@ -110,6 +125,7 @@ export const RightActions = ({
 };
 
 export const SwipableWrapper = ({ children, swipeableId, swipableProps }: SwipableWrapperProps) => {
+  const isRTL = I18nManager.isRTL;
   const swipeRegistry = useSwipeRegistryContext();
   const swipeableRef = useRef<SwipeableMethods | null>(null);
 
@@ -128,28 +144,43 @@ export const SwipableWrapper = ({ children, swipeableId, swipableProps }: Swipab
       if (swipeRegistry && swipeableId) {
         swipeRegistry.notifyWillOpen(swipeableId);
       }
-      swipableProps?.onSwipeableWillOpen?.(direction);
+
+      swipableProps?.onSwipeableOpenStartDrag?.(direction);
     },
   );
 
-  const onSwipeableWillClose = useStableCallback(() => {
-    if (swipeableId) {
-      swipeRegistry?.updateOpenTracker(swipeableId, false);
-    }
-  });
+  const onSwipeableWillClose = useStableCallback(
+    (direction: SwipeDirection.LEFT | SwipeDirection.RIGHT) => {
+      if (swipeableId) {
+        swipeRegistry?.updateOpenTracker(swipeableId, false);
+      }
+
+      swipableProps?.onSwipeableWillClose?.(direction);
+    },
+  );
+
+  const rtlAwareSwipeableProps = useMemo<SwipeableProps>(() => {
+    const { overshootLeft, overshootRight, renderLeftActions, renderRightActions, ...rest } =
+      swipableProps ?? {};
+
+    return {
+      ...rest,
+      overshootLeft: isRTL ? (overshootRight ?? true) : (overshootLeft ?? false),
+      overshootRight: isRTL ? (overshootLeft ?? false) : (overshootRight ?? true),
+      renderLeftActions: isRTL ? renderRightActions : renderLeftActions,
+      renderRightActions: isRTL ? renderLeftActions : renderRightActions,
+    };
+  }, [isRTL, swipableProps]);
 
   return (
     <ReanimatedSwipeable
       ref={swipeableRef}
-      onSwipeableOpenStartDrag={onSwipeableOpenStartDrag}
       animationOptions={animationOptions}
       friction={1.5}
+      onSwipeableOpenStartDrag={onSwipeableOpenStartDrag}
       onSwipeableWillClose={onSwipeableWillClose}
-      overshootLeft={false}
-      overshootRight={true}
       overshootFriction={16}
-      renderLeftActions={undefined}
-      {...swipableProps}
+      {...rtlAwareSwipeableProps}
     >
       {children}
     </ReanimatedSwipeable>
@@ -157,7 +188,14 @@ export const SwipableWrapper = ({ children, swipeableId, swipableProps }: Swipab
 };
 
 const styles = StyleSheet.create({
+  leftActionsContainer: {
+    direction: 'ltr',
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    overflow: 'visible',
+  },
   rightActionsContainer: {
+    direction: 'ltr',
     flexDirection: 'row',
     justifyContent: 'flex-end',
     overflow: 'visible',

--- a/package/src/components/UIComponents/__tests__/SwipableWrapper.test.tsx
+++ b/package/src/components/UIComponents/__tests__/SwipableWrapper.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { I18nManager, Text, View } from 'react-native';
+
+import { render } from '@testing-library/react-native';
+
+import { SwipeRegistryProvider } from '../../../contexts/swipeableContext/SwipeRegistryContext';
+import { SwipableWrapper } from '../SwipableWrapper';
+
+const mockReanimatedSwipeable = jest.fn(({ children }: React.PropsWithChildren) => (
+  <View>{children}</View>
+));
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockReanimatedSwipeable(...args),
+  SwipeDirection: {
+    LEFT: 'left',
+    RIGHT: 'right',
+  },
+}));
+
+describe('SwipableWrapper', () => {
+  const originalIsRTL = I18nManager.isRTL;
+
+  const setRTL = (value: boolean) => {
+    Object.defineProperty(I18nManager, 'isRTL', {
+      configurable: true,
+      value,
+    });
+  };
+
+  const renderWithRegistry = (ui: React.ReactElement) =>
+    render(<SwipeRegistryProvider>{ui}</SwipeRegistryProvider>);
+
+  beforeEach(() => {
+    mockReanimatedSwipeable.mockClear();
+  });
+
+  afterEach(() => {
+    setRTL(originalIsRTL);
+  });
+
+  it('uses right-side overshoot defaults in ltr', () => {
+    setRTL(false);
+
+    renderWithRegistry(
+      <SwipableWrapper>
+        <Text>child</Text>
+      </SwipableWrapper>,
+    );
+
+    expect(mockReanimatedSwipeable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overshootLeft: false,
+        overshootRight: true,
+      }),
+      undefined,
+    );
+  });
+
+  it('uses left-side overshoot defaults in rtl', () => {
+    setRTL(true);
+
+    renderWithRegistry(
+      <SwipableWrapper>
+        <Text>child</Text>
+      </SwipableWrapper>,
+    );
+
+    expect(mockReanimatedSwipeable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overshootLeft: true,
+        overshootRight: false,
+      }),
+      undefined,
+    );
+  });
+
+  it('maps logical right actions to left actions in rtl', () => {
+    setRTL(true);
+
+    const renderRightActions = jest.fn(() => null);
+
+    renderWithRegistry(
+      <SwipableWrapper swipableProps={{ renderRightActions }}>
+        <Text>child</Text>
+      </SwipableWrapper>,
+    );
+
+    expect(mockReanimatedSwipeable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        renderLeftActions: renderRightActions,
+        renderRightActions: undefined,
+      }),
+      undefined,
+    );
+  });
+});

--- a/package/src/components/ui/Input/Input.tsx
+++ b/package/src/components/ui/Input/Input.tsx
@@ -166,12 +166,14 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeMd,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightNormal,
+        textAlign: 'left',
       },
       description: {
         color: semantics.textTertiary,
         fontSize: primitives.typographyFontSizeSm,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightNormal,
+        textAlign: 'left',
       },
       inputContainer: {
         alignItems: 'center',
@@ -190,6 +192,7 @@ const useStyles = () => {
         fontWeight: primitives.typographyFontWeightRegular,
         color: semantics.inputTextDefault,
         paddingVertical: 0, // android is adding extra padding so we remove it
+        textAlign: I18nManager.isRTL ? 'right' : 'left',
       },
       helperContainer: {
         alignItems: 'center',
@@ -201,6 +204,7 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeSm,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightNormal,
+        textAlign: 'left',
       },
     });
   }, [semantics]);

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useMemo } from 'react';
-import { Platform, Pressable, StyleSheet, useWindowDimensions, View } from 'react-native';
+import {
+  I18nManager,
+  Platform,
+  Pressable,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   clamp,
@@ -151,12 +158,13 @@ export const MessageOverlayHostLayer = ({ BackgroundComponent }: MessageOverlayH
 
   const topItemStyle = useAnimatedStyle(() => {
     if (!topH.value) return { height: 0 };
+    const horizontalPosition = I18nManager.isRTL ? { right: topH.value.x } : { left: topH.value.x };
     return {
       height: topH.value.h,
-      left: topH.value.x,
       position: 'absolute',
       top: topH.value.y,
       width: topH.value.w,
+      ...horizontalPosition,
     };
   });
 
@@ -172,12 +180,15 @@ export const MessageOverlayHostLayer = ({ BackgroundComponent }: MessageOverlayH
 
   const bottomItemStyle = useAnimatedStyle(() => {
     if (!bottomH.value) return { height: 0 };
+    const horizontalPosition = I18nManager.isRTL
+      ? { right: bottomH.value.x }
+      : { left: bottomH.value.x };
     return {
       height: bottomH.value.h,
-      left: bottomH.value.x,
       position: 'absolute',
       top: bottomH.value.y,
       width: bottomH.value.w,
+      ...horizontalPosition,
     };
   });
 


### PR DESCRIPTION
## 🎯 Goal

This PR addresses a bunch of RTL issues our SDK has had over the last couple of majors and makes sure we have first class support for it.

## Summary

This PR fixes a set of RTL specific UI regressions that were affecting several surfaces in the SDK.

The issues were not all caused by the same thing. Some were caused by relying on implicit platform mirroring, some by scroll/list containers using the wrong coordinate space in RTL, and some by spacing being applied on the wrong level of a scrollable surface. The result was a mix of broken alignment, unstable animations, blank gallery content, and inconsistent behavior between iOS and Android.

This PR makes those behaviors explicit and stabilizes the affected components without changing their public API.

## Problems fixed

- Channel swipable actions not working properly with RTL
- Swipe to reply not working properly with RTL
- Audio playing not working properly with RTL
- Context menu positioning being broken with RTL
- Attachment upload preview strip behaved incorrectly in RTL, especially on Android.
- Poll creation and poll result modals had broken spacing in RTL, with content appearing pinned to one side.
- Poll text alignment was inconsistent between Android and iOS.
- Poll inputs inside poll screens/modals were not following the same RTL text alignment behavior as the main composer input.
- The image gallery could open in RTL, but images would not render even though gestures still worked.
- The thread list item channel name at the top of each thread card was aligned incorrectly in RTL.

## What changed

### Gesture driven bugs in RTL

For a lot of the features in the SDK, such as channel swipeables, STR and similar we rely on gestures directly in order to be able to do an action.  Gestures in RN are never RTL compliant and so we need to handle these cases explicitly. Most of the time, simple inversions work just fine however in certain instances (like our `SwipeableWrapper`) a small adapter layer is needed to be able to distinguish between left and right.

### RTL attachment preview stability

The attachment preview strip now uses a stable coordinate-space approach in RTL so it no longer fights the list/pager/layout system.

- stabilized the horizontal preview list so RTL no longer depends on fragile scroll compensation behavior
- removed the RTL specific scroll race that was causing inconsistent Android behavior
- kept the visual RTL ordering/alignment behavior while avoiding the previous listwide bounce/shift issues
- disabled problematic overscroll behavior where needed so native scroll physics stop interfering with the preview strip

Unfortunately, I could not at all get RTL to work natively here due to the fact that `reanimated`'s layout animations were completely messing with the underlying `ScrollView`'s width calculations when horizontal. After a couple of hours of debugging I settled with disabling RTL directly and handling all edge cases manually.

This was the area with the most platform sensitivity, especially on Android.

### Poll modal spacing and layout fixes

The poll modal issue turned out not to be an individual-screen bug. The main problem was that outer padding was being applied on scroll/list wrappers, which behaves badly in Android RTL and can look like horizontal padding is only applied from one side.

The fix was to move spacing from outer scroll containers into their content containers for the shared poll modal surfaces.

This fixes layout issues in:

- create poll
- poll results
- poll answers list
- full option results views
- other shared poll modal surfaces using the same pattern

As part of that cleanup, earlier safe-area wrapper changes were reverted because they were not the actual fix.

### Poll text alignment on iOS RTL

Poll titles, labels, cards, and result text were relying too much on implicit platform behavior. Android happened to look mostly correct, while iOS did not.

This PR makes the relevant non-input poll text alignment explicit where needed so the iOS rendering matches the intended RTL layout.

It also replaces a few LTR-only spacing rules with logical start-aware spacing where the text/result rows needed it.

### Poll input alignment consistency

Poll inputs now follow the same RTL alignment rule as the existing autocomplete composer input instead of using a separate behavior.

That means poll inputs now use:

- textAlign: I18nManager.isRTL ? 'right' : 'left'

This was applied to the poll-specific input surfaces, including modal inputs, so editable text behaves consistently across the SDK.

### Image gallery rendering in RTL

The gallery rendering issue was caused by a coordinate-space mismatch.

The pager/slide math in the image gallery is LTR-based, but the gallery container was still inheriting RTL layout direction. In practice, that meant the gallery could open and still respond to swipe/
close gestures, while the image slides themselves were effectively laid out off-screen.

The fix was to force only the gallery pager strip into LTR coordinates while leaving the rest of the experience intact.

This restores image rendering in RTL without changing the gallery gesture model.

### Thread list item alignment

The channel name at the top of thread list items now uses explicit alignment so it renders correctly in RTL.

This is a narrow change scoped only to that text style.

## Why this approach

The common theme across these issues is that implicit RTL handling was not reliable enough for these components.

The fixes in this PR intentionally avoid broad “flip everything” logic. Instead, each surface now expresses the behavior it actually needs:

- content containers own spacing in scrollable modal surfaces
- text components that need explicit alignment get explicit alignment
- input components use the same RTL rule as the main composer
- animation/pager surfaces that depend on physical coordinates are pinned to an LTR coordinate space when that is what their math assumes

That keeps the fixes targeted and avoids introducing new regressions in already. correct layouts.

I'm sure there are other edge cases with RTL that I did not manage to notice, however as a first step this should do just fine, especially considering we've never had any RTL support before.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


