### PR TITLE
fix: stop replaying audio on expo when seeing to 0

### DIFF
--- a/examples/ExpoMessaging/yarn.lock
+++ b/examples/ExpoMessaging/yarn.lock
@@ -6073,10 +6073,10 @@ stream-chat-react-native-core@8.1.0:
   version "0.0.0"
   uid ""
 
-stream-chat@^9.42.1:
-  version "9.42.1"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.42.1.tgz#8b6aa4e3e73a39ed07bb2a4f2a6829ba9354567a"
-  integrity sha512-o+9wQO4Ruu1A48T0IrX9ZH8+9F5xPgGLPvflaswaPeLyIZXcy8bsQdcT/HSrPmT7gs0WGD3qcbXaAJU5lMQezQ==
+stream-chat@^9.44.2:
+  version "9.44.2"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.44.2.tgz#97d23ae4ac356b352bb0f20a31a29dc63d3ea6f5"
+  integrity sha512-TXALWeHyWnSn1KlGYEF0sltEHB26vFd26l5m1qlE9Q1XHo9RPPSyLb5mfXqTEY8b2FAv57Ei3hrT8nSXVWacDQ==
   dependencies:
     "@types/jsonwebtoken" "^9.0.8"
     "@types/ws" "^8.5.14"

--- a/package/src/state-store/audio-player.ts
+++ b/package/src/state-store/audio-player.ts
@@ -425,17 +425,10 @@ export class AudioPlayer {
     }
     this.position = positionInMillis;
     if (this.isExpoCLI) {
-      if (positionInMillis === 0) {
-        // If currentTime is 0, we should replay the video from 0th position.
-        if (this.playerRef?.replayAsync) {
-          await this.playerRef.replayAsync({});
-        }
+      if (this.playerRef?.setPositionAsync) {
+        await this.playerRef.setPositionAsync(positionInMillis);
       } else {
-        if (this.playerRef?.setPositionAsync) {
-          await this.playerRef.setPositionAsync(positionInMillis);
-        } else {
-          this.notifyError('seek-not-supported');
-        }
+        this.notifyError('seek-not-supported');
       }
     } else {
       if (this.playerRef?.seek) {


### PR DESCRIPTION
## 🎯 Goal

This PR removes a relatively archaic functionality we've had for voice recordings where seeking to 0 would begin audio replay. This is neither according to our new design system, nor does it make specific sense.

In fact, it would break the state completely as `replayAsync` does not go through the `requestPlay` lifecycle of our `audio-player` pool, meaning we would not be getting any state updates (and have audio playing). Integrators anyway have access to the pool if they wish to control this themselves.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


