### PR TITLE
fix: switch to `npm` actions with `--no-workspaces`

### DIFF
--- a/package/bin/before-tag.sh
+++ b/package/bin/before-tag.sh
@@ -11,12 +11,12 @@ PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $
 PACKAGE_VERSION_WITHOUT_SHA=$(echo "$PACKAGE_VERSION" | cut -d"+" -f1)
 
 cd native-package
-npm version --allow-same-version --no-git-tag-version "$PACKAGE_VERSION_WITHOUT_SHA"
+npm version --no-workspaces --allow-same-version --no-git-tag-version "$PACKAGE_VERSION_WITHOUT_SHA"
 sed -e 's|"stream-chat-react-native-core": "[^"]*"|"stream-chat-react-native-core": "'"$PACKAGE_VERSION_WITHOUT_SHA"'"|g' -i.bak package.json
 rm package.json.bak
 
 cd ../expo-package
-npm version --allow-same-version --no-git-tag-version "$PACKAGE_VERSION_WITHOUT_SHA"
+npm version --no-workspaces --allow-same-version --no-git-tag-version "$PACKAGE_VERSION_WITHOUT_SHA"
 sed -e 's|"stream-chat-react-native-core": "[^"]*"|"stream-chat-react-native-core": "'"$PACKAGE_VERSION_WITHOUT_SHA"'"|g' -i.bak package.json
 rm package.json.bak
 cd ..
@@ -26,6 +26,3 @@ rm src/version.json.bak
 
 git add {expo,native}-package/package.json
 git add src/version.json
-
-git add expo-package/yarn.lock
-git add native-package/yarn.lock

--- a/package/bin/release.sh
+++ b/package/bin/release.sh
@@ -11,16 +11,16 @@ PACKAGE_TAG=$(sed 's/.*-\(.*\)\..*/\1/' <<< "$PACKAGE_VERSION")
 # If tag === version it means that its not a prerelease and shouuld set things to latest
 if [[ "${PACKAGE_TAG}" != "${PACKAGE_VERSION}" ]]; then
     cd native-package
-    npm publish --tag="$PACKAGE_TAG"
+    npm publish --no-workspaces --tag="$PACKAGE_TAG"
 
     cd ../expo-package
-    npm publish --tag="$PACKAGE_TAG"
+    npm publish --no-workspaces --tag="$PACKAGE_TAG"
 else
     cd native-package
-    npm publish
+    npm publish --no-workspaces
 
     cd ../expo-package
-    npm publish
+    npm publish --no-workspaces
 fi
 
 

--- a/release/release.config.js
+++ b/release/release.config.js
@@ -72,9 +72,21 @@ module.exports = Promise.resolve().then(() => {
       },
     ],
     [
-      '@semantic-release/npm',
+      '@semantic-release/exec',
       {
-        npmPublish: isSDK,
+        // Bump the version (which also runs the `version` script, before-tag.sh)
+        // with --no-workspaces so npm doesn't try to reify the Yarn workspace
+        // tree — npm can't parse Yarn's workspace:/patch: protocols.
+        prepareCmd:
+          'npm version ${nextRelease.version} --no-workspaces --no-git-tag-version --allow-same-version',
+        // Only the SDK publishes to npm. Publishing core triggers its
+        // prepublishOnly hook (before-tag.sh && release.sh), which in turn
+        // publishes native-package and expo-package.
+        ...(isSDK
+          ? {
+              publishCmd: 'npm publish --no-workspaces --tag ${nextRelease.channel || "latest"}',
+            }
+          : {}),
       },
     ],
   ];


### PR DESCRIPTION
## 🎯 Goal

This PR should address the release process issues we introduced with the Yarn Berry implementation.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


