### PR TITLE
fix: unicode replacement string android crash

### DIFF
--- a/package/src/components/Message/MessageItemView/utils/generateMarkdownText.test.ts
+++ b/package/src/components/Message/MessageItemView/utils/generateMarkdownText.test.ts
@@ -4,6 +4,9 @@ describe('generateMarkdownText', () => {
   it.each([
     ['', null],
     ['  test message  ', 'test message'],
+    ['\uFFFC', null],
+    [' \uFFFC ', null],
+    ['hello\uFFFCworld', 'hello world'],
     ['https://www.getstream.io', '[https://www.getstream.io](https://www.getstream.io)'],
     [
       'https://getstream-production.s3-accelerate.amazonaws.com/N336903591601695/33e78ef89e64642862a75c5cca2541eaf6b1c924/trimmedVideos/alert/2_270_881/outputVideo.mp4?AWSAccessKeyId=AKIAVJAW2AD2SQVQCBXV&Expires=1699998768&Signature=zdEMCGzf4Pq++16YkPprvN5NAds=',

--- a/package/src/components/Message/MessageItemView/utils/generateMarkdownText.test.ts
+++ b/package/src/components/Message/MessageItemView/utils/generateMarkdownText.test.ts
@@ -4,8 +4,8 @@ describe('generateMarkdownText', () => {
   it.each([
     ['', null],
     ['  test message  ', 'test message'],
-    ['\uFFFC', null],
-    [' \uFFFC ', null],
+    ['\uFFFC', ''],
+    [' \uFFFC ', ''],
     ['hello\uFFFCworld', 'hello world'],
     ['https://www.getstream.io', '[https://www.getstream.io](https://www.getstream.io)'],
     [

--- a/package/src/components/Message/MessageItemView/utils/generateMarkdownText.ts
+++ b/package/src/components/Message/MessageItemView/utils/generateMarkdownText.ts
@@ -9,8 +9,10 @@ export const generateMarkdownText = (text?: string) => {
     return null;
   }
 
+  const normalizedText = text.replace(/\uFFFC/g, ' ');
+
   // Trim the extra spaces from the text.
-  let resultText = text.trim();
+  let resultText = normalizedText.trim();
 
   // List of all the links present in the text.
   const linkInfos = parseLinksFromText(resultText);
@@ -24,7 +26,7 @@ export const generateMarkdownText = (text?: string) => {
     // Eg: Hi @getstream.io -> Hi @[getstream.io](getstream.io).
     const normalRegEx = new RegExp(escapeRegExp(linkInfo.raw), 'g');
     const markdown = `[${displayLink}](${linkInfo.url})`;
-    resultText = text.replace(normalRegEx, markdown);
+    resultText = normalizedText.replace(normalRegEx, markdown);
 
     // After previous step, in some cases, the mentioned user after `@` might have a link/email so we convert it back to normal raw text.
     // Eg: Hi, @[test.user@gmail.com](mailto:test.user@gmail.com) to @test.user@gmail.com.


### PR DESCRIPTION
## 🎯 Goal

This PR fixes an Android crash in message rendering caused by the Unicode object replacement character (`U+FFFC`) reaching the markdown pipeline.

The fix sanitizes message text before markdown generation by normalizing `U+FFFC` to whitespace and treating fully empty results as empty content. 

Should resolve [this issue](https://getstream.zendesk.com/agent/tickets/79676?brand_id=360003144254).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


