### PR TITLE
fix: message gallery overflow styles

### DIFF
--- a/package/src/components/Message/MessageItemView/MessageContent.tsx
+++ b/package/src/components/Message/MessageItemView/MessageContent.tsx
@@ -656,6 +656,8 @@ const styles = StyleSheet.create({
   containerInner: {
     borderTopLeftRadius: components.messageBubbleRadiusGroupBottom,
     borderTopRightRadius: components.messageBubbleRadiusGroupBottom,
+    overflow: 'hidden',
+    borderWidth: 0,
   },
   contentBody: {
     flexShrink: 1,

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.tsx.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.tsx.snap
@@ -506,6 +506,8 @@ exports[`Thread should match thread snapshot 1`] = `
                                         {
                                           "borderTopLeftRadius": 20,
                                           "borderTopRightRadius": 20,
+                                          "borderWidth": 0,
+                                          "overflow": "hidden",
                                         },
                                         {
                                           "backgroundColor": "#ebeef1",
@@ -848,6 +850,8 @@ exports[`Thread should match thread snapshot 1`] = `
                                         {
                                           "borderTopLeftRadius": 20,
                                           "borderTopRightRadius": 20,
+                                          "borderWidth": 0,
+                                          "overflow": "hidden",
                                         },
                                         {
                                           "backgroundColor": "#ebeef1",
@@ -1223,6 +1227,8 @@ exports[`Thread should match thread snapshot 1`] = `
                                         {
                                           "borderTopLeftRadius": 20,
                                           "borderTopRightRadius": 20,
+                                          "borderWidth": 0,
+                                          "overflow": "hidden",
                                         },
                                         {
                                           "backgroundColor": "#ebeef1",
@@ -1556,6 +1562,8 @@ exports[`Thread should match thread snapshot 1`] = `
                                       {
                                         "borderTopLeftRadius": 20,
                                         "borderTopRightRadius": 20,
+                                        "borderWidth": 0,
+                                        "overflow": "hidden",
                                       },
                                       {
                                         "backgroundColor": "#ebeef1",


### PR DESCRIPTION
## 🎯 Goal

This PR addresses an unfortunate regression introduced in [this PR](https://github.com/GetStream/stream-chat-react-native/pull/3600). We need the `overflow: 'hidden'` after all, for single image messages.

Regardless, everything mentioned in the previous PR still holds true; we just force the rendering into a bounding rectangle once again by applying `borderWidth` (which even if `0`, still forces the shape as it exists). 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


