### PR TITLE
fix: revert SDK name update

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -83,7 +83,7 @@
     "path": "0.12.7",
     "react-native-markdown-package": "1.8.2",
     "react-native-url-polyfill": "^2.0.0",
-    "stream-chat": "^9.42.2",
+    "stream-chat": "^9.42.1",
     "use-sync-external-store": "^1.5.0"
   },
   "peerDependencies": {

--- a/package/src/components/Chat/Chat.tsx
+++ b/package/src/components/Chat/Chat.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren, useEffect, useMemo, useState } from 'react';
 import { Platform } from 'react-native';
 
-import { Channel, OfflineDBState, SdkIdentifier } from 'stream-chat';
+import { Channel, OfflineDBState } from 'stream-chat';
 
 import { useClientMutedUsers } from './hooks';
 import { useAppSettings } from './hooks/useAppSettings';
@@ -187,10 +187,9 @@ const ChatWithContext = (props: PropsWithChildren<ChatProps>) => {
 
   useEffect(() => {
     if (client) {
-      const sdkName = (((NativeHandlers.SDK
-        ? NativeHandlers.SDK.replace('stream-chat-', '')
-        : 'react-native') as 'react-native' | 'expo') +
-        `-${Platform.OS as 'ios' | 'android'}`) as SdkIdentifier['name'];
+      const sdkName = (
+        NativeHandlers.SDK ? NativeHandlers.SDK.replace('stream-chat-', '') : 'react-native'
+      ) as 'react-native' | 'expo';
       client.sdkIdentifier = {
         name: sdkName,
         version,

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -8507,10 +8507,10 @@ stdin-discarder@^0.2.2:
   resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.2.2.tgz#390037f44c4ae1a1ae535c5fe38dc3aba8d997be"
   integrity sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==
 
-stream-chat@^9.42.2:
-  version "9.42.2"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.42.2.tgz#036dc26c46bb9eeeb36270525b0b27316373e460"
-  integrity sha512-AIGVXdEb7WGczp/B+/FtImbe8o/9RcyahIZdLXnnVll0x3mGDz51raxyaPKUylbBluF02yaJk8Ia55CR1NXYHQ==
+stream-chat@^9.42.1:
+  version "9.42.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.42.1.tgz#8b6aa4e3e73a39ed07bb2a4f2a6829ba9354567a"
+  integrity sha512-o+9wQO4Ruu1A48T0IrX9ZH8+9F5xPgGLPvflaswaPeLyIZXcy8bsQdcT/HSrPmT7gs0WGD3qcbXaAJU5lMQezQ==
   dependencies:
     "@types/jsonwebtoken" "^9.0.8"
     "@types/ws" "^8.5.14"


### PR DESCRIPTION
Reverts GetStream/stream-chat-react-native#3576

This has since been updated on the backend, so it's no longer relevant or necessary.