### PR TITLE
fix: commands flow when interacting with other composer elements

### DIFF
--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -8291,10 +8291,10 @@ stream-chat-react-native-core@8.1.0:
   version "0.0.0"
   uid ""
 
-stream-chat@^9.42.1:
-  version "9.42.1"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.42.1.tgz#8b6aa4e3e73a39ed07bb2a4f2a6829ba9354567a"
-  integrity sha512-o+9wQO4Ruu1A48T0IrX9ZH8+9F5xPgGLPvflaswaPeLyIZXcy8bsQdcT/HSrPmT7gs0WGD3qcbXaAJU5lMQezQ==
+stream-chat@^9.43.0:
+  version "9.43.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.43.0.tgz#216a80abadea83dcee6fb339b76035b26af2beb5"
+  integrity sha512-gc12LZTmRWvSi6EjnMK7Y+D8xOQIouVUO2flUShazG/NqVccJhXYphQ96PzK7Wym+5wwwitTaJqq0m/1VUPBCA==
   dependencies:
     "@types/jsonwebtoken" "^9.0.8"
     "@types/ws" "^8.5.14"

--- a/package/package.json
+++ b/package/package.json
@@ -83,7 +83,7 @@
     "path": "0.12.7",
     "react-native-markdown-package": "1.8.2",
     "react-native-url-polyfill": "^2.0.0",
-    "stream-chat": "^9.42.1",
+    "stream-chat": "^9.43.0",
     "use-sync-external-store": "^1.5.0"
   },
   "peerDependencies": {

--- a/package/src/components/AttachmentPicker/components/AttachmentPickerContent.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentPickerContent.tsx
@@ -58,9 +58,13 @@ export const AttachmentCommandNativePickerItem = ({ item }: { item: CommandSugge
   const { close } = useBottomSheetContext();
 
   const handlePress = useCallback(() => {
+    if (messageComposer.isCommandDisabled(item)) {
+      return;
+    }
+
     textComposer.setCommand(item);
     close(() => inputBoxRef.current?.focus());
-  }, [textComposer, item, close, inputBoxRef]);
+  }, [messageComposer, item, textComposer, close, inputBoxRef]);
 
   return <AttachmentCommandPickerItemUI item={item} onPress={handlePress} />;
 };
@@ -73,9 +77,13 @@ export const AttachmentCommandPickerItem = ({ item }: { item: CommandSuggestion 
   const { inputBoxRef } = useMessageInputContext();
 
   const handlePress = useCallback(() => {
+    if (messageComposer.isCommandDisabled(item)) {
+      return;
+    }
+
     textComposer.setCommand(item);
     inputBoxRef.current?.focus();
-  }, [textComposer, item, inputBoxRef]);
+  }, [messageComposer, item, textComposer, inputBoxRef]);
 
   if (disableAttachmentPicker) {
     return <AttachmentCommandNativePickerItem item={item} />;

--- a/package/src/components/AttachmentPicker/components/AttachmentTypePickerButton.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentTypePickerButton.tsx
@@ -9,7 +9,6 @@ import { AttachmentCommandPicker } from './AttachmentPickerContent';
 import {
   useAttachmentPickerContext,
   useChannelContext,
-  useMessageComposer,
   useMessageInputContext,
   useMessagesContext,
   useOwnCapabilitiesContext,
@@ -182,7 +181,6 @@ export const PollPickerButton = () => {
 
 export const CommandsPickerButton = () => {
   const [showCommandsSheet, setShowCommandsSheet] = useState(false);
-  const messageComposer = useMessageComposer();
   const { hasCommands } = useMessageInputContext();
   const { attachmentPickerStore, disableAttachmentPicker } = useAttachmentPickerContext();
   const { selectedPicker } = useAttachmentPickerState();
@@ -197,7 +195,7 @@ export const CommandsPickerButton = () => {
 
   const onClose = useStableCallback(() => setShowCommandsSheet(false));
 
-  return hasCommands && !messageComposer.editedMessage ? (
+  return hasCommands ? (
     <>
       <AttachmentTypePickerButton
         testID='commands-touchable'

--- a/package/src/components/AttachmentPicker/components/__tests__/AttachmentPickerContent.test.tsx
+++ b/package/src/components/AttachmentPicker/components/__tests__/AttachmentPickerContent.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import type { CommandSuggestion } from 'stream-chat';
+
+import {
+  AttachmentCommandNativePickerItem,
+  AttachmentCommandPickerItem,
+} from '../AttachmentPickerContent';
+
+jest.mock('stream-chat', () => ({
+  CommandSearchSource: jest.fn(() => ({
+    query: jest.fn(() => ({ items: [] })),
+  })),
+}));
+
+jest.mock('../AttachmentMediaPicker/AttachmentMediaPicker', () => ({
+  AttachmentMediaPicker: () => null,
+}));
+
+const mockClose = jest.fn((callback?: () => void) => callback?.());
+const mockFocus = jest.fn();
+const mockIsCommandDisabled = jest.fn();
+const mockSetCommand = jest.fn();
+
+jest.mock('../../../../contexts', () => ({
+  useAttachmentPickerContext: jest.fn(() => ({
+    disableAttachmentPicker: false,
+  })),
+  useBottomSheetContext: jest.fn(() => ({
+    close: mockClose,
+  })),
+  useMessageComposer: jest.fn(() => ({
+    isCommandDisabled: mockIsCommandDisabled,
+    textComposer: { setCommand: mockSetCommand },
+  })),
+  useMessageInputContext: jest.fn(() => ({
+    inputBoxRef: { current: { focus: mockFocus } },
+  })),
+}));
+
+jest.mock('../../../../contexts/themeContext/ThemeContext', () => ({
+  useTheme: jest.fn(() => ({
+    theme: {
+      semantics: {
+        backgroundUtilityPressed: '#f5f5f5',
+      },
+    },
+  })),
+}));
+
+jest.mock('../../../../hooks', () => ({
+  useAttachmentPickerState: jest.fn(() => ({ selectedPicker: 'images' })),
+  useStableCallback: (callback: unknown) => callback,
+}));
+
+jest.mock('../../../AutoCompleteInput/AutoCompleteSuggestionItem', () => {
+  const { Text } = require('react-native');
+
+  return {
+    CommandSuggestionItem: ({ name }: CommandSuggestion) => <Text>{name}</Text>,
+  };
+});
+
+const command = {
+  args: '',
+  id: 'ban',
+  name: 'ban',
+  set: 'moderation_set',
+} as CommandSuggestion;
+
+describe('AttachmentPickerContent commands', () => {
+  beforeEach(() => {
+    mockClose.mockClear();
+    mockFocus.mockClear();
+    mockIsCommandDisabled.mockReset();
+    mockSetCommand.mockClear();
+  });
+
+  it('does not focus the input when a disabled command is pressed', () => {
+    mockIsCommandDisabled.mockReturnValue(true);
+
+    render(<AttachmentCommandPickerItem item={command} />);
+
+    fireEvent.press(screen.getByText('ban'));
+
+    expect(mockIsCommandDisabled).toHaveBeenCalledWith(command);
+    expect(mockSetCommand).not.toHaveBeenCalled();
+    expect(mockFocus).not.toHaveBeenCalled();
+  });
+
+  it('does not close the picker or focus the input when a disabled command is pressed in native picker mode', () => {
+    mockIsCommandDisabled.mockReturnValue(true);
+
+    render(<AttachmentCommandNativePickerItem item={command} />);
+
+    fireEvent.press(screen.getByText('ban'));
+
+    expect(mockIsCommandDisabled).toHaveBeenCalledWith(command);
+    expect(mockSetCommand).not.toHaveBeenCalled();
+    expect(mockClose).not.toHaveBeenCalled();
+    expect(mockFocus).not.toHaveBeenCalled();
+  });
+});

--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -17,16 +17,15 @@ import {
   useChannelContext,
 } from '../../contexts/channelContext/ChannelContext';
 import { useMessageComposer } from '../../contexts/messageInputContext/hooks/useMessageComposer';
-import {
-  MessageInputContextValue,
-  useMessageInputContext,
-} from '../../contexts/messageInputContext/MessageInputContext';
+import type { MessageInputContextValue } from '../../contexts/messageInputContext/MessageInputContext';
+import { useMessageInputContext } from '../../contexts/messageInputContext/MessageInputContext';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import {
   TranslationContextValue,
   useTranslationContext,
 } from '../../contexts/translationContext/TranslationContext';
 
+import { useStableCallback } from '../../hooks';
 import { useStateStore } from '../../hooks/useStateStore';
 import { useCooldownRemaining } from '../MessageInput/hooks/useCooldownRemaining';
 
@@ -44,6 +43,19 @@ const TextInputRenderer = React.forwardRef<RNTextInput, AnimatedTextInputRendere
 );
 
 const AnimatedTextInputRenderer = Animated.createAnimatedComponent(TextInputRenderer);
+
+const setRef = <T,>(ref: React.Ref<T> | undefined, value: T | null) => {
+  if (!ref) {
+    return;
+  }
+
+  if (typeof ref === 'function') {
+    ref(value);
+    return;
+  }
+
+  (ref as React.RefObject<T | null>).current = value;
+};
 
 type AutoCompleteInputPropsWithContext = TextInputProps &
   Pick<ChannelContextValue, 'channel'> &
@@ -109,6 +121,30 @@ const AutoCompleteInputWithContext = (props: AutoCompleteInputPropsWithContext) 
     setLocalText(text);
   }, [text]);
 
+  const clearState = useCallback(() => {
+    setLocalText('');
+  }, []);
+
+  const restoreState = useStableCallback((restoredText: string) => {
+    setLocalText(restoredText);
+  });
+
+  const setExtendedInputRef = useCallback(
+    (ref: RNTextInput | null) => {
+      if (!ref) {
+        setRef(setInputBoxRef, null);
+        return;
+      }
+
+      const inputBoxRef = Object.assign(ref, {
+        clearState,
+        restoreState,
+      });
+      setRef(setInputBoxRef, inputBoxRef);
+    },
+    [clearState, restoreState, setInputBoxRef],
+  );
+
   const handleSelectionChange = useCallback(
     (e: TextInputSelectionChangeEvent) => {
       const { selection } = e.nativeEvent;
@@ -161,7 +197,7 @@ const AutoCompleteInputWithContext = (props: AutoCompleteInputPropsWithContext) 
       onSelectionChange={handleSelectionChange}
       placeholder={placeholderText}
       placeholderTextColor={semantics.inputTextPlaceholder}
-      ref={setInputBoxRef}
+      ref={setExtendedInputRef}
       style={[
         styles.inputBox,
         {

--- a/package/src/components/AutoCompleteInput/AutoCompleteSuggestionItem.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteSuggestionItem.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useMemo } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
-import { CommandSuggestion, TextComposerSuggestion, UserSuggestion } from 'stream-chat';
+import type { CommandSuggestion, TextComposerSuggestion, UserSuggestion } from 'stream-chat';
 
 import { AutoCompleteSuggestionCommandIcon } from './AutoCompleteSuggestionCommandIcon';
 
+import { useIsCommandDisabled } from '../../contexts/messageInputContext/hooks/useIsCommandDisabled';
 import { useMessageComposer } from '../../contexts/messageInputContext/hooks/useMessageComposer';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { primitives } from '../../theme';
@@ -81,11 +82,17 @@ export const CommandSuggestionItem = (item: CommandSuggestion) => {
   } = useTheme();
   const styles = useStyles();
 
+  const isDisabled = useIsCommandDisabled(item);
+
   return (
     <View style={[styles.commandContainer, commandContainer]}>
       {name ? <AutoCompleteSuggestionCommandIcon name={name} /> : null}
       <Text
-        style={[styles.title, { color: semantics.textPrimary }, title]}
+        style={[
+          styles.title,
+          { color: isDisabled ? semantics.textTertiary : semantics.textPrimary },
+          title,
+        ]}
         testID='commands-item-title'
       >
         {(name || '').replace(/^\w/, (char) => char.toUpperCase())}

--- a/package/src/components/AutoCompleteInput/__tests__/AutoCompleteInput.test.tsx
+++ b/package/src/components/AutoCompleteInput/__tests__/AutoCompleteInput.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 
+import type { TextInput } from 'react-native';
+
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import type { Channel as ChannelType, StreamChat } from 'stream-chat';
 
 import { OverlayProvider } from '../../../contexts';
+import type { InputBoxRef } from '../../../contexts/messageInputContext/MessageInputContext';
 import { initiateClientWithChannels } from '../../../mock-builders/api/initiateClientWithChannels';
 import type { ChannelProps } from '../../Channel/Channel';
 import { Channel } from '../../Channel/Channel';
@@ -120,6 +123,50 @@ describe('AutoCompleteInput', () => {
         text: 'hello',
       });
       expect(input.props.value).toBe('hello');
+    });
+  });
+
+  it('should expose imperative state handlers on the input ref', async () => {
+    let inputRef: InputBoxRef | null = null;
+    const text = 'hello';
+    const channelProps = {
+      channel,
+      setInputRef: (ref: TextInput | null) => {
+        inputRef = ref as InputBoxRef | null;
+      },
+    };
+    const props = {};
+
+    renderComponent({ channelProps, client, props });
+
+    await waitFor(() => {
+      expect(inputRef?.clearState).toBeTruthy();
+      expect(inputRef?.restoreState).toBeTruthy();
+    });
+
+    act(() => {
+      fireEvent.changeText(screen.getByTestId('auto-complete-text-input'), text);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auto-complete-text-input').props.value).toBe(text);
+    });
+
+    act(() => {
+      inputRef?.clearState();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auto-complete-text-input').props.value).toBe('');
+      expect(channel.messageComposer.textComposer.text).toBe(text);
+    });
+
+    act(() => {
+      inputRef?.restoreState(text);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auto-complete-text-input').props.value).toBe(text);
     });
   });
 

--- a/package/src/components/ui/GiphyChip.tsx
+++ b/package/src/components/ui/GiphyChip.tsx
@@ -27,7 +27,7 @@ export const GiphyChip = () => {
 
   const onPressHandler = () => {
     textComposer.clearCommand();
-    messageComposer?.restore();
+    // messageComposer?.restore();
   };
 
   return (

--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -51,7 +51,7 @@ import { isTestEnvironment } from '../utils/isTestEnvironment';
 
 export type LocalMessageInputContext = {
   closeAttachmentPicker: () => void;
-  inputBoxRef: React.RefObject<TextInput | null>;
+  inputBoxRef: React.RefObject<InputBoxRef | null>;
   openAttachmentPicker: () => void;
   /**
    * Function for picking a photo from native image picker and uploading it.
@@ -62,7 +62,7 @@ export type LocalMessageInputContext = {
   /**
    * Ref callback to set reference on input box
    */
-  setInputBoxRef: Ref<TextInput> | undefined;
+  setInputBoxRef: Ref<InputBoxRef> | undefined;
   /**
    * Function for taking a photo and uploading it
    */
@@ -75,6 +75,11 @@ export type LocalMessageInputContext = {
   deleteVoiceRecording: () => Promise<void>;
   uploadVoiceRecording: (sendOnComplete: boolean) => Promise<void>;
   stopVoiceRecording: () => Promise<void>;
+};
+
+export type InputBoxRef = TextInput & {
+  clearState: () => void;
+  restoreState: (text: string) => void;
 };
 
 export type InputMessageInputContextValue = {
@@ -215,7 +220,7 @@ export const MessageInputProvider = ({
   const { clearEditingState } = useMessageComposerAPIContext();
   const { thread } = useThreadContext();
   const { t } = useTranslationContext();
-  const inputBoxRef = useRef<TextInput | null>(null);
+  const inputBoxRef = useRef<InputBoxRef | null>(null);
 
   const [showPollCreationDialog, setShowPollCreationDialog] = useState(false);
 
@@ -368,14 +373,18 @@ export const MessageInputProvider = ({
   }, [closePicker, attachmentPickerStore]);
 
   const sendMessage = useStableCallback(async () => {
-    if (inputBoxRef.current) {
-      inputBoxRef.current.clear();
-    }
+    const textToRestore = messageComposer.textComposer.text;
+    let compositionAccepted = false;
+
+    inputBoxRef.current?.clearState();
 
     try {
       const composition = await messageComposer.compose();
 
-      if (!composition || !composition.message) return;
+      if (!composition || !composition.message) {
+        inputBoxRef.current?.restoreState(textToRestore);
+        return;
+      }
 
       const { localMessage, message, sendOptions } = composition;
       const linkInfos = parseLinksFromText(localMessage.text);
@@ -386,8 +395,11 @@ export const MessageInputProvider = ({
           t('Sending links is not allowed in this conversation'),
         );
 
+        inputBoxRef.current?.restoreState(textToRestore);
         return;
       }
+
+      compositionAccepted = true;
 
       // MODERATION: This is for the case where the message is of type 'error' and if you try to edit it, it will throw an error.
       if (editedMessage && editedMessage.type !== 'error') {
@@ -425,11 +437,14 @@ export const MessageInputProvider = ({
         }
       }
     } catch (error) {
+      if (!compositionAccepted) {
+        inputBoxRef.current?.restoreState(textToRestore);
+      }
       console.error('Error while sending message:', error);
     }
   });
 
-  const setInputBoxRef = useStableCallback((ref: TextInput | null) => {
+  const setInputBoxRef = useStableCallback((ref: InputBoxRef | null) => {
     inputBoxRef.current = ref;
     if (value.setInputRef) {
       value.setInputRef(ref);

--- a/package/src/contexts/messageInputContext/__tests__/sendMessage.test.tsx
+++ b/package/src/contexts/messageInputContext/__tests__/sendMessage.test.tsx
@@ -22,6 +22,7 @@ import {
   MessageInputProvider,
   useMessageInputContext,
 } from '../MessageInputContext';
+import type { InputBoxRef } from '../MessageInputContext';
 
 const Wrapper = ({
   messageComposerContextValue,
@@ -96,6 +97,53 @@ describe("MessageInputContext's sendMessage", () => {
       expect(sendMessageMock).not.toHaveBeenCalled();
       expect(consoleErrorMock).toHaveBeenCalled();
     });
+  });
+
+  it('should restore input state if composition is discarded', async () => {
+    const sendMessageMock = jest.fn();
+    const clearState = jest.fn();
+    const restoreState = jest.fn();
+    const initialProps = {
+      sendMessage: sendMessageMock,
+    };
+
+    const { result } = renderHook(() => useMessageInputContext(), {
+      initialProps,
+      wrapper: (props) => (
+        <Wrapper
+          client={chatClient}
+          messageComposerContextValue={{ channel }}
+          props={{ ...props, ...initialProps }}
+        />
+      ),
+    });
+
+    const text = 'Hello there';
+    const inputRef = {
+      clearState,
+      restoreState,
+    } as unknown as InputBoxRef;
+    (result.current.setInputBoxRef as (ref: InputBoxRef | null) => void)(inputRef);
+
+    await act(async () => {
+      await channel.messageComposer.textComposer.handleChange({
+        selection: {
+          end: text.length,
+          start: text.length,
+        },
+        text,
+      });
+    });
+
+    jest.spyOn(channel.messageComposer, 'compose').mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.sendMessage();
+    });
+
+    expect(clearState).toHaveBeenCalledTimes(1);
+    expect(restoreState).toHaveBeenCalledWith(text);
+    expect(sendMessageMock).not.toHaveBeenCalled();
   });
 
   it('should get into the catch block if the sendMessage throws an error', async () => {

--- a/package/src/contexts/messageInputContext/__tests__/useIsCommandDisabled.test.tsx
+++ b/package/src/contexts/messageInputContext/__tests__/useIsCommandDisabled.test.tsx
@@ -1,0 +1,110 @@
+import { act, cleanup, renderHook } from '@testing-library/react-native';
+import type { CommandSuggestion, MessageComposerState } from 'stream-chat';
+
+import { generateMessage } from '../../../mock-builders/generator/message';
+import { useIsCommandDisabled } from '../hooks/useIsCommandDisabled';
+import { useMessageComposer } from '../hooks/useMessageComposer';
+
+jest.mock('../hooks/useMessageComposer', () => ({
+  useMessageComposer: jest.fn(),
+}));
+
+type TestMessageComposerStateStore = {
+  getLatestValue: () => MessageComposerState;
+  partialNext: (nextValue: Partial<MessageComposerState>) => void;
+  subscribeWithSelector: (
+    selector: (state: MessageComposerState) => Record<string, unknown>,
+    onStoreChange: () => void,
+  ) => () => void;
+};
+
+const createMessageComposerState = (): TestMessageComposerStateStore => {
+  let value: MessageComposerState = {
+    draftId: null,
+    editedMessage: null,
+    id: 'composer-id',
+    pollId: null,
+    quotedMessage: null,
+    showReplyInChannel: false,
+  };
+  const subscribers = new Set<() => void>();
+
+  return {
+    getLatestValue: () => value,
+    partialNext: (nextValue) => {
+      value = { ...value, ...nextValue };
+      subscribers.forEach((subscriber) => subscriber());
+    },
+    subscribeWithSelector: (_selector, onStoreChange) => {
+      subscribers.add(onStoreChange);
+      return () => {
+        subscribers.delete(onStoreChange);
+      };
+    },
+  };
+};
+
+const command = {
+  id: 'ban',
+  name: 'ban',
+  set: 'moderation_set',
+} as CommandSuggestion;
+
+describe('useIsCommandDisabled', () => {
+  const mockUseMessageComposer = useMessageComposer as jest.MockedFunction<
+    typeof useMessageComposer
+  >;
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    cleanup();
+  });
+
+  it('recalculates when quoted message existence changes', () => {
+    const state = createMessageComposerState();
+    const messageComposer = {
+      isCommandDisabled: jest.fn(() => !!state.getLatestValue().quotedMessage),
+      state,
+    } as unknown as ReturnType<typeof useMessageComposer>;
+
+    mockUseMessageComposer.mockReturnValue(messageComposer);
+
+    const { result } = renderHook(() => useIsCommandDisabled(command));
+
+    expect(result.current).toBe(false);
+    expect(messageComposer.isCommandDisabled).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      state.partialNext({ quotedMessage: generateMessage({ id: 'quoted-message' }) });
+    });
+
+    expect(result.current).toBe(true);
+    expect(messageComposer.isCommandDisabled).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not recalculate when quoted message changes but existence does not', () => {
+    const state = createMessageComposerState();
+    const messageComposer = {
+      isCommandDisabled: jest.fn(() => !!state.getLatestValue().quotedMessage),
+      state,
+    } as unknown as ReturnType<typeof useMessageComposer>;
+
+    mockUseMessageComposer.mockReturnValue(messageComposer);
+
+    const { result } = renderHook(() => useIsCommandDisabled(command));
+
+    act(() => {
+      state.partialNext({ quotedMessage: generateMessage({ id: 'first-quoted-message' }) });
+    });
+
+    expect(result.current).toBe(true);
+    expect(messageComposer.isCommandDisabled).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      state.partialNext({ quotedMessage: generateMessage({ id: 'second-quoted-message' }) });
+    });
+
+    expect(result.current).toBe(true);
+    expect(messageComposer.isCommandDisabled).toHaveBeenCalledTimes(2);
+  });
+});

--- a/package/src/contexts/messageInputContext/hooks/useIsCommandDisabled.ts
+++ b/package/src/contexts/messageInputContext/hooks/useIsCommandDisabled.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+
+import type { CommandSuggestion, MessageComposerState } from 'stream-chat';
+
+import { useMessageComposer } from './useMessageComposer';
+
+import { useStateStore } from '../../../hooks/useStateStore';
+
+const hasQuotedMessageSelector = (state: MessageComposerState) => ({
+  hasQuotedMessage: !!state.quotedMessage,
+});
+
+export const useIsCommandDisabled = (command: CommandSuggestion) => {
+  const messageComposer = useMessageComposer();
+  const { hasQuotedMessage } = useStateStore(messageComposer.state, hasQuotedMessageSelector);
+
+  return useMemo(
+    () => messageComposer.isCommandDisabled(command),
+    // isCommandDisabled reads quotedMessage through the composer state getter.
+    // Keep this dependency scoped to quote presence, not quote object identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [command, hasQuotedMessage, messageComposer],
+  );
+};

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -8507,10 +8507,10 @@ stdin-discarder@^0.2.2:
   resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.2.2.tgz#390037f44c4ae1a1ae535c5fe38dc3aba8d997be"
   integrity sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==
 
-stream-chat@^9.42.1:
-  version "9.42.1"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.42.1.tgz#8b6aa4e3e73a39ed07bb2a4f2a6829ba9354567a"
-  integrity sha512-o+9wQO4Ruu1A48T0IrX9ZH8+9F5xPgGLPvflaswaPeLyIZXcy8bsQdcT/HSrPmT7gs0WGD3qcbXaAJU5lMQezQ==
+stream-chat@^9.43.0:
+  version "9.43.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.43.0.tgz#216a80abadea83dcee6fb339b76035b26af2beb5"
+  integrity sha512-gc12LZTmRWvSi6EjnMK7Y+D8xOQIouVUO2flUShazG/NqVccJhXYphQ96PzK7Wym+5wwwitTaJqq0m/1VUPBCA==
   dependencies:
     "@types/jsonwebtoken" "^9.0.8"
     "@types/ws" "^8.5.14"


### PR DESCRIPTION
## 🎯 Goal

This PR is an extension of our commands flow to better reflect what's allowed and what's not on our backend. 

LLC PR with better explanation: https://github.com/GetStream/stream-chat-js/pull/1723

General points:

- Commands are disabled in certain scenarios:
  - When a quoted message is available, only `giphy` commands are allowed
  - When we're in an editing state, no commands are allowed (this is ignored server-side)
- Adding a command when we have `composer` state already (specifically `text` and `attachments`), removes these but keeps a snapshot of the state so that if we remove the command we go back to the previous state
- Adding `editing`/`quoted_message` state on already existing commands for which this is not allowed will remove them 

Trying to attach commands in a non-allowed state will also fire a notification so that the UI can react accordingly.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


