### PR TITLE
fix: autoscrolling while ctx menu is active

### DIFF
--- a/package/src/components/MessageList/MessageFlashList.tsx
+++ b/package/src/components/MessageList/MessageFlashList.tsx
@@ -55,7 +55,7 @@ import { mergeThemes, useTheme } from '../../contexts/themeContext/ThemeContext'
 import { ThreadContextValue, useThreadContext } from '../../contexts/threadContext/ThreadContext';
 
 import { useStableCallback, useStateStore } from '../../hooks';
-import { bumpOverlayLayoutRevision } from '../../state-store';
+import { bumpOverlayLayoutRevision, useHasActiveId } from '../../state-store';
 import { MessageInputHeightState } from '../../state-store/message-input-height-store';
 import { primitives } from '../../theme';
 import { transitions } from '../../utils/animations/transitions';
@@ -400,13 +400,18 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
     }
   }, [autoscrollToRecent, hasPendingInitialTargetLoad]);
 
+  // While the message overlay is open we suppress autoscroll-to-recent so that
+  // incoming messages do not shift visible content and invalidate the overlay's
+  // anchored geometry. Content anchoring (startRenderingFromBottom) stays on.
+  const isOverlayOpen = useHasActiveId();
+
   const maintainVisibleContentPosition = useMemo(() => {
     return {
       animateAutoscrollToBottom: true,
-      autoscrollToBottomThreshold: autoscrollToRecent ? 1 : undefined,
+      autoscrollToBottomThreshold: autoscrollToRecent && !isOverlayOpen ? 1 : undefined,
       startRenderingFromBottom: true,
     };
-  }, [autoscrollToRecent]);
+  }, [isOverlayOpen, autoscrollToRecent]);
 
   useEffect(() => {
     if (disabled) {

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -68,7 +68,7 @@ import { ThreadContextValue, useThreadContext } from '../../contexts/threadConte
 
 import { useStableCallback } from '../../hooks';
 import { useStateStore } from '../../hooks/useStateStore';
-import { bumpOverlayLayoutRevision } from '../../state-store';
+import { bumpOverlayLayoutRevision, useHasActiveId } from '../../state-store';
 import { MessageInputHeightState } from '../../state-store/message-input-height-store';
 import { primitives } from '../../theme';
 import { transitions } from '../../utils/animations/transitions';
@@ -440,7 +440,13 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
 
   const minIndexForVisible = Math.min(1, processedMessageList.length);
 
-  const autoscrollToTopThreshold = autoscrollToRecent ? (isLiveStreaming ? 300 : 10) : undefined;
+  // While the message overlay is open we suppress autoscroll-to-recent so that
+  // incoming messages do not shift visible content and invalidate the overlay's
+  // anchored geometry. Content anchoring (minIndexForVisible) stays on.
+  const isOverlayOpen = useHasActiveId();
+
+  const autoscrollToTopThreshold =
+    autoscrollToRecent && !isOverlayOpen ? (isLiveStreaming ? 300 : 10) : undefined;
 
   const maintainVisibleContentPosition = useMemo(
     () => ({


### PR DESCRIPTION
## 🎯 Goal

This PR addresses an issue with autoscrolling behaviour with our context menu, where view positioning would be offset if we have the context menu open and we receive new messages (and are near the bottom). 

Typically, since the `Message` position would change the context menu would not really have the correct position to crawl back to when we want to animate back. While this can be easily solved through another correction `SharedValue` (in order to simply adjust positioning), it is in fact not so trivial to solve the fact that if we receive enough messages (i.e anything past the virtualization window of `FlatList` or even worse,  enforcing recycling for `FlashList`) it is very possible that the `Message` we have in the context menu would either be unmounted (or again worse, recycled) and the `Portal` would detach from its host. This is very possible within a livestream scenario, for example - where it's not uncommon to receive 10s or 100s of messages in a relatively short timespan.

Instead, we simply disable autoscrolling when the context menu is opened. This is still performant because internally, even though a prop changed `FlatList` is going to simply disable autoscrolling native side rather than do heavy rerendering internally (basically just the shell). This works similarly for `FlashList` as well. 

This generally makes sense from a UX perspective as well, as typically when we want to do a message action we don't particularly want to lose the context of that message's surroundings either (this is how Twitch chat does it as well, for example). 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


](https://github.com/GetStream/stream-chat-react-native/issues)` `