### PR TITLE
chore: update github actions to latest versions

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -14,12 +14,12 @@ jobs:
         node-version: [ 24.x ]
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Linux build tools
         run: sudo apt-get update && sudo apt-get install -y build-essential
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           ref: develop
           # pulls all commits (needed for semantic release to correctly version)
@@ -27,7 +27,7 @@ jobs:
       # pulls all tags (needed for semantic release to correctly version)
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
@@ -62,12 +62,12 @@ jobs:
             echo "::set-output name=exists::true"
             echo "::set-output name=preview::$CHANGELOG_PREVIEW_ESCAPED"
           fi
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@v3
         if: steps.generate_changelog.outputs.exists == 'true'
         with:
           header: changelog_preview
           message: ${{ steps.generate_changelog.outputs.preview }}
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@v3
         if: steps.generate_changelog.outputs.exists != 'true'
         with:
           header: changelog_preview

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         node-version: [24.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Linux build tools

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -10,7 +10,22 @@ on:
 jobs:
   lint_pr_title:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
-      - uses: deepakputhraya/action-pr-title@v1.0.2
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          regex: '^(\w*)(?:\((.*)\))?: (.*)$'
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            chore
+            test
+            perf
+            ci
+            build
+            style
+            revert

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: [24.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
 
@@ -27,7 +27,7 @@ jobs:
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -20,14 +20,14 @@ jobs:
         node-version: [24.x]
     steps:
       - name: Connect Bot
-        uses: webfactory/ssh-agent@v0.7.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.BOT_SSH_PRIVATE_KEY }}
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.2' # Update as needed
@@ -35,7 +35,7 @@ jobs:
       - name: Install && Build - SDK and Sample App
         uses: ./.github/actions/install-and-build-sdk
       - name: Cache iOS pods
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: examples/SampleApp/ios/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('examples/SampleApp/ios/Podfile.lock') }}
@@ -65,13 +65,13 @@ jobs:
         node-version: [24.x]
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install Linux build tools
         run: sudo apt-get update && sudo apt-get install -y build-essential
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Connect Bot
-        uses: webfactory/ssh-agent@v0.7.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.BOT_SSH_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ruby-cache
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24.x
           cache: 'yarn'


### PR DESCRIPTION
## Summary

- Bumps all GitHub Actions to their latest major versions across every workflow.
- Standardizes Node 24 setup across CI (already in place; confirmed and consistent now).
- Replaces the abandoned `deepakputhraya/action-pr-title` (no release since Mar 2021) with the actively maintained `amannn/action-semantic-pull-request@v6` for PR-title linting.

## Action version changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v2`, `v3`, `v3.1.0` (mixed) | `v6` |
| `actions/setup-node` | `v4` | `v6` |
| `actions/cache` | `v4` | `v5` |
| `actions/setup-java` | `v3` | `v5` |
| `webfactory/ssh-agent` | `v0.7.0` | `v0.10.0` |
| `marocchino/sticky-pull-request-comment` | `v2` | `v3` |
| `deepakputhraya/action-pr-title@v1.0.2` | abandoned | `amannn/action-semantic-pull-request@v6` |

## Behavior change worth noting

The new PR-title linter enforces a strict allowlist of conventional-commit types (`feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `perf`, `ci`, `build`, `style`, `revert`). The old regex (`^(\w*)(?:\((.*)\))?: (.*)$`) accepted *any* word as a type, so PRs that previously slipped through with non-standard types (e.g. `wip:`) will now fail the title check. This aligns with what `commitlint` enforces on commits anyway.

## Test plan

- [ ] CI runs green on this PR (exercises `check-pr.yml`, `changelog-preview.yml`, `lint-pr-title.yml`, `sdk-size-metrics.yml`).
- [ ] Verify the new PR title check triggers and accepts the `chore:` prefix on this PR.
- [ ] Sanity check the changelog preview comment appears on a PR targeting `main`.
- [ ] On merge to `develop`, verify `release.yml` and `sample-distribution.yml` still run successfully end-to-end.