### PR TITLE
chore: predefined filter support for offline mode

### DIFF
--- a/examples/ExpoMessaging/app/index.tsx
+++ b/examples/ExpoMessaging/app/index.tsx
@@ -3,13 +3,12 @@ import { Alert, Image, Pressable, StyleSheet, View } from 'react-native';
 import { ChannelList, SqliteClient } from 'stream-chat-expo';
 import { useCallback, useContext, useMemo } from 'react';
 import { Stack, useRouter } from 'expo-router';
-import { ChannelSort } from 'stream-chat';
 import { AppContext } from '../context/AppContext';
 import { useUserContext } from '@/context/UserContext';
 import { getInitialsOfName } from '@/utils/getInitialsOfName';
 
-const sort: ChannelSort = { last_updated: -1 };
-const options = {
+const baseOptions = {
+  predefined_filter: 'basic_channel_list_filter',
   state: true,
   watch: true,
 };
@@ -46,12 +45,15 @@ const LogoutButton = () => {
 
 export default function ChannelListScreen() {
   const { user } = useUserContext();
-  const filters = useMemo(
+  const userId = user?.id || '';
+  const options = useMemo(
     () => ({
-      members: { $in: [user?.id as string] },
-      type: 'messaging',
+      ...baseOptions,
+      filter_values: {
+        user_id: userId,
+      },
     }),
-    [user?.id],
+    [userId],
   );
   const router = useRouter();
   const { setChannel } = useContext(AppContext);
@@ -63,13 +65,11 @@ export default function ChannelListScreen() {
       />
 
       <ChannelList
-        filters={filters}
         onSelect={(channel) => {
           setChannel(channel);
           router.push(`/channel/${channel.cid}`);
         }}
         options={options}
-        sort={sort}
       />
     </View>
   );

--- a/examples/SampleApp/src/screens/ChannelListScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelListScreen.tsx
@@ -60,13 +60,6 @@ const styles = StyleSheet.create({
   },
 });
 
-const baseFilters = {
-  archived: false,
-  type: 'messaging',
-};
-
-const sort: ChannelSort = [{ pinned_at: -1 }, { last_message_at: -1 }, { updated_at: -1 }];
-
 const baseOptions = {
   presence: true,
   state: true,

--- a/examples/SampleApp/src/screens/ChannelListScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelListScreen.tsx
@@ -92,15 +92,6 @@ export const ChannelListScreen: React.FC = () => {
     usePaginatedSearchedMessages(searchQuery);
 
   const chatClientUserId = chatClient?.user?.id || '';
-  // const filters = useMemo(
-  //   () => ({
-  //     ...baseFilters,
-  //     members: {
-  //       $in: [chatClientUserId],
-  //     },
-  //   }),
-  //   [chatClientUserId],
-  // );
   const options = useMemo(() => ({
     ...baseOptions,
     filter_values: {
@@ -255,13 +246,11 @@ export const ChannelListScreen: React.FC = () => {
           <View style={[styles.channelListContainer, { opacity: searchQuery ? 0 : 1 }]}>
             <ChannelList
               additionalFlatListProps={additionalFlatListProps}
-              // filters={filters}
               maxUnreadCount={99}
               onSelect={onSelect}
               options={options}
               setFlatListRef={setScrollRef}
               getChannelActionItems={getChannelActionItems}
-              // sort={sort}
             />
           </View>
         </View>

--- a/examples/SampleApp/src/screens/ChannelListScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelListScreen.tsx
@@ -67,11 +67,12 @@ const baseFilters = {
 
 const sort: ChannelSort = [{ pinned_at: -1 }, { last_message_at: -1 }, { updated_at: -1 }];
 
-const options = {
+const baseOptions = {
   presence: true,
   state: true,
   watch: true,
   message_limit: 25,
+  predefined_filter: 'basic_channel_list_filter',
 };
 
 export const ChannelListScreen: React.FC = () => {
@@ -91,15 +92,21 @@ export const ChannelListScreen: React.FC = () => {
     usePaginatedSearchedMessages(searchQuery);
 
   const chatClientUserId = chatClient?.user?.id || '';
-  const filters = useMemo(
-    () => ({
-      ...baseFilters,
-      members: {
-        $in: [chatClientUserId],
-      },
-    }),
-    [chatClientUserId],
-  );
+  // const filters = useMemo(
+  //   () => ({
+  //     ...baseFilters,
+  //     members: {
+  //       $in: [chatClientUserId],
+  //     },
+  //   }),
+  //   [chatClientUserId],
+  // );
+  const options = useMemo(() => ({
+    ...baseOptions,
+    filter_values: {
+      user_id: chatClientUserId,
+    }
+  }), [chatClientUserId])
 
   useScrollToTop(scrollRef as RefObject<FlatList<Channel>>);
 
@@ -248,13 +255,13 @@ export const ChannelListScreen: React.FC = () => {
           <View style={[styles.channelListContainer, { opacity: searchQuery ? 0 : 1 }]}>
             <ChannelList
               additionalFlatListProps={additionalFlatListProps}
-              filters={filters}
+              // filters={filters}
               maxUnreadCount={99}
               onSelect={onSelect}
               options={options}
               setFlatListRef={setScrollRef}
               getChannelActionItems={getChannelActionItems}
-              sort={sort}
+              // sort={sort}
             />
           </View>
         </View>

--- a/examples/SampleApp/src/screens/ChannelListScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelListScreen.tsx
@@ -17,7 +17,6 @@ import { MessageSearchList } from '../components/MessageSearch/MessageSearchList
 import { useAppContext } from '../context/AppContext';
 import { usePaginatedSearchedMessages } from '../hooks/usePaginatedSearchedMessages';
 
-import type { ChannelSort } from 'stream-chat';
 import { useStreamChatContext } from '../context/StreamChatContext';
 import { Search } from '../icons/Search';
 import { ChannelInfo } from '../icons/ChannelInfo.tsx';

--- a/package/package.json
+++ b/package/package.json
@@ -83,7 +83,7 @@
     "path": "0.12.7",
     "react-native-markdown-package": "1.8.2",
     "react-native-url-polyfill": "^2.0.0",
-    "stream-chat": "^9.43.2",
+    "stream-chat": "^9.44.1",
     "use-sync-external-store": "^1.5.0"
   },
   "peerDependencies": {

--- a/package/src/components/ChannelList/__tests__/ChannelList.test.tsx
+++ b/package/src/components/ChannelList/__tests__/ChannelList.test.tsx
@@ -184,6 +184,74 @@ describe('ChannelList', () => {
     });
   });
 
+  it('should re-query channels when predefined filter options change', async () => {
+    const queryChannelsSpy = jest.spyOn(chatClient, 'queryChannels');
+    useMockedApis(chatClient, [queryChannelsApi([testChannel1])]);
+
+    render(
+      <Chat client={chatClient}>
+        <WithComponents overrides={{ ChannelPreview: ChannelPreviewComponent }}>
+          <ChannelList
+            {...props}
+            options={{
+              filter_values: { user_id: 'dan' },
+              predefined_filter: 'user_messaging',
+            }}
+          />
+        </WithComponents>
+      </Chat>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId(testChannel1.channel.id)).toBeTruthy();
+    });
+
+    expect(queryChannelsSpy).toHaveBeenNthCalledWith(
+      1,
+      {},
+      expect.anything(),
+      expect.objectContaining({
+        filter_values: { user_id: 'dan' },
+        offset: 0,
+        predefined_filter: 'user_messaging',
+      }),
+      expect.anything(),
+    );
+
+    useMockedApis(chatClient, [queryChannelsApi([testChannel2])]);
+
+    screen.rerender(
+      <Chat client={chatClient}>
+        <WithComponents overrides={{ ChannelPreview: ChannelPreviewComponent }}>
+          <ChannelList
+            {...props}
+            options={{
+              filter_values: { user_id: 'sara' },
+              predefined_filter: 'user_messaging',
+            }}
+          />
+        </WithComponents>
+      </Chat>,
+    );
+
+    await waitFor(() => {
+      expect(queryChannelsSpy).toHaveBeenCalledTimes(2);
+      expect(screen.getByTestId(testChannel2.channel.id)).toBeTruthy();
+    });
+
+    expect(queryChannelsSpy).toHaveBeenNthCalledWith(
+      2,
+      {},
+      expect.anything(),
+      expect.objectContaining({
+        filter_values: { user_id: 'sara' },
+        offset: 0,
+        predefined_filter: 'user_messaging',
+      }),
+      expect.anything(),
+    );
+  });
+
   it('should update if filters are updated while awaiting api call', async () => {
     const deferredCallForStaleFilter = new DeferredPromise();
     const deferredCallForFreshFilter = new DeferredPromise();

--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -53,6 +53,7 @@ export const usePaginatedChannels = ({
   const hasNextPage = pagination?.hasNext;
 
   const filtersRef = useRef<typeof filters | null>(null);
+  const optionsRef = useRef<typeof options | null>(null);
   const sortRef = useRef<typeof sort | null>(null);
   const activeRequestId = useRef<number>(0);
   const isQueryingRef = useRef(false);
@@ -71,6 +72,7 @@ export const usePaginatedChannels = ({
       queryType === 'backgroundRefresh' ||
       [
         JSON.stringify(filtersRef.current) !== JSON.stringify(filters),
+        JSON.stringify(optionsRef.current) !== JSON.stringify(options),
         JSON.stringify(sortRef.current) !== JSON.stringify(sort),
       ].some(Boolean);
 
@@ -87,6 +89,7 @@ export const usePaginatedChannels = ({
     }
 
     filtersRef.current = filters;
+    optionsRef.current = options;
     sortRef.current = sort;
     isQueryingRef.current = true;
     activeRequestId.current++;
@@ -146,7 +149,7 @@ export const usePaginatedChannels = ({
   };
 
   /**
-   * Equality check using stringified filters/sort ensure that we don't make un-necessary queryChannels api calls
+   * Equality check using stringified filters/options/sort ensure that we don't make un-necessary queryChannels api calls
    * for the scenario:
    *
    * <ChannelList
@@ -161,6 +164,7 @@ export const usePaginatedChannels = ({
    * in return will trigger useEffect. To avoid this, we can add a value check.
    */
   const filterStr = useMemo(() => JSON.stringify(filters), [filters]);
+  const optionsStr = useMemo(() => JSON.stringify(options), [options]);
   const sortStr = useMemo(() => JSON.stringify(sort), [sort]);
 
   useEffect(() => {
@@ -178,7 +182,7 @@ export const usePaginatedChannels = ({
 
     return () => listener?.unsubscribe?.();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterStr, sortStr, channelManager]);
+  }, [filterStr, optionsStr, sortStr, channelManager]);
 
   return {
     channelListInitialized,

--- a/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/package/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -70,11 +70,9 @@ export const usePaginatedChannels = ({
       queryType === 'loadChannels' ||
       queryType === 'refresh' ||
       queryType === 'backgroundRefresh' ||
-      [
-        JSON.stringify(filtersRef.current) !== JSON.stringify(filters),
-        JSON.stringify(optionsRef.current) !== JSON.stringify(options),
-        JSON.stringify(sortRef.current) !== JSON.stringify(sort),
-      ].some(Boolean);
+      JSON.stringify(filtersRef.current) !== JSON.stringify(filters) ||
+      JSON.stringify(optionsRef.current) !== JSON.stringify(options) ||
+      JSON.stringify(sortRef.current) !== JSON.stringify(sort);
 
     const isQueryStale = () => !isMountedRef || activeRequestId.current !== currentRequestId;
 

--- a/package/src/store/OfflineDB.ts
+++ b/package/src/store/OfflineDB.ts
@@ -1,5 +1,6 @@
 import { AbstractOfflineDB, StreamChat } from 'stream-chat';
 import type {
+  ChannelOptions,
   DBGetAppSettingsType,
   DBGetChannelsForQueryType,
   DBGetChannelsType,
@@ -10,6 +11,10 @@ import type {
 
 import * as api from './apis';
 import { SqliteClient } from './SqliteClient';
+
+type DBGetChannelsForQueryTypeWithOptions = DBGetChannelsForQueryType & {
+  options?: ChannelOptions;
+};
 
 export class OfflineDB extends AbstractOfflineDB {
   constructor({ client }: { client: StreamChat }) {
@@ -51,8 +56,13 @@ export class OfflineDB extends AbstractOfflineDB {
     api.getChannels({ channelIds: cids, currentUserId: userId });
 
   // TODO: Rename currentUserId -> userId in the next major version as it is technically breaking.
-  getChannelsForQuery = ({ userId, filters, sort }: DBGetChannelsForQueryType) =>
-    api.getChannelsForFilterSort({ currentUserId: userId, filters, sort });
+  getChannelsForQuery = ({
+    userId,
+    filters,
+    options,
+    sort,
+  }: DBGetChannelsForQueryTypeWithOptions) =>
+    api.getChannelsForFilterSort({ currentUserId: userId, filters, options, sort });
 
   getAllChannelCids = api.getAllChannelIds;
 

--- a/package/src/store/OfflineDB.ts
+++ b/package/src/store/OfflineDB.ts
@@ -1,6 +1,5 @@
 import { AbstractOfflineDB, StreamChat } from 'stream-chat';
 import type {
-  ChannelOptions,
   DBGetAppSettingsType,
   DBGetChannelsForQueryType,
   DBGetChannelsType,
@@ -11,10 +10,6 @@ import type {
 
 import * as api from './apis';
 import { SqliteClient } from './SqliteClient';
-
-type DBGetChannelsForQueryTypeWithOptions = DBGetChannelsForQueryType & {
-  options?: ChannelOptions;
-};
 
 export class OfflineDB extends AbstractOfflineDB {
   constructor({ client }: { client: StreamChat }) {
@@ -56,12 +51,7 @@ export class OfflineDB extends AbstractOfflineDB {
     api.getChannels({ channelIds: cids, currentUserId: userId });
 
   // TODO: Rename currentUserId -> userId in the next major version as it is technically breaking.
-  getChannelsForQuery = ({
-    userId,
-    filters,
-    options,
-    sort,
-  }: DBGetChannelsForQueryTypeWithOptions) =>
+  getChannelsForQuery = ({ userId, filters, options, sort }: DBGetChannelsForQueryType) =>
     api.getChannelsForFilterSort({ currentUserId: userId, filters, options, sort });
 
   getAllChannelCids = api.getAllChannelIds;

--- a/package/src/store/apis/__tests__/channelQueryCids.test.ts
+++ b/package/src/store/apis/__tests__/channelQueryCids.test.ts
@@ -1,0 +1,55 @@
+import { BetterSqlite } from '../../../test-utils/BetterSqlite';
+import { SqliteClient } from '../../SqliteClient';
+import { selectChannelIdsForFilterSort } from '../queries/selectChannelIdsForFilterSort';
+import { upsertCidsForQuery } from '../upsertCidsForQuery';
+
+describe('channel query cids', () => {
+  beforeEach(async () => {
+    await SqliteClient.initializeDatabase();
+    await BetterSqlite.openDB();
+  });
+
+  afterEach(() => {
+    BetterSqlite.dropAllTables();
+    BetterSqlite.closeDB();
+    jest.clearAllMocks();
+  });
+
+  it('stores separate cid lists for predefined filter queries with the same filters and sort', async () => {
+    await upsertCidsForQuery({
+      cids: ['messaging:channel-1'],
+      filters: {},
+      options: {
+        predefined_filter: 'user_messaging',
+      },
+      sort: {},
+    });
+    await upsertCidsForQuery({
+      cids: ['messaging:channel-2'],
+      filters: {},
+      options: {
+        predefined_filter: 'team_channels',
+      },
+      sort: {},
+    });
+
+    await expect(
+      selectChannelIdsForFilterSort({
+        filters: {},
+        options: {
+          predefined_filter: 'user_messaging',
+        },
+        sort: {},
+      }),
+    ).resolves.toEqual(['messaging:channel-1']);
+    await expect(
+      selectChannelIdsForFilterSort({
+        filters: {},
+        options: {
+          predefined_filter: 'team_channels',
+        },
+        sort: {},
+      }),
+    ).resolves.toEqual(['messaging:channel-2']);
+  });
+});

--- a/package/src/store/apis/getChannelsForFilterSort.ts
+++ b/package/src/store/apis/getChannelsForFilterSort.ts
@@ -1,4 +1,4 @@
-import type { ChannelAPIResponse, ChannelFilters, ChannelSort } from 'stream-chat';
+import type { ChannelAPIResponse, ChannelFilters, ChannelOptions, ChannelSort } from 'stream-chat';
 
 import { getChannels } from './getChannels';
 import { selectChannelIdsForFilterSort } from './queries/selectChannelIdsForFilterSort';
@@ -18,20 +18,24 @@ import { SqliteClient } from '../SqliteClient';
 export const getChannelsForFilterSort = async ({
   currentUserId,
   filters,
+  options,
   sort,
 }: {
   currentUserId: string;
   filters?: ChannelFilters;
+  options?: ChannelOptions;
   sort?: ChannelSort;
 }): Promise<Omit<ChannelAPIResponse, 'duration'>[] | null> => {
-  if (!filters && !sort) {
-    console.warn('Please provide the query (filters/sort) to fetch channels from DB');
+  if (!filters && !sort && !options?.predefined_filter) {
+    console.warn(
+      'Please provide the query (filters/sort/options.predefined_filters) to fetch channels from the DB.',
+    );
     return null;
   }
 
-  SqliteClient.logger?.('info', 'getChannelsForFilterSort', { filters, sort });
+  SqliteClient.logger?.('info', 'getChannelsForFilterSort', { filters, options, sort });
 
-  const channelIds = await selectChannelIdsForFilterSort({ filters, sort });
+  const channelIds = await selectChannelIdsForFilterSort({ filters, options, sort });
 
   if (!channelIds) {
     return null;

--- a/package/src/store/apis/getChannelsForFilterSort.ts
+++ b/package/src/store/apis/getChannelsForFilterSort.ts
@@ -28,7 +28,7 @@ export const getChannelsForFilterSort = async ({
 }): Promise<Omit<ChannelAPIResponse, 'duration'>[] | null> => {
   if (!filters && !sort && !options?.predefined_filter) {
     console.warn(
-      'Please provide the query (filters/sort/options.predefined_filters) to fetch channels from the DB.',
+      'Please provide the query (filters/sort/options.predefined_filter) to fetch channels from the DB.',
     );
     return null;
   }

--- a/package/src/store/apis/queries/selectChannelIdsForFilterSort.ts
+++ b/package/src/store/apis/queries/selectChannelIdsForFilterSort.ts
@@ -1,4 +1,4 @@
-import type { ChannelFilters, ChannelSort } from 'stream-chat';
+import type { ChannelFilters, ChannelOptions, ChannelSort } from 'stream-chat';
 
 import { createSelectQuery } from '../../sqlite-utils/createSelectQuery';
 import { SqliteClient } from '../../SqliteClient';
@@ -17,12 +17,14 @@ import { convertFilterSortToQuery } from '../utils/convertFilterSortToQuery';
 
 export const selectChannelIdsForFilterSort = async ({
   filters,
+  options,
   sort,
 }: {
   filters?: ChannelFilters;
+  options?: ChannelOptions;
   sort?: ChannelSort;
 }): Promise<string[] | null> => {
-  const query = convertFilterSortToQuery({ filters, sort });
+  const query = convertFilterSortToQuery({ filters, options, sort });
 
   SqliteClient.logger?.('info', 'selectChannelIdsForFilterSort', {
     query,

--- a/package/src/store/apis/upsertCidsForQuery.ts
+++ b/package/src/store/apis/upsertCidsForQuery.ts
@@ -1,4 +1,4 @@
-import type { ChannelFilters, ChannelSort } from 'stream-chat';
+import type { ChannelFilters, ChannelOptions, ChannelSort } from 'stream-chat';
 
 import { convertFilterSortToQuery } from './utils/convertFilterSortToQuery';
 
@@ -9,16 +9,18 @@ export const upsertCidsForQuery = async ({
   cids,
   filters,
   execute = true,
+  options,
   sort,
 }: {
   cids: string[];
   filters?: ChannelFilters;
   execute?: boolean;
+  options?: ChannelOptions;
   sort?: ChannelSort;
 }) => {
   // Update the database only if the query is provided.
   const cidsString = JSON.stringify(cids);
-  const id = convertFilterSortToQuery({ filters, sort });
+  const id = convertFilterSortToQuery({ filters, options, sort });
   const query = createUpsertQuery('channelQueries', {
     cids: cidsString,
     id,

--- a/package/src/store/apis/utils/__tests__/convertFilterSortToQuery.test.ts
+++ b/package/src/store/apis/utils/__tests__/convertFilterSortToQuery.test.ts
@@ -1,0 +1,73 @@
+import { convertFilterSortToQuery } from '../convertFilterSortToQuery';
+
+describe('convertFilterSortToQuery', () => {
+  it('preserves the existing filters and sort key for traditional queries', () => {
+    const filters = { members: { $in: ['user-1'] }, type: 'messaging' };
+    const sort = { last_updated: 1 as const };
+
+    expect(convertFilterSortToQuery({ filters, sort })).toBe(
+      JSON.stringify(`${JSON.stringify(filters)}-${JSON.stringify(sort)}`),
+    );
+  });
+
+  it('uses predefined filter options in the query key', () => {
+    const firstKey = convertFilterSortToQuery({
+      options: {
+        predefined_filter: 'user_messaging',
+      },
+      sort: [],
+    });
+    const secondKey = convertFilterSortToQuery({
+      options: {
+        predefined_filter: 'team_channels',
+      },
+      sort: [],
+    });
+
+    expect(firstKey).not.toBe(secondKey);
+  });
+
+  it('distinguishes predefined filter interpolation values', () => {
+    const firstKey = convertFilterSortToQuery({
+      options: {
+        filter_values: { user_id: 'user-1' },
+        predefined_filter: 'user_messaging',
+        sort_values: { sort_field: 'last_message_at' },
+      },
+      sort: [],
+    });
+    const secondKey = convertFilterSortToQuery({
+      options: {
+        filter_values: { user_id: 'user-2' },
+        predefined_filter: 'user_messaging',
+        sort_values: { sort_field: 'last_message_at' },
+      },
+      sort: [],
+    });
+
+    expect(firstKey).not.toBe(secondKey);
+  });
+
+  it('ignores pagination and control options for predefined filter keys', () => {
+    const firstKey = convertFilterSortToQuery({
+      options: {
+        limit: 10,
+        offset: 0,
+        predefined_filter: 'user_messaging',
+        watch: true,
+      },
+      sort: [],
+    });
+    const secondKey = convertFilterSortToQuery({
+      options: {
+        limit: 20,
+        offset: 20,
+        predefined_filter: 'user_messaging',
+        watch: false,
+      },
+      sort: [],
+    });
+
+    expect(firstKey).toBe(secondKey);
+  });
+});

--- a/package/src/store/apis/utils/convertFilterSortToQuery.ts
+++ b/package/src/store/apis/utils/convertFilterSortToQuery.ts
@@ -1,10 +1,42 @@
-import type { ChannelFilters, ChannelSort } from 'stream-chat';
+import type { ChannelFilters, ChannelOptions, ChannelSort } from 'stream-chat';
+
+type PredefinedFilterCacheKeyOptions = Pick<
+  ChannelOptions,
+  'predefined_filter' | 'filter_values' | 'sort_values'
+>;
+
+const getPredefinedFilterOptions = (
+  options?: ChannelOptions,
+): PredefinedFilterCacheKeyOptions | undefined => {
+  if (!options?.predefined_filter) {
+    return undefined;
+  }
+
+  return {
+    predefined_filter: options.predefined_filter,
+    ...(options.filter_values !== undefined ? { filter_values: options.filter_values } : {}),
+    ...(options.sort_values !== undefined ? { sort_values: options.sort_values } : {}),
+  };
+};
 
 export const convertFilterSortToQuery = ({
   filters,
+  options,
   sort,
 }: {
   filters?: ChannelFilters;
+  options?: ChannelOptions;
   sort?: ChannelSort;
-}) =>
-  JSON.stringify(`${filters ? JSON.stringify(filters) : ''}-${sort ? JSON.stringify(sort) : ''}`);
+}) => {
+  const predefinedFilterOptions = getPredefinedFilterOptions(options);
+
+  if (predefinedFilterOptions) {
+    return JSON.stringify(
+      `predefined-${JSON.stringify(predefinedFilterOptions)}-${sort ? JSON.stringify(sort) : ''}`,
+    );
+  }
+
+  return JSON.stringify(
+    `${filters ? JSON.stringify(filters) : ''}-${sort ? JSON.stringify(sort) : ''}`,
+  );
+};

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -8507,10 +8507,10 @@ stdin-discarder@^0.2.2:
   resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.2.2.tgz#390037f44c4ae1a1ae535c5fe38dc3aba8d997be"
   integrity sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==
 
-stream-chat@^9.43.2:
-  version "9.43.2"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.43.2.tgz#2b53af3a4ce00c90f531cb44f01b6e09a91bfe13"
-  integrity sha512-+o1f8RfqqeBq7ShH74TyZDei4+8UWagKFz2xYhmANHCNl2bNPuLIAaDbV7sK3Liw9eg/26Kml/gUgGoSLUwZVA==
+stream-chat@^9.44.1:
+  version "9.44.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.44.1.tgz#94663a104d4cef32ff07130d6351bede7fd0abd8"
+  integrity sha512-AmChJiqnZSG+6XndtcfawTqP9CsqQn+pQQd5PMxMaNnd5ZNNyIJrVQnF1Za2Bt3sZF0cvb20axIidx8rhji4MQ==
   dependencies:
     "@types/jsonwebtoken" "^9.0.8"
     "@types/ws" "^8.5.14"


### PR DESCRIPTION
## 🎯 Goal

This PR introduces missing support for offline handling of predefined filters.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


