### PR TITLE
feat: svg aware images

### DIFF
--- a/package/src/components/ImageGallery/components/AnimatedGalleryImage.tsx
+++ b/package/src/components/ImageGallery/components/AnimatedGalleryImage.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { ImageStyle, StyleProp } from 'react-native';
 import Animated, { SharedValue } from 'react-native-reanimated';
-import { SvgUri } from 'react-native-svg';
 
 import { useChatConfigContext } from '../../../contexts/chatConfigContext/ChatConfigContext';
 import { useImageGalleryContext } from '../../../contexts/imageGalleryContext/ImageGalleryContext';
@@ -13,6 +12,7 @@ import {
   ImageGalleryState,
 } from '../../../state-store/image-gallery-state-store';
 import { getResizedImageUrl } from '../../../utils/getResizedImageUrl';
+import { SvgAwareImage } from '../../UIComponents/SvgAwareImage';
 import { useAnimatedGalleryStyle } from '../hooks/useAnimatedGalleryStyle';
 
 const oneEighth = 1 / 8;
@@ -88,19 +88,21 @@ export const AnimatedGalleryImage = React.memo(
 
     if (isSvg) {
       // The outer Animated.View is sized at 8× screen so raster images stay
-      // crisp under pinch-zoom (see useAnimatedGalleryStyle). rn-svg on
-      // Android rasterizes the SVG to a bitmap at its layout size, and an
-      // 8×-screen bitmap exceeds RecordingCanvas's per-draw byte limit. The
-      // inner View is 1× screen with a counter-scale of 8 so the bitmap stays
-      // small while the composed visible scale (1/8 × 8 = 1) is unchanged.
+      // crisp under pinch zoom (see useAnimatedGalleryStyle). rn-svg on
+      // Android rasterizes the SVG to a bitmap at its layout size and an
+      // 8x screen bitmap exceeds RecordingCanvas's per draw byte limit. The
+      // inner SvgAwareImage is sized at 1x screen with a counter scale of 8 so
+      // the bitmap stays small while the composed visible scale (1/8 × 8 === 1)
+      // is unchanged.
       return (
         <Animated.View
           accessibilityLabel={accessibilityLabel}
           style={[...animatedStyles, style, styles.svgOuter]}
         >
-          <View style={[{ height: screenHeight, width: screenWidth }, styles.svgInner]}>
-            <SvgUri height='100%' uri={uri} width='100%' />
-          </View>
+          <SvgAwareImage
+            source={{ uri }}
+            style={[{ height: screenHeight, width: screenWidth }, styles.svgInner]}
+          />
         </Animated.View>
       );
     }

--- a/package/src/components/ImageGallery/components/AnimatedGalleryImage.tsx
+++ b/package/src/components/ImageGallery/components/AnimatedGalleryImage.tsx
@@ -7,12 +7,12 @@ import { SvgUri } from 'react-native-svg';
 import { useChatConfigContext } from '../../../contexts/chatConfigContext/ChatConfigContext';
 import { useImageGalleryContext } from '../../../contexts/imageGalleryContext/ImageGalleryContext';
 import { useStateStore } from '../../../hooks';
+import { useIsSvg } from '../../../hooks/useIsSvg';
 import {
   ImageGalleryAsset,
   ImageGalleryState,
 } from '../../../state-store/image-gallery-state-store';
 import { getResizedImageUrl } from '../../../utils/getResizedImageUrl';
-import { isSvgUri } from '../../UIComponents/SvgAwareImage';
 import { useAnimatedGalleryStyle } from '../hooks/useAnimatedGalleryStyle';
 
 const oneEighth = 1 / 8;
@@ -61,6 +61,7 @@ export const AnimatedGalleryImage = React.memo(
       });
     }, [photo.uri, resizableCDNHosts, screenHeight, screenWidth]);
 
+    const isSvg = useIsSvg(uri);
     const selected = currentIndex === index;
     const previous = currentIndex > index;
     const shouldRender = Math.abs(currentIndex - index) < 4;
@@ -85,7 +86,7 @@ export const AnimatedGalleryImage = React.memo(
       return <View style={[style, { transform: [{ scale: oneEighth }] }]} />;
     }
 
-    if (isSvgUri(uri)) {
+    if (isSvg) {
       // The outer Animated.View is sized at 8× screen so raster images stay
       // crisp under pinch-zoom (see useAnimatedGalleryStyle). rn-svg on
       // Android rasterizes the SVG to a bitmap at its layout size, and an

--- a/package/src/components/ImageGallery/components/AnimatedGalleryImage.tsx
+++ b/package/src/components/ImageGallery/components/AnimatedGalleryImage.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import type { ImageStyle, StyleProp } from 'react-native';
 import Animated, { SharedValue } from 'react-native-reanimated';
+import { SvgUri } from 'react-native-svg';
 
 import { useChatConfigContext } from '../../../contexts/chatConfigContext/ChatConfigContext';
 import { useImageGalleryContext } from '../../../contexts/imageGalleryContext/ImageGalleryContext';
@@ -11,6 +12,7 @@ import {
   ImageGalleryState,
 } from '../../../state-store/image-gallery-state-store';
 import { getResizedImageUrl } from '../../../utils/getResizedImageUrl';
+import { isSvgUri } from '../../UIComponents/SvgAwareImage';
 import { useAnimatedGalleryStyle } from '../hooks/useAnimatedGalleryStyle';
 
 const oneEighth = 1 / 8;
@@ -83,6 +85,25 @@ export const AnimatedGalleryImage = React.memo(
       return <View style={[style, { transform: [{ scale: oneEighth }] }]} />;
     }
 
+    if (isSvgUri(uri)) {
+      // The outer Animated.View is sized at 8× screen so raster images stay
+      // crisp under pinch-zoom (see useAnimatedGalleryStyle). rn-svg on
+      // Android rasterizes the SVG to a bitmap at its layout size, and an
+      // 8×-screen bitmap exceeds RecordingCanvas's per-draw byte limit. The
+      // inner View is 1× screen with a counter-scale of 8 so the bitmap stays
+      // small while the composed visible scale (1/8 × 8 = 1) is unchanged.
+      return (
+        <Animated.View
+          accessibilityLabel={accessibilityLabel}
+          style={[...animatedStyles, style, styles.svgOuter]}
+        >
+          <View style={[{ height: screenHeight, width: screenWidth }, styles.svgInner]}>
+            <SvgUri height='100%' uri={uri} width='100%' />
+          </View>
+        </Animated.View>
+      );
+    }
+
     return (
       <Animated.Image
         accessibilityLabel={accessibilityLabel}
@@ -106,3 +127,13 @@ export const AnimatedGalleryImage = React.memo(
 );
 
 AnimatedGalleryImage.displayName = 'AnimatedGalleryImage';
+
+const styles = StyleSheet.create({
+  svgInner: {
+    transform: [{ scale: 8 }],
+  },
+  svgOuter: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/package/src/components/ImageGallery/components/ImageGrid.tsx
+++ b/package/src/components/ImageGallery/components/ImageGrid.tsx
@@ -1,13 +1,10 @@
 import React, { useMemo } from 'react';
 import { Image, Pressable, StyleSheet, View } from 'react-native';
 
-import { SvgUri } from 'react-native-svg';
-
 import type { ImageGalleryGridProps } from './types';
 
 import { useImageGalleryContext } from '../../../contexts/imageGalleryContext/ImageGalleryContextBase';
 import { useTheme } from '../../../contexts/themeContext/ThemeContext';
-import { useIsSvg } from '../../../hooks/useIsSvg';
 import { useStateStore } from '../../../hooks/useStateStore';
 import { useViewport } from '../../../hooks/useViewport';
 import type {
@@ -18,6 +15,7 @@ import { primitives } from '../../../theme';
 import { FileTypes } from '../../../types/types';
 import { VideoPlayIndicator } from '../../ui/VideoPlayIndicator';
 import { StreamBottomSheetModalFlatList } from '../../UIComponents/StreamBottomSheetModalFlatList';
+import { SvgAwareImage } from '../../UIComponents/SvgAwareImage';
 
 export type ImageGalleryGridImageComponent = ({
   item,
@@ -39,7 +37,6 @@ const GridImage = ({ item }: { item: GridImageItem }) => {
   const { ...restItem } = item;
 
   const { numberOfImageGalleryGridColumns, selectAndClose, thumb_url, type, uri } = restItem;
-  const isSvg = useIsSvg(uri);
 
   const size = vw(100) / (numberOfImageGalleryGridColumns || 3) - 2;
 
@@ -52,12 +49,8 @@ const GridImage = ({ item }: { item: GridImageItem }) => {
             <VideoPlayIndicator size='md' />
           </View>
         </View>
-      ) : isSvg ? (
-        <View style={[styles.image, { height: size, width: size }]}>
-          <SvgUri height='100%' uri={uri} width='100%' />
-        </View>
       ) : (
-        <Image source={{ uri }} style={[styles.image, { height: size, width: size }]} />
+        <SvgAwareImage source={{ uri }} style={[styles.image, { height: size, width: size }]} />
       )}
     </Pressable>
   );

--- a/package/src/components/ImageGallery/components/ImageGrid.tsx
+++ b/package/src/components/ImageGallery/components/ImageGrid.tsx
@@ -5,7 +5,6 @@ import { SvgUri } from 'react-native-svg';
 
 import type { ImageGalleryGridProps } from './types';
 
-import { VideoThumbnail } from '../../../components/Attachment/VideoThumbnail';
 import { useImageGalleryContext } from '../../../contexts/imageGalleryContext/ImageGalleryContextBase';
 import { useTheme } from '../../../contexts/themeContext/ThemeContext';
 import { useIsSvg } from '../../../hooks/useIsSvg';
@@ -17,6 +16,7 @@ import type {
 } from '../../../state-store/image-gallery-state-store';
 import { primitives } from '../../../theme';
 import { FileTypes } from '../../../types/types';
+import { VideoPlayIndicator } from '../../ui/VideoPlayIndicator';
 import { StreamBottomSheetModalFlatList } from '../../UIComponents/StreamBottomSheetModalFlatList';
 
 export type ImageGalleryGridImageComponent = ({
@@ -46,8 +46,11 @@ const GridImage = ({ item }: { item: GridImageItem }) => {
   return (
     <Pressable accessibilityLabel='Grid Image' onPress={selectAndClose}>
       {type === FileTypes.Video ? (
-        <View style={[styles.image, { height: size, width: size }]}>
-          <VideoThumbnail thumb_url={thumb_url} />
+        <View style={[styles.image, { height: size, width: size }, styles.videoCell]}>
+          {thumb_url ? <Image source={{ uri: thumb_url }} style={StyleSheet.absoluteFill} /> : null}
+          <View pointerEvents='none' style={[StyleSheet.absoluteFill, styles.playIndicator]}>
+            <VideoPlayIndicator size='md' />
+          </View>
         </View>
       ) : isSvg ? (
         <View style={[styles.image, { height: size, width: size }]}>
@@ -122,6 +125,13 @@ const useStyles = () => {
         ...contentContainer,
       },
       image: { margin: 1, ...gridImage },
+      playIndicator: {
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+      videoCell: {
+        overflow: 'hidden',
+      },
     });
   }, [contentContainer, gridImage, semantics]);
 };

--- a/package/src/components/ImageGallery/components/ImageGrid.tsx
+++ b/package/src/components/ImageGallery/components/ImageGrid.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo } from 'react';
-import { Image, Pressable, StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 
 import type { ImageGalleryGridProps } from './types';
 
 import { VideoThumbnail } from '../../../components/Attachment/VideoThumbnail';
+import { useComponentsContext } from '../../../contexts/componentsContext/ComponentsContext';
 import { useImageGalleryContext } from '../../../contexts/imageGalleryContext/ImageGalleryContextBase';
 import { useTheme } from '../../../contexts/themeContext/ThemeContext';
 import { useStateStore } from '../../../hooks/useStateStore';
@@ -33,6 +34,7 @@ export type GridImageItem = ImageGalleryAsset & {
 const GridImage = ({ item }: { item: GridImageItem }) => {
   const styles = useStyles();
   const { vw } = useViewport();
+  const { ImageComponent } = useComponentsContext();
   const { ...restItem } = item;
 
   const { numberOfImageGalleryGridColumns, selectAndClose, thumb_url, type, uri } = restItem;
@@ -46,7 +48,7 @@ const GridImage = ({ item }: { item: GridImageItem }) => {
           <VideoThumbnail thumb_url={thumb_url} />
         </View>
       ) : (
-        <Image source={{ uri }} style={[styles.image, { height: size, width: size }]} />
+        <ImageComponent source={{ uri }} style={[styles.image, { height: size, width: size }]} />
       )}
     </Pressable>
   );

--- a/package/src/components/ImageGallery/components/ImageGrid.tsx
+++ b/package/src/components/ImageGallery/components/ImageGrid.tsx
@@ -1,12 +1,14 @@
 import React, { useMemo } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { Image, Pressable, StyleSheet, View } from 'react-native';
+
+import { SvgUri } from 'react-native-svg';
 
 import type { ImageGalleryGridProps } from './types';
 
 import { VideoThumbnail } from '../../../components/Attachment/VideoThumbnail';
-import { useComponentsContext } from '../../../contexts/componentsContext/ComponentsContext';
 import { useImageGalleryContext } from '../../../contexts/imageGalleryContext/ImageGalleryContextBase';
 import { useTheme } from '../../../contexts/themeContext/ThemeContext';
+import { useIsSvg } from '../../../hooks/useIsSvg';
 import { useStateStore } from '../../../hooks/useStateStore';
 import { useViewport } from '../../../hooks/useViewport';
 import type {
@@ -34,10 +36,10 @@ export type GridImageItem = ImageGalleryAsset & {
 const GridImage = ({ item }: { item: GridImageItem }) => {
   const styles = useStyles();
   const { vw } = useViewport();
-  const { ImageComponent } = useComponentsContext();
   const { ...restItem } = item;
 
   const { numberOfImageGalleryGridColumns, selectAndClose, thumb_url, type, uri } = restItem;
+  const isSvg = useIsSvg(uri);
 
   const size = vw(100) / (numberOfImageGalleryGridColumns || 3) - 2;
 
@@ -47,8 +49,12 @@ const GridImage = ({ item }: { item: GridImageItem }) => {
         <View style={[styles.image, { height: size, width: size }]}>
           <VideoThumbnail thumb_url={thumb_url} />
         </View>
+      ) : isSvg ? (
+        <View style={[styles.image, { height: size, width: size }]}>
+          <SvgUri height='100%' uri={uri} width='100%' />
+        </View>
       ) : (
-        <ImageComponent source={{ uri }} style={[styles.image, { height: size, width: size }]} />
+        <Image source={{ uri }} style={[styles.image, { height: size, width: size }]} />
       )}
     </Pressable>
   );

--- a/package/src/components/MessageInput/components/AttachmentPreview/ImageAttachmentUploadPreview.tsx
+++ b/package/src/components/MessageInput/components/AttachmentPreview/ImageAttachmentUploadPreview.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
-import { Image, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import { LocalImageAttachment } from 'stream-chat';
 
@@ -26,6 +26,7 @@ export const ImageAttachmentUploadPreview = ({
   const [loading, setLoading] = useState(true);
   const { allowSendBeforeAttachmentsUpload } = useMessageInputContext();
   const {
+    ImageComponent,
     ImageLoadingIndicator,
     ImageUploadInProgressIndicator,
     ImageUploadRetryIndicator,
@@ -67,7 +68,7 @@ export const ImageAttachmentUploadPreview = ({
   return (
     <View style={[styles.wrapper, wrapper]} testID={'image-attachment-upload-preview'}>
       <View style={[styles.image, upload]}>
-        <Image
+        <ImageComponent
           onError={onErrorHandler}
           onLoadEnd={onLoadEndHandler}
           source={{ uri: previewUri }}

--- a/package/src/components/UIComponents/SvgAwareImage.tsx
+++ b/package/src/components/UIComponents/SvgAwareImage.tsx
@@ -1,33 +1,15 @@
 import React from 'react';
-import { Image, ImageProps, ImageURISource, View } from 'react-native';
+import { Image, ImageProps, View } from 'react-native';
 
 import { SvgUri } from 'react-native-svg';
 
-/**
- * Returns true if `uri` points to an SVG (either by `.svg` extension or by
- * `image/svg+xml` data-URI prefix). Exported so other surfaces (e.g. the
- * fullscreen image gallery) can branch on SVG without re-implementing the
- * detection.
- */
-export const isSvgUri = (uri: string | null | undefined): boolean => {
-  if (typeof uri !== 'string' || uri.length === 0) {
-    return false;
-  }
-  const lower = uri.toLowerCase();
-  if (lower.startsWith('data:image/svg+xml')) {
-    return true;
-  }
-  const pathOnly = lower.split('#')[0].split('?')[0];
-  return pathOnly.endsWith('.svg');
-};
+import { useIsSvg } from '../../hooks/useIsSvg';
 
-const getSvgRemoteUri = (source: ImageProps['source']): string | null => {
+const getSourceUri = (source: ImageProps['source']): string | undefined => {
   if (!source || typeof source !== 'object' || Array.isArray(source)) {
-    return null;
+    return undefined;
   }
-
-  const { uri } = source as ImageURISource;
-  return isSvgUri(uri) ? (uri as string) : null;
+  return source.uri;
 };
 
 /**
@@ -38,9 +20,10 @@ const getSvgRemoteUri = (source: ImageProps['source']): string | null => {
  * responsible for SVG handling in their override.
  */
 export const SvgAwareImage = (props: ImageProps) => {
-  const svgUri = getSvgRemoteUri(props.source);
+  const uri = getSourceUri(props.source);
+  const isSvg = useIsSvg(uri);
 
-  if (!svgUri) {
+  if (!isSvg || !uri) {
     return <Image {...props} />;
   }
 
@@ -58,7 +41,7 @@ export const SvgAwareImage = (props: ImageProps) => {
           onLoad?.({} as never);
           onLoadEnd?.();
         }}
-        uri={svgUri}
+        uri={uri}
         width='100%'
       />
     </View>

--- a/package/src/components/UIComponents/SvgAwareImage.tsx
+++ b/package/src/components/UIComponents/SvgAwareImage.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Image, ImageProps, ImageURISource, View } from 'react-native';
+
+import { SvgUri } from 'react-native-svg';
+
+/**
+ * Returns true if `uri` points to an SVG (either by `.svg` extension or by
+ * `image/svg+xml` data-URI prefix). Exported so other surfaces (e.g. the
+ * fullscreen image gallery) can branch on SVG without re-implementing the
+ * detection.
+ */
+export const isSvgUri = (uri: string | null | undefined): boolean => {
+  if (typeof uri !== 'string' || uri.length === 0) {
+    return false;
+  }
+  const lower = uri.toLowerCase();
+  if (lower.startsWith('data:image/svg+xml')) {
+    return true;
+  }
+  const pathOnly = lower.split('#')[0].split('?')[0];
+  return pathOnly.endsWith('.svg');
+};
+
+const getSvgRemoteUri = (source: ImageProps['source']): string | null => {
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    return null;
+  }
+
+  const { uri } = source as ImageURISource;
+  return isSvgUri(uri) ? (uri as string) : null;
+};
+
+/**
+ * Default `ImageComponent` for the SDK. Behaves exactly like RN's `Image` for
+ * raster sources, but transparently renders SVG URIs (`.svg`, `image/svg+xml`
+ * data URIs) via `SvgUri` from `react-native-svg`. Integrators who override
+ * `ImageComponent` with a custom image library (e.g. FastImage) are
+ * responsible for SVG handling in their override.
+ */
+export const SvgAwareImage = (props: ImageProps) => {
+  const svgUri = getSvgRemoteUri(props.source);
+
+  if (!svgUri) {
+    return <Image {...props} />;
+  }
+
+  const { accessibilityLabel, onError, onLoad, onLoadEnd, style, testID } = props;
+
+  return (
+    <View accessibilityLabel={accessibilityLabel} style={style} testID={testID}>
+      <SvgUri
+        height='100%'
+        onError={(error) => {
+          onError?.({ nativeEvent: { error } } as never);
+          onLoadEnd?.();
+        }}
+        onLoad={() => {
+          onLoad?.({} as never);
+          onLoadEnd?.();
+        }}
+        uri={svgUri}
+        width='100%'
+      />
+    </View>
+  );
+};

--- a/package/src/components/UIComponents/index.ts
+++ b/package/src/components/UIComponents/index.ts
@@ -1,6 +1,7 @@
 export * from './BottomSheetModal';
 export * from './StreamBottomSheetModalFlatList';
 export * from './ImageBackground';
+export * from './SvgAwareImage';
 export * from './Spinner';
 export * from './SwipableWrapper';
 export * from './PortalWhileClosingView';

--- a/package/src/components/index.ts
+++ b/package/src/components/index.ts
@@ -188,6 +188,7 @@ export * from './ui';
 export * from './UIComponents/BottomSheetModal';
 export * from './UIComponents/StreamBottomSheetModalFlatList';
 export * from './UIComponents/ImageBackground';
+export * from './UIComponents/SvgAwareImage';
 export * from './UIComponents/Spinner';
 export * from './UIComponents/SwipableWrapper';
 export * from './UIComponents/PortalWhileClosingView';

--- a/package/src/contexts/componentsContext/defaultComponents.ts
+++ b/package/src/contexts/componentsContext/defaultComponents.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, ImageProps, TextInputProps } from 'react-native';
+import { TextInputProps } from 'react-native';
 
 import type { LocalMessage, UserResponse } from 'stream-chat';
 
@@ -149,6 +149,7 @@ import { ThreadListItemMessagePreview } from '../../components/ThreadList/Thread
 import { ThreadListUnreadBanner } from '../../components/ThreadList/ThreadListUnreadBanner';
 import { ThreadMessagePreviewDeliveryStatus } from '../../components/ThreadList/ThreadMessagePreviewDeliveryStatus';
 import { ChannelAvatar } from '../../components/ui/Avatar/ChannelAvatar';
+import { SvgAwareImage } from '../../components/UIComponents/SvgAwareImage';
 import { DefaultMessageOverlayBackground } from '../../contexts/overlayContext/MessageOverlayHostLayer';
 import type { MessageActionsProps } from '../../contexts/overlayContext/MessageOverlayHostLayer';
 
@@ -317,7 +318,7 @@ const components = {
   MessageOverlayBackground: DefaultMessageOverlayBackground,
 
   // Image
-  ImageComponent: Image as React.ComponentType<ImageProps>,
+  ImageComponent: SvgAwareImage,
 };
 
 /**

--- a/package/src/hooks/index.ts
+++ b/package/src/hooks/index.ts
@@ -7,6 +7,7 @@ export * from './useStateStore';
 export * from './usePendingAttachmentUpload';
 export * from './useStableCallback';
 export * from './useLoadingImage';
+export * from './useIsSvg';
 export * from './useMessageReminder';
 export * from './useQueryReminders';
 export * from './useAfterKeyboardOpenCallback';

--- a/package/src/hooks/useIsSvg.ts
+++ b/package/src/hooks/useIsSvg.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+
+/**
+ * Returns true if `uri` points to an SVG (either by `.svg` extension or by
+ * `image/svg+xml` data-URI prefix). Exported as a pure function for non-React
+ * callers; React components should prefer `useIsSvg` so the check is memoized
+ * per URI.
+ */
+export const isSvgUri = (uri: string | null | undefined): boolean => {
+  if (typeof uri !== 'string' || uri.length === 0) {
+    return false;
+  }
+  const lower = uri.toLowerCase();
+  if (lower.startsWith('data:image/svg+xml')) {
+    return true;
+  }
+  const pathOnly = lower.split('#')[0].split('?')[0];
+  return pathOnly.endsWith('.svg');
+};
+
+/**
+ * Memoized variant of `isSvgUri`. Re-runs the string check only when `uri`
+ * actually changes — useful in hot render paths like the gallery where the
+ * surrounding component re-renders frequently (animated styles, swipe state)
+ * but the URI is stable.
+ */
+export const useIsSvg = (uri: string | null | undefined): boolean =>
+  useMemo(() => isSvgUri(uri), [uri]);


### PR DESCRIPTION
## 🎯 Goal

This PR provides SVG image awareness to our default `Image` rendering component. Historically, we've never supported SVG rendering within the `ImageGallery`, message images as well as the `ImageGrid`. This PR should address that. 

The default component used for `ImageComponent` is now `SvgAwareImage` from the SDK. This should of course be non-breaking as it doesn't affect rendering at all. 

Unfortunately, not all places could default to using `ImageComponent`, specifically `AnimatedGalleryImage.tsx` and the images within `ImageGrid.tsx`. The reason behind this is the fact that also historically, we've only used `ImageComponent` within the confines of the `Chat` component. This means that some integrations might actually depend on this in respect to rendering the `ImageComponent` itself (a popular usecase would be to `useChatContext` to know if we're offline or not, for example). Since the gallery still lives typically outside of `Chat`, we can't safely move this up there without breaking various integrations. This will be addressed in the next major version for sure and is now on my radar.

And last, but not least, this PR addresses a similar issue where opening the `ImageGrid` with videos would crash. The reason is of course the usage of `LoadingImage`, which also assumes it lives within `Chat`. 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


