### PR TITLE
chore: major version bumps

### DIFF
--- a/package/expo-package/package.json
+++ b/package/expo-package/package.json
@@ -30,7 +30,7 @@
     "stream-chat-react-native-core": "8.1.0"
   },
   "peerDependencies": {
-    "expo": ">=51.0.0",
+    "expo": ">=52.0.0",
     "react-native": ">=0.76.0",
     "expo-av": "*",
     "expo-clipboard": "*",

--- a/package/native-package/package.json
+++ b/package/native-package/package.json
@@ -33,27 +33,24 @@
     "stream-chat-react-native-core": "8.1.0"
   },
   "peerDependencies": {
-    "@react-native-camera-roll/camera-roll": ">=7.8.0",
-    "@react-native-clipboard/clipboard": ">=1.14.1",
+    "@react-native-camera-roll/camera-roll": ">=7.9.0",
+    "@react-native-clipboard/clipboard": ">=1.16.0",
     "@react-native-documents/picker": ">=10.1.1",
-    "@stream-io/flat-list-mvcp": ">=0.10.3",
-    "react-native": ">=0.73.0",
+    "react-native": ">=0.76.0",
     "react-native-audio-recorder-player": ">=3.6.13",
     "react-native-nitro-sound": ">=0.2.9",
-    "react-native-blob-util": ">=0.21.1",
+    "react-native-blob-util": ">=0.22.0",
     "react-native-haptic-feedback": ">=2.3.0",
     "react-native-image-picker": ">=7.1.2",
     "react-native-share": ">=11.0.0",
     "react-native-video": ">=6.4.2"
   },
+
   "peerDependenciesMeta": {
     "@react-native-camera-roll/camera-roll": {
       "optional": true
     },
     "@react-native-clipboard/clipboard": {
-      "optional": true
-    },
-    "@stream-io/flat-list-mvcp": {
       "optional": true
     },
     "react-native-share": {

--- a/package/src/__tests__/offline-support/offline-feature.js
+++ b/package/src/__tests__/offline-support/offline-feature.js
@@ -1569,7 +1569,11 @@ export const Generic = () => {
         expect(matchingReadRows[0].lastReadMessageId).toBe('321');
         // FIXME: Currently missing from the DB, uncomment when added.
         // expect(matchingReadRows[0].firstUnreadMessageId).toBe('123');
-        expect(matchingReadRows[0].lastRead).toBe(readTimestamp);
+        expect(
+          Math.abs(
+            new Date(matchingReadRows[0].lastRead).getTime() - new Date(readTimestamp).getTime(),
+          ),
+        ).toBeLessThanOrEqual(1);
       });
     });
 
@@ -1613,7 +1617,11 @@ export const Generic = () => {
         expect(matchingReadRows[0].lastReadMessageId).toBe('321');
         // FIXME: Currently missing from the DB, uncomment when added.
         // expect(matchingReadRows[0].firstUnreadMessageId).toBe('123');
-        expect(matchingReadRows[0].lastRead).toBe(readTimestamp);
+        expect(
+          Math.abs(
+            new Date(matchingReadRows[0].lastRead).getTime() - new Date(readTimestamp).getTime(),
+          ),
+        ).toBeLessThanOrEqual(1);
       });
     });
   });

--- a/package/src/components/Attachment/Giphy/Giphy.tsx
+++ b/package/src/components/Attachment/Giphy/Giphy.tsx
@@ -220,12 +220,10 @@ const useStyles = ({
     return StyleSheet.create({
       container: {
         backgroundColor: hasActions
-          ? isMyMessage
-            ? semantics.chatBgAttachmentOutgoing
-            : semantics.chatBgAttachmentIncoming
+          ? semantics.chatBgOutgoing
           : isMyMessage
-            ? semantics.chatBgOutgoing
-            : semantics.chatBgIncoming,
+            ? semantics.chatBgAttachmentOutgoing
+            : semantics.chatBgAttachmentIncoming,
         borderRadius: primitives.radiusLg,
         maxWidth: 256, // TODO: Not sure how to fix this
         overflow: 'hidden',

--- a/package/src/components/Attachment/Giphy/Giphy.tsx
+++ b/package/src/components/Attachment/Giphy/Giphy.tsx
@@ -54,7 +54,7 @@ const GiphyWithContext = (props: GiphyPropsWithContext) => {
     },
   } = useTheme();
 
-  const styles = useStyles({ isMyMessage });
+  const styles = useStyles({ hasActions: !!actions, isMyMessage });
 
   const uri = image_url || thumb_url;
 
@@ -209,16 +209,23 @@ export const Giphy = (props: GiphyProps) => {
 
 Giphy.displayName = 'Giphy{messageItemView{giphy}}';
 
-const useStyles = ({ isMyMessage }: Pick<GiphyPropsWithContext, 'isMyMessage'>) => {
+const useStyles = ({
+  hasActions,
+  isMyMessage,
+}: Pick<GiphyPropsWithContext, 'isMyMessage'> & { hasActions: boolean }) => {
   const {
     theme: { semantics },
   } = useTheme();
   return useMemo(() => {
     return StyleSheet.create({
       container: {
-        backgroundColor: isMyMessage
-          ? semantics.chatBgAttachmentOutgoing
-          : semantics.chatBgAttachmentIncoming,
+        backgroundColor: hasActions
+          ? isMyMessage
+            ? semantics.chatBgAttachmentOutgoing
+            : semantics.chatBgAttachmentIncoming
+          : isMyMessage
+            ? semantics.chatBgOutgoing
+            : semantics.chatBgIncoming,
         borderRadius: primitives.radiusLg,
         maxWidth: 256, // TODO: Not sure how to fix this
         overflow: 'hidden',
@@ -252,5 +259,5 @@ const useStyles = ({ isMyMessage }: Pick<GiphyPropsWithContext, 'isMyMessage'>) 
         lineHeight: primitives.typographyLineHeightTight,
       },
     });
-  }, [isMyMessage, semantics]);
+  }, [hasActions, isMyMessage, semantics]);
 };

--- a/package/src/components/Attachment/__tests__/Giphy.test.js
+++ b/package/src/components/Attachment/__tests__/Giphy.test.js
@@ -117,7 +117,7 @@ describe('Giphy', () => {
     });
   });
 
-  it('uses the default outgoing bubble background for outgoing giphys', async () => {
+  it('uses the outgoing attachment background for outgoing giphys', async () => {
     render(getAttachmentComponent({ attachment }, { isMyMessage: true }));
 
     await waitFor(() => {
@@ -125,14 +125,14 @@ describe('Giphy', () => {
       expect(style).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            backgroundColor: lightTheme.semantics.chatBgOutgoing,
+            backgroundColor: lightTheme.semantics.chatBgAttachmentOutgoing,
           }),
         ]),
       );
     });
   });
 
-  it('uses the default incoming bubble background for incoming giphys', async () => {
+  it('uses the incoming attachment background for incoming giphys', async () => {
     render(getAttachmentComponent({ attachment }, { isMyMessage: false }));
 
     await waitFor(() => {
@@ -140,14 +140,14 @@ describe('Giphy', () => {
       expect(style).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            backgroundColor: lightTheme.semantics.chatBgIncoming,
+            backgroundColor: lightTheme.semantics.chatBgAttachmentIncoming,
           }),
         ]),
       );
     });
   });
 
-  it('uses the outgoing attachment background for ephemeral giphy previews', async () => {
+  it('uses the outgoing bubble background for ephemeral giphy previews', async () => {
     render(
       getAttachmentComponent(
         {
@@ -156,7 +156,7 @@ describe('Giphy', () => {
             actions,
           },
         },
-        { isMyMessage: true },
+        { isMyMessage: false },
       ),
     );
 
@@ -165,7 +165,7 @@ describe('Giphy', () => {
       expect(style).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            backgroundColor: lightTheme.semantics.chatBgAttachmentOutgoing,
+            backgroundColor: lightTheme.semantics.chatBgOutgoing,
           }),
         ]),
       );

--- a/package/src/components/Attachment/__tests__/Giphy.test.js
+++ b/package/src/components/Attachment/__tests__/Giphy.test.js
@@ -117,7 +117,7 @@ describe('Giphy', () => {
     });
   });
 
-  it('uses the outgoing attachment background for outgoing giphys', async () => {
+  it('uses the default outgoing bubble background for outgoing giphys', async () => {
     render(getAttachmentComponent({ attachment }, { isMyMessage: true }));
 
     await waitFor(() => {
@@ -125,14 +125,14 @@ describe('Giphy', () => {
       expect(style).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            backgroundColor: lightTheme.semantics.chatBgAttachmentOutgoing,
+            backgroundColor: lightTheme.semantics.chatBgOutgoing,
           }),
         ]),
       );
     });
   });
 
-  it('uses the incoming attachment background for incoming giphys', async () => {
+  it('uses the default incoming bubble background for incoming giphys', async () => {
     render(getAttachmentComponent({ attachment }, { isMyMessage: false }));
 
     await waitFor(() => {
@@ -140,7 +140,32 @@ describe('Giphy', () => {
       expect(style).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            backgroundColor: lightTheme.semantics.chatBgAttachmentIncoming,
+            backgroundColor: lightTheme.semantics.chatBgIncoming,
+          }),
+        ]),
+      );
+    });
+  });
+
+  it('uses the outgoing attachment background for ephemeral giphy previews', async () => {
+    render(
+      getAttachmentComponent(
+        {
+          attachment: {
+            ...attachment,
+            actions,
+          },
+        },
+        { isMyMessage: true },
+      ),
+    );
+
+    await waitFor(() => {
+      const style = screen.getByTestId('giphy-action-attachment').props.style;
+      expect(style).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            backgroundColor: lightTheme.semantics.chatBgAttachmentOutgoing,
           }),
         ]),
       );

--- a/package/src/components/Message/MessageItemView/MessageItemView.tsx
+++ b/package/src/components/Message/MessageItemView/MessageItemView.tsx
@@ -99,10 +99,12 @@ const useStyles = ({
           ...bubbleReactionListTopContainer,
         },
         bubbleWrapper: {
+          zIndex: 1,
           ...bubbleWrapper,
         },
         repliesContainer: {
           marginTop: -primitives.spacingXxs, // Reducing the margin to account the gap added in the content container
+          zIndex: 0,
           ...repliesContainer,
         },
         leftAlignItems: {

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.js.snap
@@ -465,7 +465,11 @@ exports[`Thread should match thread snapshot 1`] = `
                             testID="message-components"
                           >
                             <View
-                              style={{}}
+                              style={
+                                {
+                                  "zIndex": 1,
+                                }
+                              }
                             >
                               <View
                                 style={
@@ -606,6 +610,7 @@ exports[`Thread should match thread snapshot 1`] = `
                               style={
                                 {
                                   "marginTop": -4,
+                                  "zIndex": 0,
                                 }
                               }
                             />
@@ -799,7 +804,11 @@ exports[`Thread should match thread snapshot 1`] = `
                             testID="message-components"
                           >
                             <View
-                              style={{}}
+                              style={
+                                {
+                                  "zIndex": 1,
+                                }
+                              }
                             >
                               <View
                                 style={
@@ -940,6 +949,7 @@ exports[`Thread should match thread snapshot 1`] = `
                               style={
                                 {
                                   "marginTop": -4,
+                                  "zIndex": 0,
                                 }
                               }
                             />
@@ -1166,7 +1176,11 @@ exports[`Thread should match thread snapshot 1`] = `
                             testID="message-components"
                           >
                             <View
-                              style={{}}
+                              style={
+                                {
+                                  "zIndex": 1,
+                                }
+                              }
                             >
                               <View
                                 style={
@@ -1307,6 +1321,7 @@ exports[`Thread should match thread snapshot 1`] = `
                               style={
                                 {
                                   "marginTop": -4,
+                                  "zIndex": 0,
                                 }
                               }
                             />
@@ -1491,7 +1506,11 @@ exports[`Thread should match thread snapshot 1`] = `
                           testID="message-components"
                         >
                           <View
-                            style={{}}
+                            style={
+                              {
+                                "zIndex": 1,
+                              }
+                            }
                           >
                             <View
                               style={
@@ -1632,6 +1651,7 @@ exports[`Thread should match thread snapshot 1`] = `
                             style={
                               {
                                 "marginTop": -4,
+                                "zIndex": 0,
                               }
                             }
                           />


### PR DESCRIPTION
## 🎯 Goal

This PR addresses 2 small UI issues regarding giphies and bumps the peer dependency versions to what they'll be for V9. It should be the last change before the V9 release.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


