### PR TITLE
fix: message reply border in RTL mode

### DIFF
--- a/package/src/components/Reply/Reply.tsx
+++ b/package/src/components/Reply/Reply.tsx
@@ -3,6 +3,7 @@ import {
   I18nManager,
   Image,
   ImageProps,
+  Platform,
   StyleSheet,
   Text,
   TextStyle,
@@ -303,19 +304,26 @@ const useStyles = () => {
           paddingHorizontal: primitives.spacingXs,
           gap: primitives.spacingXxxs,
           alignItems: 'flex-start',
-          ...(isRTL
+          ...(Platform.OS === 'android'
             ? {
-                borderRightColor: isMyMessage
-                  ? semantics.chatReplyIndicatorOutgoing
-                  : semantics.chatReplyIndicatorIncoming,
-                borderRightWidth: 2,
-              }
-            : {
                 borderLeftColor: isMyMessage
                   ? semantics.chatReplyIndicatorOutgoing
                   : semantics.chatReplyIndicatorIncoming,
                 borderLeftWidth: 2,
-              }),
+              }
+            : isRTL
+              ? {
+                  borderRightColor: isMyMessage
+                    ? semantics.chatReplyIndicatorOutgoing
+                    : semantics.chatReplyIndicatorIncoming,
+                  borderRightWidth: 2,
+                }
+              : {
+                  borderLeftColor: isMyMessage
+                    ? semantics.chatReplyIndicatorOutgoing
+                    : semantics.chatReplyIndicatorIncoming,
+                  borderLeftWidth: 2,
+                }),
         },
         rightContainer: {},
         title: {


### PR DESCRIPTION
## 🎯 Goal

I missed that iOS and Android have a difference in border mirroring in RTL mode, and only fixed the message reply border for iOS, and not for Android.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

Before - border is positioned incorrectly on Android:
<img width="720" height="1600" alt="Screenshot_20260415_101603_Chat Sample React Native (1)" src="https://github.com/user-attachments/assets/7800c4ea-36b6-4f54-b721-5db1c8447a2a" />

After - Android:
<img width="720" height="1600" alt="Screenshot_20260416_172414_Chat Sample React Native" src="https://github.com/user-attachments/assets/8aee0697-728b-43ca-87df-cf9abc3d4555" />

<img width="720" height="1600" alt="Screenshot_20260416_172517_Chat Sample React Native" src="https://github.com/user-attachments/assets/42e39dd2-cf7f-4002-a220-4b0db3288f6e" />

iOS - unchanged:
<img width="399" height="801" alt="Screenshot 2026-04-16 at 17 26 36" src="https://github.com/user-attachments/assets/787c665d-5e74-4b09-ab37-5be8f739440e" />
<img width="392" height="794" alt="Screenshot 2026-04-16 at 17 27 02" src="https://github.com/user-attachments/assets/99e50da0-53c3-41e3-b718-951c204a4097" />


<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


