### PR TITLE
fix: predefined filters sorting

### DIFF
--- a/examples/SampleApp/ios/Podfile.lock
+++ b/examples/SampleApp/ios/Podfile.lock
@@ -3367,7 +3367,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - Teleport (1.1.2):
+  - Teleport (1.1.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3394,9 +3394,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-    - Teleport/common (= 1.1.2)
+    - Teleport/common (= 1.1.5)
     - Yoga
-  - Teleport/common (1.1.2):
+  - Teleport/common (1.1.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3884,7 +3884,7 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   stream-chat-react-native: d15df89b47c1a08bc7db90c316d34b8ac4e13900
-  Teleport: ed828b19e62ca8b9ec101d991bf0594b1c1c8812
+  Teleport: 11e953f37a889cb6a1b24c16182f84b95f77e002
   Yoga: ff16d80456ce825ffc9400eeccc645a0dfcccdf5
 
 PODFILE CHECKSUM: 84efea5f3e8c9c79671ee6e525f700f244c17388

--- a/examples/SampleApp/package.json
+++ b/examples/SampleApp/package.json
@@ -66,7 +66,7 @@
     "react-native-screens": "^4.24.0",
     "react-native-share": "^12.0.11",
     "react-native-svg": "^15.15.4",
-    "react-native-teleport": "^1.1.2",
+    "react-native-teleport": "^1.1.5",
     "react-native-video": "^6.16.1",
     "react-native-worklets": "^0.8.1",
     "stream-chat-react-native": "link:../../package/native-package",

--- a/examples/SampleApp/package.json
+++ b/examples/SampleApp/package.json
@@ -49,7 +49,7 @@
     "@react-navigation/drawer": "7.4.1",
     "@react-navigation/native": "^7.1.19",
     "@react-navigation/native-stack": "^7.6.2",
-    "@shopify/flash-list": "^2.1.0",
+    "@shopify/flash-list": "^2.3.1",
     "emoji-mart": "^5.6.0",
     "lodash.mergewith": "^4.6.2",
     "react": "19.1.4",

--- a/examples/SampleApp/src/components/NewDirectMessagingSendButton.tsx
+++ b/examples/SampleApp/src/components/NewDirectMessagingSendButton.tsx
@@ -4,11 +4,11 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 import { useNavigation } from '@react-navigation/core';
 
 import {
-  MessageInputContextValue,
   Search,
   SendRight,
   useChannelContext,
-  useMessageInputContext,
+  useMessageComposer,
+  useStateStore,
   useTheme,
 } from 'stream-chat-react-native';
 
@@ -19,11 +19,16 @@ import { useAppContext } from '../context/AppContext';
 import { SendUp } from '../icons/SendUp';
 import { useLegacyColors } from '../theme/useLegacyColors';
 
-type NewDirectMessagingSendButtonPropsWithContext = Pick<
-  MessageInputContextValue,
-  'giphyActive' | 'sendMessage'
-> & {
+import type { TextComposerState } from 'stream-chat';
+
+const textComposerStateSelector = (state: TextComposerState) => ({
+  command: state.command,
+});
+
+type NewDirectMessagingSendButtonPropsWithContext = {
   /** Disables the button */ disabled: boolean;
+  giphyActive: boolean;
+  sendMessage: () => Promise<void>;
 };
 
 const SendButtonWithContext = (props: NewDirectMessagingSendButtonPropsWithContext) => {
@@ -97,8 +102,9 @@ export const NewDirectMessagingSendButton = (props: SendButtonProps) => {
   const navigation = useNavigation<NewDirectMessagingScreenNavigationProp>();
   const { channel } = useChannelContext();
   const { selectedUserIds, reset } = useUserSearchContext();
-
-  const { giphyActive, text } = useMessageInputContext();
+  const messageComposer = useMessageComposer();
+  const { command } = useStateStore(messageComposer.textComposer.state, textComposerStateSelector);
+  const giphyActive = command?.name === 'giphy';
 
   const sendMessage = async () => {
     if (!channel) {
@@ -107,6 +113,12 @@ export const NewDirectMessagingSendButton = (props: SendButtonProps) => {
     if (!chatClient || !chatClient.user) {
       return;
     }
+
+    const composition = await messageComposer.compose();
+    if (!composition?.message) {
+      return;
+    }
+
     const members = [chatClient.user.id, ...selectedUserIds];
     channel.initialized = false;
     const newChannel = chatClient.channel('messaging', {
@@ -114,7 +126,8 @@ export const NewDirectMessagingSendButton = (props: SendButtonProps) => {
     });
     try {
       await newChannel.watch();
-      await newChannel.sendMessage({ text });
+      await newChannel.sendMessage(composition.message, composition.sendOptions);
+      messageComposer.clear();
       navigation.replace('ChannelScreen', {
         channelId: newChannel.id,
       });

--- a/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
+++ b/examples/SampleApp/src/screens/NewDirectMessagingScreen.tsx
@@ -7,9 +7,11 @@ import {
   MessageComposer,
   MessageList,
   UserAdd,
+  WithComponents,
   useTheme,
 } from 'stream-chat-react-native';
 
+import { NewDirectMessagingSendButton } from '../components/NewDirectMessagingSendButton';
 import { User } from '../icons/User';
 import { RoundButton } from '../components/RoundButton';
 import { ScreenHeader } from '../components/ScreenHeader';
@@ -359,7 +361,9 @@ export const NewDirectMessagingScreen: React.FC<NewDirectMessagingScreenProps> =
         {results && results.length >= 0 && !focusOnSearchInput && focusOnMessageInput && (
           <MessageList />
         )}
-        <MessageComposer />
+        <WithComponents overrides={{ SendButton: NewDirectMessagingSendButton }}>
+          <MessageComposer />
+        </WithComponents>
       </Channel>
     </SafeAreaView>
   );

--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -2712,10 +2712,10 @@
     read-yaml-file "^2.1.0"
     strip-json-comments "^3.1.1"
 
-"@shopify/flash-list@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@shopify/flash-list/-/flash-list-2.1.0.tgz#b1eefcf9fbd01ca04a5f24a6003cda3b46a59f64"
-  integrity sha512-/EIQlptG456yM5o9qNmNsmaZEFEOGvG3WGyb6GUAxSLlcKUGlPUkPI2NLW5wQSDEY4xSRa5zocUI+9xwmsM4Kg==
+"@shopify/flash-list@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@shopify/flash-list/-/flash-list-2.3.1.tgz#d4f90b1471a741a97c07d9aadbfaf200e92c86f7"
+  integrity sha512-7oktg2NQR7KAODjFoDaWe8/OBzyYbdTE3zQTrUBMxjIbxHTHN7UXRX1hX3DHk8KvtkgQdRfZOV8Gjj2l4fGrXw==
 
 "@sideway/address@^4.1.5":
   version "4.1.5"

--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -8291,10 +8291,10 @@ stream-chat-react-native-core@8.1.0:
   version "0.0.0"
   uid ""
 
-stream-chat@^9.43.2:
-  version "9.43.2"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.43.2.tgz#2b53af3a4ce00c90f531cb44f01b6e09a91bfe13"
-  integrity sha512-+o1f8RfqqeBq7ShH74TyZDei4+8UWagKFz2xYhmANHCNl2bNPuLIAaDbV7sK3Liw9eg/26Kml/gUgGoSLUwZVA==
+stream-chat@^9.44.2:
+  version "9.44.2"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.44.2.tgz#97d23ae4ac356b352bb0f20a31a29dc63d3ea6f5"
+  integrity sha512-TXALWeHyWnSn1KlGYEF0sltEHB26vFd26l5m1qlE9Q1XHo9RPPSyLb5mfXqTEY8b2FAv57Ei3hrT8nSXVWacDQ==
   dependencies:
     "@types/jsonwebtoken" "^9.0.8"
     "@types/ws" "^8.5.14"

--- a/examples/SampleApp/yarn.lock
+++ b/examples/SampleApp/yarn.lock
@@ -7695,10 +7695,10 @@ react-native-svg@^15.15.4:
     css-tree "^1.1.3"
     warn-once "0.1.1"
 
-react-native-teleport@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-teleport/-/react-native-teleport-1.1.2.tgz#23deea2a34f6b1bb378e0305d44deeb93d51d490"
-  integrity sha512-64dcEkxlVKzxIts2FAVhzI2tDExcD23T13c2yDC/E+1dA1vP9UlDwPYUEkHvnoTOFtMDGrKLH03RJahIWfQC1g==
+react-native-teleport@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-native-teleport/-/react-native-teleport-1.1.5.tgz#53709238828ef346948531593f81950e57461396"
+  integrity sha512-nK7gI9Ak8RVOgE08YLL/AhY1ZjnccVpqNymyfYW+qQdGxpRCys6ndjQpc4YWiQLLWRG2hs47YS5wnXURPcWWEA==
 
 react-native-url-polyfill@^2.0.0:
   version "2.0.0"

--- a/package/package.json
+++ b/package/package.json
@@ -83,7 +83,7 @@
     "path": "0.12.7",
     "react-native-markdown-package": "1.8.2",
     "react-native-url-polyfill": "^2.0.0",
-    "stream-chat": "^9.44.1",
+    "stream-chat": "^9.44.2",
     "use-sync-external-store": "^1.5.0"
   },
   "peerDependencies": {

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -8507,10 +8507,10 @@ stdin-discarder@^0.2.2:
   resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.2.2.tgz#390037f44c4ae1a1ae535c5fe38dc3aba8d997be"
   integrity sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==
 
-stream-chat@^9.44.1:
-  version "9.44.1"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.44.1.tgz#94663a104d4cef32ff07130d6351bede7fd0abd8"
-  integrity sha512-AmChJiqnZSG+6XndtcfawTqP9CsqQn+pQQd5PMxMaNnd5ZNNyIJrVQnF1Za2Bt3sZF0cvb20axIidx8rhji4MQ==
+stream-chat@^9.44.2:
+  version "9.44.2"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.44.2.tgz#97d23ae4ac356b352bb0f20a31a29dc63d3ea6f5"
+  integrity sha512-TXALWeHyWnSn1KlGYEF0sltEHB26vFd26l5m1qlE9Q1XHo9RPPSyLb5mfXqTEY8b2FAv57Ei3hrT8nSXVWacDQ==
   dependencies:
     "@types/jsonwebtoken" "^9.0.8"
     "@types/ws" "^8.5.14"


### PR DESCRIPTION
## 🎯 Goal

This PR is a follow-up to [this one](https://github.com/GetStream/stream-chat-js/commits/master/) from our LLC and it fixes local sorting of our `ChannelList` while `predefined_filter`s are being used.

It additionally bumps some dependencies in our `SampleApp` as a bit of housekeeping.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


