### PR TITLE
fix: notification styles and default icons

### DIFF
--- a/package/src/components/Notifications/Notification.tsx
+++ b/package/src/components/Notifications/Notification.tsx
@@ -12,7 +12,7 @@ import { useComponentsContext } from '../../contexts/componentsContext/Component
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
 import { Check } from '../../icons/checkmark';
-import { Warning } from '../../icons/exclamation-triangle-fill';
+import { ExclamationCircle } from '../../icons/exclamation-circle-fill';
 import { Reload } from '../../icons/refresh';
 import { IconProps } from '../../icons/utils/base';
 import { NewClose } from '../../icons/xmark';
@@ -36,11 +36,11 @@ export const getNotificationVariant = (notification: NotificationType): Notifica
   notification.severity ?? 'default';
 
 const IconsByVariant: Partial<Record<NotificationVariant, ComponentType<IconProps> | null>> = {
-  error: Warning,
+  error: ExclamationCircle,
   info: null,
   loading: Reload,
   success: Check,
-  warning: Warning,
+  warning: ExclamationCircle,
 };
 
 const getNotificationIconComponent = (notification: NotificationType) => {
@@ -210,9 +210,8 @@ const useNotificationStyles = ({ hasResolvedIcon }: { hasResolvedIcon: boolean }
         borderRadius: primitives.radius3xl,
         flexDirection: 'row',
         maxWidth: '100%',
-        paddingHorizontal: primitives.spacingSm,
+        paddingHorizontal: primitives.spacingXs,
         ...notificationShadow,
-        shadowOpacity: 0,
       },
       contentContainer: {
         alignItems: 'center',


### PR DESCRIPTION
## 🎯 Goal

This PR applies some minor fixes to the styles of notification snackbars.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


