### PR TITLE
fix: podspecPath warning

### DIFF
--- a/package/expo-package/react-native.config.js
+++ b/package/expo-package/react-native.config.js
@@ -5,9 +5,6 @@ module.exports = {
         packageImportPath: 'import com.streamchatexpo.StreamChatExpoPackage;',
         packageInstance: 'new StreamChatExpoPackage()',
       },
-      ios: {
-        podspecPath: 'stream-chat-expo.podspec',
-      },
     },
   },
 };

--- a/package/native-package/react-native.config.js
+++ b/package/native-package/react-native.config.js
@@ -5,9 +5,6 @@ module.exports = {
         packageImportPath: 'import com.streamchatreactnative.StreamChatReactNativePackage;',
         packageInstance: 'new StreamChatReactNativePackage()',
       },
-      ios: {
-        podspecPath: 'stream-chat-react-native.podspec',
-      },
     },
   },
 };


### PR DESCRIPTION
## 🎯 Goal

This PR removes the deprecated iOS `podspecPath` entries from the RN CLI and Expo packages' `react-native.config.js` files. RN CLI 20 rejects `dependency.platforms.ios.podspecPath` and for RN `0.76+` the CLI discovers the package root `*.podspec` automatically during autolinking.

Verified with `npx react-native config` in `examples/SampleApp`.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


