### PR TITLE
fix: ui redesign bugs

### DIFF
--- a/examples/SampleApp/android/app/src/main/java/com/sampleapp/MainActivity.kt
+++ b/examples/SampleApp/android/app/src/main/java/com/sampleapp/MainActivity.kt
@@ -16,30 +16,6 @@ class MainActivity : ReactActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(null)
-
-    if (Build.VERSION.SDK_INT >= 35) {
-      val rootView = findViewById<View>(android.R.id.content)
-
-      val initial = Insets.of(
-        rootView.paddingLeft,
-        rootView.paddingTop,
-        rootView.paddingRight,
-        rootView.paddingBottom
-      )
-
-      ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
-        val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
-
-        v.updatePadding(
-          left = initial.left,
-          top = initial.top,
-          right = initial.right,
-          bottom = initial.bottom + ime.bottom
-        )
-
-        insets
-      }
-    }
   }
 
   override fun getMainComponentName(): String = "SampleApp"

--- a/examples/SampleApp/android/app/src/main/java/com/sampleapp/MainActivity.kt
+++ b/examples/SampleApp/android/app/src/main/java/com/sampleapp/MainActivity.kt
@@ -1,12 +1,8 @@
 package io.getstream.reactnative.sampleapp
 
+import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
-import android.view.View
-import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updatePadding
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
@@ -16,6 +12,14 @@ class MainActivity : ReactActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(null)
+
+    window.navigationBarColor = Color.TRANSPARENT
+    window.statusBarColor = Color.TRANSPARENT
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      window.isNavigationBarContrastEnforced = false
+      window.isStatusBarContrastEnforced = false
+    }
   }
 
   override fun getMainComponentName(): String = "SampleApp"

--- a/examples/SampleApp/android/app/src/main/res/values/styles.xml
+++ b/examples/SampleApp/android/app/src/main/res/values/styles.xml
@@ -2,7 +2,9 @@
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <!-- Customize your theme here. -->
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
 
 </resources>

--- a/examples/SampleApp/src/components/ChannelDetailProfileSection.tsx
+++ b/examples/SampleApp/src/components/ChannelDetailProfileSection.tsx
@@ -1,15 +1,17 @@
 import React, { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { useTheme } from 'stream-chat-react-native';
+
+import { ChannelPreviewMutedStatus, useTheme } from 'stream-chat-react-native';
 
 type ChannelDetailProfileSectionProps = {
   avatar: React.ReactNode;
+  muted?: boolean;
   subtitle: string;
   title: string;
 };
 
 export const ChannelDetailProfileSection = React.memo(
-  ({ avatar, subtitle, title }: ChannelDetailProfileSectionProps) => {
+  ({ avatar, muted, subtitle, title }: ChannelDetailProfileSectionProps) => {
     const {
       theme: { semantics },
     } = useTheme();
@@ -19,9 +21,12 @@ export const ChannelDetailProfileSection = React.memo(
       <View style={styles.container}>
         {avatar}
         <View style={styles.heading}>
-          <Text style={[styles.title, { color: semantics.textPrimary }]} numberOfLines={2}>
-            {title}
-          </Text>
+          <View style={styles.titleRow}>
+            <Text style={[styles.title, { color: semantics.textPrimary }]} numberOfLines={2}>
+              {title}
+            </Text>
+            {muted ? <ChannelPreviewMutedStatus /> : null}
+          </View>
           {subtitle ? (
             <Text style={[styles.subtitle, { color: semantics.textSecondary }]} numberOfLines={1}>
               {subtitle}
@@ -49,8 +54,16 @@ const useStyles = () =>
           gap: 8,
           width: '100%',
         },
+        titleRow: {
+          alignItems: 'center',
+          flexDirection: 'row',
+          gap: 4,
+          justifyContent: 'center',
+          maxWidth: '100%',
+        },
         title: {
           fontSize: 22,
+          flexShrink: 1,
           fontWeight: '600',
           lineHeight: 24,
           textAlign: 'center',

--- a/examples/SampleApp/src/screens/ChannelScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelScreen.tsx
@@ -273,7 +273,7 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({ navigation, route 
         messageInputFloating={messageInputFloating}
         onPressMessage={onPressMessage}
         initialScrollToFirstUnreadMessage
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : -300}
+        keyboardVerticalOffset={0}
         messageActions={messageActions}
         MessageLocation={MessageLocation}
         messageId={messageId}

--- a/examples/SampleApp/src/screens/GroupChannelDetailsScreen.tsx
+++ b/examples/SampleApp/src/screens/GroupChannelDetailsScreen.tsx
@@ -1,10 +1,17 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Switch, Text, View } from 'react-native';
+
 import { SafeAreaView } from 'react-native-safe-area-context';
+
 import { RouteProp, useNavigation } from '@react-navigation/native';
+
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { ChannelMemberResponse, UserResponse } from 'stream-chat';
+
 import {
   ChannelAvatar,
   useChannelPreviewDisplayName,
+  useIsChannelMuted,
   useOverlayContext,
   useTheme,
   Pin,
@@ -26,9 +33,6 @@ import { GoForward } from '../icons/GoForward';
 import { LeaveGroup } from '../icons/LeaveGroup';
 import { Mute } from '../icons/Mute';
 import { Picture } from '../icons/Picture';
-
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import type { ChannelMemberResponse, UserResponse } from 'stream-chat';
 import type { StackNavigatorParamList } from '../types';
 
 const MAX_VISIBLE_MEMBERS = 5;
@@ -55,6 +59,7 @@ export const GroupChannelDetailsScreen: React.FC<GroupChannelDetailsProps> = ({
   const {
     theme: { semantics },
   } = useTheme();
+  const { muted: channelMuted } = useIsChannelMuted(channel);
 
   const [muted, setMuted] = useState(
     chatClient?.mutedChannels.some((mute) => mute.channel?.id === channel?.id),
@@ -197,6 +202,7 @@ export const GroupChannelDetailsScreen: React.FC<GroupChannelDetailsProps> = ({
       <ScrollView contentContainerStyle={styles.scrollContent} style={styles.container}>
         <ChannelDetailProfileSection
           avatar={<ChannelAvatar channel={channel} size='2xl' />}
+          muted={channelMuted}
           title={displayName}
           subtitle={memberStatusText}
         />
@@ -317,11 +323,7 @@ export const GroupChannelDetailsScreen: React.FC<GroupChannelDetailsProps> = ({
         onClose={closeContactDetail}
         visible={selectedMember !== null}
       />
-      <EditGroupBottomSheet
-        channel={channel}
-        onClose={closeEditSheet}
-        visible={editVisible}
-      />
+      <EditGroupBottomSheet channel={channel} onClose={closeEditSheet} visible={editVisible} />
     </SafeAreaView>
   );
 };

--- a/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
+++ b/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
@@ -341,7 +341,7 @@ export const NewDirectMessagingScreen: React.FC<NewDirectMessagingScreenProps> =
         channel={currentChannel.current}
         EmptyStateIndicator={EmptyMessagesIndicator}
         enforceUniqueReaction
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : -300}
+        keyboardVerticalOffset={0}
         onChangeText={setMessageInputText}
         overrideOwnCapabilities={{ sendMessage: true }}
         SendButton={NewDirectMessagingSendButton}

--- a/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
+++ b/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Platform, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
@@ -204,9 +204,20 @@ export const NewDirectMessagingScreen: React.FC<NewDirectMessagingScreenProps> =
     initChannel();
   }, [chatClient, selectedUserIds, selectedUsersLength]);
 
+  const onBackPress = useCallback(() => {
+    reset();
+
+    if (!navigation.canGoBack()) {
+      navigation.reset({ index: 0, routes: [{ name: 'MessagingScreen' }] });
+      return;
+    }
+
+    navigation.goBack();
+  }, [navigation, reset]);
+
   const renderUserSearch = ({ inSafeArea }: { inSafeArea: boolean }) => (
     <View style={[{ backgroundColor: white }, focusOnSearchInput ? styles.container : undefined]}>
-      <ScreenHeader inSafeArea={inSafeArea} onBack={reset} titleText='New Chat' />
+      <ScreenHeader inSafeArea={inSafeArea} onBack={onBackPress} titleText='New Chat' />
       <TouchableOpacity
         activeOpacity={1}
         onPress={() => {

--- a/examples/SampleApp/src/screens/NewGroupChannelAddMemberScreen.tsx
+++ b/examples/SampleApp/src/screens/NewGroupChannelAddMemberScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { FlatList, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
 import { Search, useTheme } from 'stream-chat-react-native';
 
@@ -79,6 +79,17 @@ export const NewGroupChannelAddMemberScreen: React.FC<Props> = ({ navigation }) 
   const { onChangeSearchText, onFocusInput, removeUser, reset, searchText, selectedUsers } =
     useUserSearchContext();
 
+  const onBackPress = useCallback(() => {
+    reset();
+
+    if (!navigation.canGoBack()) {
+      navigation.reset({ index: 0, routes: [{ name: 'MessagingScreen' }] });
+      return;
+    }
+
+    navigation.goBack();
+  }, [navigation, reset]);
+
   const onRightArrowPress = () => {
     if (selectedUsers.length === 0) {
       return;
@@ -93,7 +104,7 @@ export const NewGroupChannelAddMemberScreen: React.FC<Props> = ({ navigation }) 
   return (
     <View style={styles.container}>
       <ScreenHeader
-        onBack={reset}
+        onBack={onBackPress}
         // eslint-disable-next-line react/no-unstable-nested-components
         RightContent={() => (
           <RightArrowButton disabled={selectedUsers.length === 0} onPress={onRightArrowPress} />

--- a/examples/SampleApp/src/screens/OneOnOneChannelDetailScreen.tsx
+++ b/examples/SampleApp/src/screens/OneOnOneChannelDetailScreen.tsx
@@ -1,7 +1,18 @@
 import React, { useCallback, useState } from 'react';
 import { ScrollView, StyleSheet, Switch } from 'react-native';
-import { ChannelAvatar, Delete, useTheme, Pin, CircleBan } from 'stream-chat-react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+
+import type { RouteProp } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import {
+  ChannelAvatar,
+  CircleBan,
+  Delete,
+  useChannelMuteActive,
+  Pin,
+  useTheme,
+} from 'stream-chat-react-native';
 
 import { ChannelDetailProfileSection } from '../components/ChannelDetailProfileSection';
 import { ConfirmationBottomSheet } from '../components/ConfirmationBottomSheet';
@@ -13,11 +24,8 @@ import { File } from '../icons/File';
 import { GoForward } from '../icons/GoForward';
 import { Mute } from '../icons/Mute';
 import { Picture } from '../icons/Picture';
-import { getUserActivityStatus } from '../utils/getUserActivityStatus';
-
-import type { RouteProp } from '@react-navigation/native';
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { StackNavigatorParamList } from '../types';
+import { getUserActivityStatus } from '../utils/getUserActivityStatus';
 
 type OneOnOneChannelDetailScreenRouteProp = RouteProp<
   StackNavigatorParamList,
@@ -44,6 +52,7 @@ export const OneOnOneChannelDetailScreen: React.FC<Props> = ({
     theme: { semantics },
   } = useTheme();
   const { chatClient } = useAppContext();
+  const userMuted = useChannelMuteActive(channel);
 
   const [confirmationVisible, setConfirmationVisible] = useState(false);
   const [blockUserConfirmationVisible, setBlockUserConfirmationVisible] = useState(false);
@@ -141,6 +150,7 @@ export const OneOnOneChannelDetailScreen: React.FC<Props> = ({
       <ScrollView contentContainerStyle={styles.scrollContent} style={styles.container}>
         <ChannelDetailProfileSection
           avatar={<ChannelAvatar channel={channel} size='2xl' />}
+          muted={userMuted}
           title={user.name || user.id}
           subtitle={activityStatus}
         />

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import {
   AlsoSentToChannelHeaderPressPayload,
@@ -149,7 +149,7 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
   return (
     <View style={[styles.container, { backgroundColor: white }]}>
       <Channel
-        audioRecordingEnabled={false}
+        audioRecordingEnabled={true}
         AttachmentPickerSelectionBar={CustomAttachmentPickerSelectionBar}
         channel={channel}
         enforceUniqueReaction

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -153,7 +153,7 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({
         AttachmentPickerSelectionBar={CustomAttachmentPickerSelectionBar}
         channel={channel}
         enforceUniqueReaction
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : -300}
+        keyboardVerticalOffset={0}
         messageActions={messageActions}
         messageInputFloating={messageInputFloating}
         MessageLocation={MessageLocation}

--- a/package/src/components/AttachmentPicker/components/AttachmentPickerContent.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentPickerContent.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../../contexts';
 import { useTheme } from '../../../contexts/themeContext/ThemeContext';
 import { useAttachmentPickerState, useStableCallback } from '../../../hooks';
-import { Camera, FilePickerIcon, PollThumbnail, Recorder } from '../../../icons';
+import { Camera, FilePickerIcon, PollThumbnail, VideoIcon } from '../../../icons';
 import { primitives } from '../../../theme';
 import { CommandSuggestionItem } from '../../AutoCompleteInput/AutoCompleteSuggestionItem';
 
@@ -197,7 +197,7 @@ export const AttachmentCameraPicker = (
     />
   ) : (
     <AttachmentPickerGenericContent
-      Icon={videoOnly ? Recorder : Camera}
+      Icon={videoOnly ? VideoIcon : Camera}
       onPress={openCameraPicker}
       height={height}
       buttonText={t('Open Camera')}

--- a/package/src/components/AttachmentPicker/components/AttachmentTypePickerButton.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentTypePickerButton.tsx
@@ -19,7 +19,7 @@ import { useAttachmentPickerState } from '../../../hooks/useAttachmentPickerStat
 import {
   Camera,
   Picture,
-  Recorder,
+  VideoIcon,
   FilePickerIcon,
   PollThumbnail,
   CommandsIcon,
@@ -121,7 +121,7 @@ export const CameraPickerButton = () => {
       />
       {Platform.OS === 'android' ? (
         <AttachmentTypePickerButton
-          Icon={Recorder}
+          Icon={VideoIcon}
           selected={selectedPicker === 'camera-video'}
           onPress={onVideoRecorderPickerPress}
         />

--- a/package/src/components/ChannelList/hooks/__tests__/useChannelActionItems.test.tsx
+++ b/package/src/components/ChannelList/hooks/__tests__/useChannelActionItems.test.tsx
@@ -110,7 +110,7 @@ describe('useChannelActionItems', () => {
       'destructive',
     ]);
     expect(result.current.map((item) => item.placement)).toEqual([
-      'both',
+      'swipe',
       'both',
       'sheet',
       'sheet',
@@ -266,7 +266,7 @@ describe('getChannelActionItems', () => {
 
     expect(actionItems[0].action).toBe(channelActions.unmuteChannel);
     expect(actionItems[0].label).toBe('Unmute Group');
-    expect(actionItems[0].placement).toBe('both');
+    expect(actionItems[0].placement).toBe('swipe');
 
     expect(actionItems[1].action).toBe(channelActions.unarchive);
     expect(actionItems[1].label).toBe('Unarchive Group');

--- a/package/src/components/ChannelList/hooks/useChannelActionItems.tsx
+++ b/package/src/components/ChannelList/hooks/useChannelActionItems.tsx
@@ -112,7 +112,7 @@ export const buildDefaultChannelActionItems: BuildDefaultChannelActionItems = (
         : muteActive
           ? t('Unmute Group')
           : t('Mute Group'),
-      placement: isDirectChat ? 'sheet' : 'both',
+      placement: isDirectChat ? 'sheet' : 'swipe',
       type: 'standard',
     },
   ];

--- a/package/src/components/ChannelPreview/ChannelDetailsBottomSheet.tsx
+++ b/package/src/components/ChannelPreview/ChannelDetailsBottomSheet.tsx
@@ -6,7 +6,9 @@ import { Pressable } from 'react-native-gesture-handler';
 
 import { Channel } from 'stream-chat';
 
+import { ChannelPreviewMutedStatus } from './ChannelPreviewMutedStatus';
 import { ChannelPreviewTitle } from './ChannelPreviewTitle';
+import { useIsChannelMuted } from './hooks/useIsChannelMuted';
 
 import { useBottomSheetContext, useTheme, useTranslationContext } from '../../contexts';
 import { useSwipeRegistryContext } from '../../contexts/swipeableContext/SwipeRegistryContext';
@@ -14,6 +16,7 @@ import { useStableCallback } from '../../hooks';
 import { primitives } from '../../theme';
 import { ChannelActionItem } from '../ChannelList/hooks/useChannelActionItems';
 import { useChannelMembersState } from '../ChannelList/hooks/useChannelMembersState';
+import { useChannelMuteActive } from '../ChannelList/hooks/useChannelMuteActive';
 import { useChannelOnlineMemberCount } from '../ChannelList/hooks/useChannelOnlineMemberCount';
 import { useIsDirectChat } from '../ChannelList/hooks/useIsDirectChat';
 import { ChannelAvatar } from '../ui';
@@ -35,6 +38,9 @@ export const ChannelDetailsHeader = ({ channel }: ChannelDetailsHeaderProps) => 
   const memberCount = useMemo(() => Object.keys(members).length, [members]);
   const onlineCount = useChannelOnlineMemberCount(channel);
   const isDirectChat = useIsDirectChat(channel);
+  const { muted: channelMuted } = useIsChannelMuted(channel);
+  const directChatUserMuted = useChannelMuteActive(channel);
+  const muted = isDirectChat ? directChatUserMuted : channelMuted;
   const displayedMemberCount = memberCount > 9 ? '9+' : `${memberCount}`;
   const displayedOnlineCount = onlineCount > 9 ? '9+' : `${onlineCount}`;
   const membersAndOnlineLabel = useMemo(
@@ -51,7 +57,10 @@ export const ChannelDetailsHeader = ({ channel }: ChannelDetailsHeaderProps) => 
     <View style={styles.headerContainer}>
       <ChannelAvatar channel={channel} size={'lg'} />
       <View style={styles.metaContainer}>
-        <ChannelPreviewTitle channel={channel} />
+        <View style={styles.titleContainer}>
+          <ChannelPreviewTitle channel={channel} />
+          {muted ? <ChannelPreviewMutedStatus /> : null}
+        </View>
         <Text style={styles.headerMeta}>
           {isDirectChat ? (onlineCount === 1 ? t('Online') : t('Offline')) : membersAndOnlineLabel}
         </Text>
@@ -144,6 +153,11 @@ const useStyles = () => {
         metaContainer: {
           gap: primitives.spacingXxs,
           ...header.metaContainer,
+        },
+        titleContainer: {
+          alignItems: 'center',
+          flexDirection: 'row',
+          gap: primitives.spacingXxs,
         },
         itemContainer: {
           flexDirection: 'row',

--- a/package/src/components/ChannelPreview/ChannelPreviewMessage.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewMessage.tsx
@@ -76,6 +76,7 @@ export const ChannelPreviewMessage = (props: ChannelPreviewMessageProps) => {
 
   const isFailedMessage =
     lastMessage?.status === MessageStatusTypes.FAILED || lastMessage?.type === 'error';
+  const showMessageDeliveryStatus = !isMessageDeleted;
 
   if (usersTyping.length > 0) {
     return <PreviewTypingIndicator channel={channel} usersTyping={usersTyping} />;
@@ -120,14 +121,18 @@ export const ChannelPreviewMessage = (props: ChannelPreviewMessageProps) => {
   if (channel.data?.name || membersWithoutSelf.length > 1) {
     return (
       <View style={styles.container}>
-        <PreviewMessageDeliveryStatus channel={channel} message={lastMessage} />
+        {showMessageDeliveryStatus ? (
+          <PreviewMessageDeliveryStatus channel={channel} message={lastMessage} />
+        ) : null}
         <PreviewLastMessage message={lastMessage} />
       </View>
     );
   } else {
     return (
       <View style={styles.container}>
-        <PreviewMessageDeliveryStatus channel={channel} message={lastMessage} />
+        {showMessageDeliveryStatus ? (
+          <PreviewMessageDeliveryStatus channel={channel} message={lastMessage} />
+        ) : null}
         <PreviewLastMessage message={lastMessage} />
       </View>
     );

--- a/package/src/components/ChannelPreview/ChannelSwipableWrapper.tsx
+++ b/package/src/components/ChannelPreview/ChannelSwipableWrapper.tsx
@@ -7,15 +7,14 @@ import { Channel } from 'stream-chat';
 
 import { ChannelDetailsBottomSheet as DefaultChannelDetailsBottomSheet } from './ChannelDetailsBottomSheet';
 import type { ChannelDetailsBottomSheetProps } from './ChannelDetailsBottomSheet';
+import { useIsChannelMuted } from './hooks/useIsChannelMuted';
 
 import { useTheme } from '../../contexts';
 import { useSwipeRegistryContext } from '../../contexts/swipeableContext/SwipeRegistryContext';
-import { Archive, MenuPointHorizontal, Mute, Sound } from '../../icons';
+import { MenuPointHorizontal, Mute, Sound } from '../../icons';
 import { GetChannelActionItems } from '../ChannelList/hooks/useChannelActionItems';
 import { useChannelActionItems } from '../ChannelList/hooks/useChannelActionItems';
-import { useChannelActionItemsById } from '../ChannelList/hooks/useChannelActionItemsById';
-import { useChannelMuteActive } from '../ChannelList/hooks/useChannelMuteActive';
-import { useIsDirectChat } from '../ChannelList/hooks/useIsDirectChat';
+import { useChannelActions } from '../ChannelList/hooks/useChannelActions';
 import {
   BottomSheetModal,
   RightActions,
@@ -44,8 +43,12 @@ export const ChannelSwipableWrapper = ({
   swipableProps?: SwipableWrapperProps['swipableProps'];
 }>) => {
   const [channelDetailSheetOpen, setChannelDetailSheetOpen] = useState(false);
-  const channelActionsById = useChannelActionItemsById({ channel, getChannelActionItems });
+  const { muteChannel, unmuteChannel } = useChannelActions(channel);
   const channelActionItems = useChannelActionItems({ channel, getChannelActionItems });
+  const sheetItems = useMemo(
+    () => channelActionItems.filter((item) => item.placement !== 'swipe'),
+    [channelActionItems],
+  );
   const swipableRegistry = useSwipeRegistryContext();
 
   const {
@@ -53,19 +56,17 @@ export const ChannelSwipableWrapper = ({
   } = useTheme();
   const styles = useStyles();
 
-  const isDirectChannel = useIsDirectChat(channel);
-  const muteActive = useChannelMuteActive(channel);
+  const channelMuteState = useIsChannelMuted(channel);
+  const channelMuteActive = channelMuteState.muted;
 
   const Icon = useCallback(
     () =>
-      isDirectChannel ? (
-        <Archive width={20} height={20} stroke={semantics.textOnAccent} />
-      ) : muteActive ? (
+      channelMuteActive ? (
         <Sound width={20} height={20} stroke={semantics.textOnAccent} />
       ) : (
         <Mute width={20} height={20} fill={semantics.textOnAccent} />
       ),
-    [isDirectChannel, muteActive, semantics.textOnAccent],
+    [channelMuteActive, semantics.textOnAccent],
   );
 
   const swipableActions = useMemo<SwipableActionItem[]>(() => {
@@ -78,29 +79,25 @@ export const ChannelSwipableWrapper = ({
       },
     ];
 
-    const extraItem = isDirectChannel ? channelActionsById.archive : channelActionsById.mute;
-
-    if (extraItem) {
-      const { id, action } = extraItem;
-      items.push({
-        id,
-        action: () => {
-          action();
-          swipableRegistry?.closeAll();
-        },
-        Content: Icon,
-        contentContainerStyle: [styles.contentContainerStyle, styles.standard],
-      });
-    }
+    items.push({
+      id: 'mute',
+      action: () => {
+        const action = channelMuteActive ? unmuteChannel : muteChannel;
+        action();
+        swipableRegistry?.closeAll();
+      },
+      Content: Icon,
+      contentContainerStyle: [styles.contentContainerStyle, styles.standard],
+    });
 
     return items;
   }, [
     styles.contentContainerStyle,
     styles.elipsis,
     styles.standard,
-    isDirectChannel,
-    channelActionsById.mute,
-    channelActionsById.archive,
+    channelMuteActive,
+    muteChannel,
+    unmuteChannel,
     Icon,
     swipableRegistry,
   ]);
@@ -127,7 +124,7 @@ export const ChannelSwipableWrapper = ({
         visible={channelDetailSheetOpen}
         height={356}
       >
-        <ChannelDetailsBottomSheetComponent channel={channel} items={channelActionItems} />
+        <ChannelDetailsBottomSheetComponent channel={channel} items={sheetItems} />
       </BottomSheetModal>
     </>
   );

--- a/package/src/components/ChannelPreview/__tests__/ChannelSwipableWrapper.test.tsx
+++ b/package/src/components/ChannelPreview/__tests__/ChannelSwipableWrapper.test.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+import { act, render } from '@testing-library/react-native';
+import type { Channel } from 'stream-chat';
+
+import type { ChannelActionItem } from '../../ChannelList/hooks/useChannelActionItems';
+import * as ChannelActionItemsModule from '../../ChannelList/hooks/useChannelActionItems';
+import * as ChannelActionsModule from '../../ChannelList/hooks/useChannelActions';
+import { ChannelSwipableWrapper } from '../ChannelSwipableWrapper';
+import * as UseIsChannelMutedModule from '../hooks/useIsChannelMuted';
+
+const rightActionsProbe = {
+  items: [] as Array<{ action: () => void; id: string }>,
+};
+
+const mockSwipableWrapper = jest.fn(
+  ({
+    children,
+    swipableProps,
+  }: React.PropsWithChildren<{
+    swipableProps?: { renderRightActions?: (...args: never[]) => void };
+  }>) => {
+    const rightActions = swipableProps?.renderRightActions?.({} as never, {} as never);
+    return (
+      <>
+        {children}
+        {rightActions}
+      </>
+    );
+  },
+);
+
+jest.mock('../../../contexts', () => ({
+  useTheme: () => ({
+    theme: {
+      semantics: {
+        accentPrimary: '#00f',
+        backgroundCoreSurface: '#fff',
+        textOnAccent: '#000',
+        textPrimary: '#111',
+      },
+    },
+  }),
+}));
+
+jest.mock('../../../contexts/swipeableContext/SwipeRegistryContext', () => ({
+  useSwipeRegistryContext: () => ({
+    closeAll: jest.fn(),
+  }),
+}));
+
+jest.mock('../../UIComponents', () => ({
+  BottomSheetModal: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  RightActions: ({ items }: { items: Array<{ action: () => void; id: string }> }) => {
+    rightActionsProbe.items = items;
+    return null;
+  },
+  SwipableWrapper: (...args: unknown[]) => mockSwipableWrapper(...args),
+}));
+
+describe('ChannelSwipableWrapper', () => {
+  const channel = { cid: 'messaging:test-channel', id: 'test-channel' } as Channel;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rightActionsProbe.items = [];
+  });
+
+  it('uses channel mute for direct-channel swipe actions and keeps mute user in the sheet', () => {
+    const muteChannel = jest.fn();
+    const unmuteChannel = jest.fn();
+    const customBottomSheet = jest.fn(() => null);
+    const items: ChannelActionItem[] = [
+      {
+        Icon: () => null,
+        action: jest.fn(),
+        id: 'mute',
+        label: 'Mute User',
+        placement: 'sheet',
+        type: 'standard',
+      },
+      {
+        Icon: () => null,
+        action: jest.fn(),
+        id: 'archive',
+        label: 'Archive Chat',
+        placement: 'sheet',
+        type: 'standard',
+      },
+    ];
+
+    jest.spyOn(ChannelActionsModule, 'useChannelActions').mockReturnValue({
+      archive: jest.fn(),
+      blockUser: jest.fn(),
+      deleteChannel: jest.fn(),
+      leave: jest.fn(),
+      muteChannel,
+      muteUser: jest.fn(),
+      pin: jest.fn(),
+      unarchive: jest.fn(),
+      unblockUser: jest.fn(),
+      unmuteChannel,
+      unmuteUser: jest.fn(),
+      unpin: jest.fn(),
+    });
+    jest.spyOn(ChannelActionItemsModule, 'useChannelActionItems').mockReturnValue(items);
+    jest.spyOn(UseIsChannelMutedModule, 'useIsChannelMuted').mockReturnValue({
+      createdAt: null,
+      expiresAt: null,
+      muted: false,
+    });
+
+    render(
+      <ChannelSwipableWrapper channel={channel} ChannelDetailsBottomSheet={customBottomSheet}>
+        <Text>child</Text>
+      </ChannelSwipableWrapper>,
+    );
+
+    expect(customBottomSheet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel,
+        items,
+      }),
+      undefined,
+    );
+    expect(rightActionsProbe.items.map((item) => item.id)).toEqual(['openSheet', 'mute']);
+
+    act(() => {
+      rightActionsProbe.items[1].action();
+    });
+
+    expect(muteChannel).toHaveBeenCalledTimes(1);
+    expect(unmuteChannel).not.toHaveBeenCalled();
+  });
+
+  it('removes mute group from the sheet while keeping mute as the quick swipe action', () => {
+    const muteChannel = jest.fn();
+    const customBottomSheet = jest.fn(() => null);
+    const muteItem = {
+      Icon: () => null,
+      action: jest.fn(),
+      id: 'mute',
+      label: 'Mute Group',
+      placement: 'swipe',
+      type: 'standard',
+    } as const satisfies ChannelActionItem;
+    const archiveItem = {
+      Icon: () => null,
+      action: jest.fn(),
+      id: 'archive',
+      label: 'Archive Group',
+      placement: 'both',
+      type: 'standard',
+    } as const satisfies ChannelActionItem;
+
+    jest.spyOn(ChannelActionsModule, 'useChannelActions').mockReturnValue({
+      archive: jest.fn(),
+      blockUser: jest.fn(),
+      deleteChannel: jest.fn(),
+      leave: jest.fn(),
+      muteChannel,
+      muteUser: jest.fn(),
+      pin: jest.fn(),
+      unarchive: jest.fn(),
+      unblockUser: jest.fn(),
+      unmuteChannel: jest.fn(),
+      unmuteUser: jest.fn(),
+      unpin: jest.fn(),
+    });
+    jest
+      .spyOn(ChannelActionItemsModule, 'useChannelActionItems')
+      .mockReturnValue([muteItem, archiveItem]);
+    jest.spyOn(UseIsChannelMutedModule, 'useIsChannelMuted').mockReturnValue({
+      createdAt: null,
+      expiresAt: null,
+      muted: false,
+    });
+
+    render(
+      <ChannelSwipableWrapper channel={channel} ChannelDetailsBottomSheet={customBottomSheet}>
+        <Text>child</Text>
+      </ChannelSwipableWrapper>,
+    );
+
+    expect(customBottomSheet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel,
+        items: [archiveItem],
+      }),
+      undefined,
+    );
+    expect(rightActionsProbe.items.map((item) => item.id)).toEqual(['openSheet', 'mute']);
+
+    act(() => {
+      rightActionsProbe.items[1].action();
+    });
+
+    expect(muteChannel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
+++ b/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  AccessibilityInfo,
   AppState,
   AppStateStatus,
   Dimensions,
@@ -39,7 +40,7 @@ export class KeyboardCompatibleView extends React.Component<
     KeyboardAvoidingViewProps,
     'behavior' | 'enabled' | 'keyboardVerticalOffset'
   > = {
-    behavior: Platform.OS === 'ios' ? 'padding' : 'position',
+    behavior: 'padding',
     enabled: true,
     keyboardVerticalOffset: Platform.OS === 'ios' ? 86.5 : -300, // default MessageComposer height
   };
@@ -62,35 +63,40 @@ export class KeyboardCompatibleView extends React.Component<
     this.viewRef = React.createRef();
   }
 
-  _relativeKeyboardHeight(keyboardFrame: KeyboardMetrics) {
+  async _relativeKeyboardHeight(keyboardFrame: KeyboardMetrics): Promise<number> {
     const frame = this._frame;
-    /**
-     * With iOS 14 & Reduce Motion > Prefer Cross-Fade Transitions enabled, the keyboard position
-     * height is reported differently (0 instead of Y position value) which caused the view to take full height
-     * of the screen.
-     */
-    if (!frame || !keyboardFrame || keyboardFrame.screenY === 0) {
+    if (!frame || !keyboardFrame) {
+      return 0;
+    }
+
+    if (
+      Platform.OS === 'ios' &&
+      keyboardFrame.screenY === 0 &&
+      (await AccessibilityInfo.prefersCrossFadeTransitions())
+    ) {
       return 0;
     }
 
     const keyboardY = keyboardFrame.screenY - (this.props.keyboardVerticalOffset ?? 0);
-    const relativeHeight = frame.y + frame.height - keyboardY;
 
-    /**
-     * When the StatusBar is translucent there is an issue
-     * where the relative keyboard height is returned incorrectly
-     * instead of 0 when closed.
-     */
-    if (Platform.OS === 'android') {
-      const barHeights = Dimensions.get('screen').height - Dimensions.get('window').height;
-      if (relativeHeight <= Math.max(barHeights, StatusBar.currentHeight ?? 0)) {
-        return 0;
-      }
+    if (this.props.behavior === 'height') {
+      return Math.max(this.state.bottom + frame.y + frame.height - keyboardY, 0);
     }
 
     // Calculate the displacement needed for the view such that it
     // no longer overlaps with the keyboard
-    return Math.max(relativeHeight, 0);
+    const relativeHeight = Math.max(frame.y + frame.height - keyboardY, 0);
+
+    if (Platform.OS === 'android') {
+      const barHeights = Dimensions.get('screen').height - Dimensions.get('window').height;
+      const systemInsetFloor = Math.max(barHeights, StatusBar.currentHeight ?? 0);
+
+      if (relativeHeight <= systemInsetFloor) {
+        return 0;
+      }
+    }
+
+    return relativeHeight;
   }
 
   _onKeyboardChange: KeyboardEventListener = (event) => {
@@ -98,7 +104,12 @@ export class KeyboardCompatibleView extends React.Component<
     this._updateBottomIfNecessary();
   };
 
-  _onLayout: (event: LayoutChangeEvent) => void = (event) => {
+  _onKeyboardHide: KeyboardEventListener = () => {
+    this._keyboardEvent = null;
+    this._updateBottomIfNecessary();
+  };
+
+  _onLayout: (event: LayoutChangeEvent) => void = async (event) => {
     event.persist();
 
     const oldFrame = this._frame;
@@ -110,7 +121,7 @@ export class KeyboardCompatibleView extends React.Component<
 
     // update bottom height for the first time or when the height is changed
     if (!oldFrame || oldFrame.height !== this._frame.height) {
-      this._updateBottomIfNecessary();
+      await this._updateBottomIfNecessary();
     }
 
     if (this.props.onLayout) {
@@ -127,14 +138,14 @@ export class KeyboardCompatibleView extends React.Component<
     }
   };
 
-  _updateBottomIfNecessary = () => {
+  _updateBottomIfNecessary = async () => {
     if (this._keyboardEvent == null) {
       this._setBottom(0);
       return;
     }
 
     const { duration, easing, endCoordinates } = this._keyboardEvent;
-    const height = this._relativeKeyboardHeight(endCoordinates);
+    const height = await this._relativeKeyboardHeight(endCoordinates);
 
     if (this._bottom === height) {
       return;
@@ -142,7 +153,8 @@ export class KeyboardCompatibleView extends React.Component<
 
     this._setBottom(height);
 
-    if (duration && easing) {
+    const enabled = this.props.enabled ?? true;
+    if (enabled && duration && easing) {
       LayoutAnimation.configureNext({
         // We have to pass the duration equal to minimal accepted duration defined here: RCTLayoutAnimation.m
         duration: duration > 10 ? duration : 10,
@@ -169,11 +181,12 @@ export class KeyboardCompatibleView extends React.Component<
   setKeyboardListeners = () => {
     if (Platform.OS === 'ios') {
       this._subscriptions = [
-        Keyboard.addListener('keyboardWillChangeFrame', this._onKeyboardChange),
+        Keyboard.addListener('keyboardWillHide', this._onKeyboardHide),
+        Keyboard.addListener('keyboardWillShow', this._onKeyboardChange),
       ];
     } else {
       this._subscriptions = [
-        Keyboard.addListener('keyboardDidHide', this._onKeyboardChange),
+        Keyboard.addListener('keyboardDidHide', this._onKeyboardHide),
         Keyboard.addListener('keyboardDidShow', this._onKeyboardChange),
       ];
     }
@@ -218,6 +231,11 @@ export class KeyboardCompatibleView extends React.Component<
   }
 
   componentDidMount() {
+    if (!Keyboard.isVisible()) {
+      this._keyboardEvent = null;
+      this._setBottom(0);
+    }
+
     this._appStateSubscription = AppState.addEventListener('change', this._handleAppStateChange);
     this.setKeyboardListeners();
   }

--- a/package/src/components/KeyboardCompatibleView/KeyboardControllerAvoidingView.tsx
+++ b/package/src/components/KeyboardCompatibleView/KeyboardControllerAvoidingView.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 
 import {
   Keyboard,
-  Platform,
   KeyboardAvoidingViewProps as ReactNativeKeyboardAvoidingViewProps,
 } from 'react-native';
 
@@ -51,12 +50,7 @@ export const KeyboardCompatibleView = (props: KeyboardCompatibleViewProps) => {
       </KeyboardProvider>
     );
   }
-  const compatibleBehavior =
-    behavior === 'translate-with-padding'
-      ? Platform.OS === 'ios'
-        ? 'padding'
-        : 'position'
-      : behavior;
+  const compatibleBehavior = behavior === 'translate-with-padding' ? 'padding' : behavior;
 
   return (
     <KeyboardCompatibleViewDefault behavior={compatibleBehavior} {...rest}>

--- a/package/src/components/Message/utils/messageActions.ts
+++ b/package/src/components/Message/utils/messageActions.ts
@@ -90,7 +90,7 @@ export const messageActions = ({
     actions.push(copyMessage);
   }
 
-  if (ownCapabilities.readEvents && !error && !isThreadMessage) {
+  if (ownCapabilities.readEvents && !error && !isThreadMessage && !isMyMessage) {
     actions.push(markUnread);
   }
 

--- a/package/src/components/MessageMenu/MessageUserReactions.tsx
+++ b/package/src/components/MessageMenu/MessageUserReactions.tsx
@@ -125,7 +125,9 @@ export const MessageUserReactions = (props: MessageUserReactionsProps) => {
   const MessageUserReactionsItem = propMessageUserReactionsItem ?? contextMessageUserReactionsItem;
 
   const onSelectReaction = useStableCallback((reactionType: string) => {
-    setSelectedReaction(reactionType);
+    setSelectedReaction((currentReaction) =>
+      currentReaction === reactionType ? undefined : reactionType,
+    );
   });
 
   useEffect(() => {

--- a/package/src/components/MessageMenu/__tests__/MessageUserReactions.test.tsx
+++ b/package/src/components/MessageMenu/__tests__/MessageUserReactions.test.tsx
@@ -100,14 +100,21 @@ describe('MessageUserReactions when the supportedReactions are defined', () => {
     expect(reactionButtons[1].props.accessibilityLabel).toBe('reaction-button-love-unselected');
   });
 
-  it('changes selected reaction when a reaction button is pressed', () => {
+  it('toggles the selected reaction when a reaction button is pressed twice', () => {
     const { getAllByLabelText } = renderComponent();
-    const reactionButtons = getAllByLabelText(/\breaction-button[^\s]+/);
+    let reactionButtons = getAllByLabelText(/\breaction-button[^\s]+/);
 
     fireEvent.press(reactionButtons[1]);
 
     expect(reactionButtons[0].props.accessibilityLabel).toBe('reaction-button-like-unselected');
     expect(reactionButtons[1].props.accessibilityLabel).toBe('reaction-button-love-selected');
+
+    fireEvent.press(reactionButtons[1]);
+
+    reactionButtons = getAllByLabelText(/\breaction-button[^\s]+/);
+
+    expect(reactionButtons[0].props.accessibilityLabel).toBe('reaction-button-like-unselected');
+    expect(reactionButtons[1].props.accessibilityLabel).toBe('reaction-button-love-unselected');
   });
 
   it('renders reactions list', () => {

--- a/package/src/components/UIComponents/BottomSheetModal.tsx
+++ b/package/src/components/UIComponents/BottomSheetModal.tsx
@@ -242,8 +242,10 @@ export const BottomSheetModal = (props: PropsWithChildren<BottomSheetModalProps>
         KeyboardControllerPackage.KeyboardEvents.addListener('keyboardDidHide', keyboardDidHide),
       );
     } else {
-      listeners.push(Keyboard.addListener('keyboardDidShow', keyboardDidShowRN));
-      listeners.push(Keyboard.addListener('keyboardDidHide', keyboardDidHide));
+      if (Platform.OS === 'ios') {
+        listeners.push(Keyboard.addListener('keyboardWillShow', keyboardDidShowRN));
+        listeners.push(Keyboard.addListener('keyboardWillHide', keyboardDidHide));
+      }
     }
 
     return () => listeners.forEach((l) => l.remove());

--- a/package/src/icons/index.ts
+++ b/package/src/icons/index.ts
@@ -34,6 +34,7 @@ export * from './clock';
 export * from './Unknown';
 export * from './unpin';
 export * from './video-fill';
+export * from './video';
 export * from './user-add';
 export * from './user-remove';
 export * from './filetype-video-xl';


### PR DESCRIPTION
## 🎯 Goal

This PR includes a batch of follow-up fixes on top of the redesign branch, focused on sample app UX regressions, channel list actions, and Android behaviour.

On the platform side, it improves Android behaviour by removing the old IME hack from keyboard avoiding logic and makes our `KeyboardCompatibleView` compatible with ETE on `Android` 🚀 . It also rounds out the redesign polish by making filters toggleable and reflecting the related behaviour in sample app screens.

Included changes

- enable audio recording in threads
- use the correct outlined video icon
- hide read indicators for deleted last messages
- fix back navigation in channel creation screens
- fix Android keyboard avoiding without the IME hack
- remove mark unread for own messages (this was never working well)
- make filters toggleable
- reflect filter behavior in sample app screens
- add muted icon/state to details bottom sheet
- make swipe actions always use mute


## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


