### PR TITLE
perf: short circuit removal of redundant views

### DIFF
--- a/package/src/components/Message/MessageItemView/MessageAuthor.tsx
+++ b/package/src/components/Message/MessageItemView/MessageAuthor.tsx
@@ -27,6 +27,13 @@ const MessageAuthorWithContext = (props: MessageAuthorPropsWithContext) => {
 
   const visible = typeof showAvatar === 'boolean' ? showAvatar : lastGroupMessage;
 
+  // TODO (next major): this wrapper View is a perf cost we'd like to remove (row weight
+  // reduction). It can't be dropped without a breaking change: its `style` is the public
+  // `theme.messageItemView.authorWrapper.container` override hook, and it anchors the
+  // `message-author` testID. The not visible branch's spacer also can't be removed - it
+  // reserves the avatar column so grouped (non-last) received messages stay aligned.
+  // Revisit when we can change UserAvatar's API (testID + wrapper-style props) and accept
+  // the theme API break.
   return (
     <View style={container} testID='message-author'>
       {visible && message.user ? (

--- a/package/src/components/Message/MessageItemView/MessageItemView.tsx
+++ b/package/src/components/Message/MessageItemView/MessageItemView.tsx
@@ -212,6 +212,7 @@ export type MessageItemViewPropsWithContext = Pick<
   | 'lastGroupMessage'
   | 'contextMenuAnchorRef'
   | 'members'
+  | 'threadList'
 > &
   Pick<
     MessagesContextValue,
@@ -243,6 +244,7 @@ const MessageItemViewWithContext = (props: MessageItemViewPropsWithContext) => {
     reactionListPosition,
     reactionListType,
     setQuotedMessage,
+    threadList,
   } = props;
   const {
     MessageAuthor,
@@ -357,9 +359,11 @@ const MessageItemViewWithContext = (props: MessageItemViewPropsWithContext) => {
             </View>
           </View>
 
-          <View style={styles.repliesContainer}>
-            <MessageReplies />
-          </View>
+          {!threadList && !!message.reply_count ? (
+            <View style={styles.repliesContainer}>
+              <MessageReplies />
+            </View>
+          ) : null}
 
           {reactionListPosition === 'bottom' && ReactionListBottom ? (
             <ReactionListBottom type={reactionListType} />
@@ -526,6 +530,7 @@ export const MessageItemView = (props: MessageItemViewProps) => {
     setQuotedMessage,
     lastGroupMessage,
     members,
+    threadList,
   } = useMessageContext();
 
   const {
@@ -560,6 +565,7 @@ export const MessageItemView = (props: MessageItemViewProps) => {
         setQuotedMessage,
         lastGroupMessage,
         members,
+        threadList,
       }}
       {...props}
     />

--- a/package/src/components/Message/MessageItemView/MessageWrapper.tsx
+++ b/package/src/components/Message/MessageItemView/MessageWrapper.tsx
@@ -114,16 +114,14 @@ export const MessageWrapper = React.memo((props: MessageWrapperProps) => {
         <MessageSystem message={message} style={messageContainer} />
       ) : wrapMessageInTheme ? (
         <ThemeProvider mergedStyle={modifiedTheme}>
-          <View testID={`message-list-item-${message.id}`}>
-            {renderDateSeperator}
-            {renderMessage}
-          </View>
-        </ThemeProvider>
-      ) : (
-        <View testID={`message-list-item-${message.id}`}>
           {renderDateSeperator}
           {renderMessage}
-        </View>
+        </ThemeProvider>
+      ) : (
+        <>
+          {renderDateSeperator}
+          {renderMessage}
+        </>
       )}
       {showUnreadUnderlay && (
         <View style={styles.unreadUnderlayContainer}>

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.tsx.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.tsx.snap
@@ -589,14 +589,6 @@ exports[`Thread should match thread snapshot 1`] = `
                           </View>
                           <View
                             style={
-                              {
-                                "marginTop": -4,
-                                "zIndex": 0,
-                              }
-                            }
-                          />
-                          <View
-                            style={
                               [
                                 {
                                   "alignItems": "center",
@@ -927,14 +919,6 @@ exports[`Thread should match thread snapshot 1`] = `
                               </View>
                             </View>
                           </View>
-                          <View
-                            style={
-                              {
-                                "marginTop": -4,
-                                "zIndex": 0,
-                              }
-                            }
-                          />
                           <View
                             style={
                               [
@@ -1302,14 +1286,6 @@ exports[`Thread should match thread snapshot 1`] = `
                           </View>
                           <View
                             style={
-                              {
-                                "marginTop": -4,
-                                "zIndex": 0,
-                              }
-                            }
-                          />
-                          <View
-                            style={
                               [
                                 {
                                   "alignItems": "center",
@@ -1634,14 +1610,6 @@ exports[`Thread should match thread snapshot 1`] = `
                               </View>
                             </View>
                           </View>
-                          <View
-                            style={
-                              {
-                                "marginTop": -4,
-                                "zIndex": 0,
-                              }
-                            }
-                          />
                           <View
                             style={
                               [

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.tsx.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.tsx.snap
@@ -330,325 +330,321 @@ exports[`Thread should match thread snapshot 1`] = `
               testID="message-list-item-38ef6f7c-3090-5759-a37f-ab0053aadb96"
             >
               <View
-                testID="message-list-item-38ef6f7c-3090-5759-a37f-ab0053aadb96"
-              >
-                <View
-                  style={
+                style={
+                  [
                     [
-                      [
-                        {},
-                      ],
-                      {
-                        "paddingHorizontal": 16,
-                      },
-                    ]
-                  }
-                  testID="message-wrapper"
-                >
-                  <View />
-                  <View>
+                      {},
+                    ],
+                    {
+                      "paddingHorizontal": 16,
+                    },
+                  ]
+                }
+                testID="message-wrapper"
+              >
+                <View />
+                <View>
+                  <View
+                    collapsable={false}
+                  >
                     <View
                       collapsable={false}
+                      hitSlop={
+                        {
+                          "left": 750,
+                          "right": 750,
+                        }
+                      }
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "zIndex": 1,
+                        }
+                      }
                     >
                       <View
-                        collapsable={false}
-                        hitSlop={
-                          {
-                            "left": 750,
-                            "right": 750,
-                          }
-                        }
+                        pointerEvents="box-none"
                         style={
                           {
-                            "alignItems": "center",
+                            "alignItems": "flex-end",
                             "flexDirection": "row",
-                            "zIndex": 1,
+                            "gap": 8,
+                            "paddingVertical": 8,
+                            "width": "100%",
                           }
                         }
+                        testID="message-item-view-wrapper"
                       >
                         <View
-                          pointerEvents="box-none"
-                          style={
-                            {
-                              "alignItems": "flex-end",
-                              "flexDirection": "row",
-                              "gap": 8,
-                              "paddingVertical": 8,
-                              "width": "100%",
-                            }
-                          }
-                          testID="message-item-view-wrapper"
+                          style={{}}
+                          testID="message-author"
                         >
                           <View
-                            style={{}}
-                            testID="message-author"
+                            testID="user-avatar"
                           >
-                            <View
-                              testID="user-avatar"
-                            >
-                              <View
-                                style={
-                                  [
-                                    {
-                                      "alignItems": "center",
-                                      "borderRadius": 9999,
-                                      "justifyContent": "center",
-                                      "overflow": "hidden",
-                                    },
-                                    {
-                                      "height": 32,
-                                      "width": 32,
-                                    },
-                                    {
-                                      "backgroundColor": "#fcd579",
-                                    },
-                                    {
-                                      "borderColor": "rgba(26, 27, 37, 0.1)",
-                                      "borderWidth": 1,
-                                    },
-                                    undefined,
-                                  ]
-                                }
-                                testID="avatar-image"
-                              >
-                                <Image
-                                  accessibilityElementsHidden={true}
-                                  importantForAccessibility="no"
-                                  onError={[Function]}
-                                  source={
-                                    {
-                                      "uri": "https://i.imgur.com/LuuGvh0.png",
-                                    }
-                                  }
-                                  style={
-                                    [
-                                      {},
-                                      {
-                                        "height": 32,
-                                        "width": 32,
-                                      },
-                                    ]
-                                  }
-                                />
-                              </View>
-                            </View>
-                          </View>
-                          <View
-                            style={
-                              [
-                                {
-                                  "gap": 4,
-                                },
-                                {
-                                  "alignItems": "flex-start",
-                                },
-                                {},
-                              ]
-                            }
-                            testID="message-components"
-                          >
-                            <View
-                              style={
-                                {
-                                  "zIndex": 1,
-                                }
-                              }
-                            >
-                              <View
-                                style={
-                                  {
-                                    "alignSelf": "flex-end",
-                                  }
-                                }
-                              />
-                              <View
-                                style={
-                                  {
-                                    "alignSelf": "flex-start",
-                                  }
-                                }
-                              >
-                                <View
-                                  accessibilityState={
-                                    {
-                                      "busy": undefined,
-                                      "checked": undefined,
-                                      "disabled": undefined,
-                                      "expanded": undefined,
-                                      "selected": undefined,
-                                    }
-                                  }
-                                  accessibilityValue={
-                                    {
-                                      "max": undefined,
-                                      "min": undefined,
-                                      "now": undefined,
-                                      "text": undefined,
-                                    }
-                                  }
-                                  accessible={true}
-                                  collapsable={false}
-                                  focusable={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onResponderGrant={[Function]}
-                                  onResponderMove={[Function]}
-                                  onResponderRelease={[Function]}
-                                  onResponderTerminate={[Function]}
-                                  onResponderTerminationRequest={[Function]}
-                                  onStartShouldSetResponder={[Function]}
-                                  style={{}}
-                                >
-                                  <View
-                                    style={
-                                      [
-                                        {
-                                          "borderTopLeftRadius": 20,
-                                          "borderTopRightRadius": 20,
-                                          "borderWidth": 0,
-                                          "overflow": "hidden",
-                                        },
-                                        {
-                                          "backgroundColor": "#ebeef1",
-                                          "borderBottomLeftRadius": 0,
-                                          "borderBottomRightRadius": 20,
-                                        },
-                                        {},
-                                        {},
-                                        {},
-                                      ]
-                                    }
-                                    testID="message-content-wrapper"
-                                  >
-                                    <View
-                                      style={
-                                        [
-                                          {
-                                            "gap": 8,
-                                            "paddingBottom": 0,
-                                            "paddingHorizontal": 8,
-                                            "paddingTop": 0,
-                                          },
-                                          {},
-                                        ]
-                                      }
-                                    />
-                                    <View
-                                      style={
-                                        [
-                                          {
-                                            "maxWidth": 256,
-                                            "paddingHorizontal": 12,
-                                          },
-                                          {},
-                                          undefined,
-                                        ]
-                                      }
-                                      testID="message-text-container"
-                                    >
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "alignSelf": "stretch",
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <Text
-                                          style={
-                                            {
-                                              "alignItems": "flex-start",
-                                              "flexDirection": "row",
-                                              "flexWrap": "wrap",
-                                              "fontSize": 17,
-                                              "justifyContent": "flex-start",
-                                              "lineHeight": 20,
-                                              "marginBottom": 8,
-                                              "marginTop": 8,
-                                            }
-                                          }
-                                        >
-                                          <Text
-                                            style={
-                                              {
-                                                "color": "#1a1b25",
-                                                "fontSize": 17,
-                                                "lineHeight": 20,
-                                                "writingDirection": "ltr",
-                                              }
-                                            }
-                                          >
-                                            Message6
-                                          </Text>
-                                        </Text>
-                                      </View>
-                                    </View>
-                                  </View>
-                                </View>
-                              </View>
-                            </View>
-                            <View
-                              style={
-                                {
-                                  "marginTop": -4,
-                                  "zIndex": 0,
-                                }
-                              }
-                            />
                             <View
                               style={
                                 [
                                   {
                                     "alignItems": "center",
-                                    "flexDirection": "row",
-                                    "gap": 4,
+                                    "borderRadius": 9999,
                                     "justifyContent": "center",
-                                    "maxWidth": "100%",
-                                    "paddingVertical": 4,
+                                    "overflow": "hidden",
                                   },
-                                  {},
+                                  {
+                                    "height": 32,
+                                    "width": 32,
+                                  },
+                                  {
+                                    "backgroundColor": "#fcd579",
+                                  },
+                                  {
+                                    "borderColor": "rgba(26, 27, 37, 0.1)",
+                                    "borderWidth": 1,
+                                  },
+                                  undefined,
                                 ]
                               }
-                              testID="message-status-time"
+                              testID="avatar-image"
                             >
-                              <Text
+                              <Image
+                                accessibilityElementsHidden={true}
+                                importantForAccessibility="no"
+                                onError={[Function]}
+                                source={
+                                  {
+                                    "uri": "https://i.imgur.com/LuuGvh0.png",
+                                  }
+                                }
                                 style={
+                                  [
+                                    {},
+                                    {
+                                      "height": 32,
+                                      "width": 32,
+                                    },
+                                  ]
+                                }
+                              />
+                            </View>
+                          </View>
+                        </View>
+                        <View
+                          style={
+                            [
+                              {
+                                "gap": 4,
+                              },
+                              {
+                                "alignItems": "flex-start",
+                              },
+                              {},
+                            ]
+                          }
+                          testID="message-components"
+                        >
+                          <View
+                            style={
+                              {
+                                "zIndex": 1,
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "alignSelf": "flex-end",
+                                }
+                              }
+                            />
+                            <View
+                              style={
+                                {
+                                  "alignSelf": "flex-start",
+                                }
+                              }
+                            >
+                              <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={{}}
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "borderTopLeftRadius": 20,
+                                        "borderTopRightRadius": 20,
+                                        "borderWidth": 0,
+                                        "overflow": "hidden",
+                                      },
+                                      {
+                                        "backgroundColor": "#ebeef1",
+                                        "borderBottomLeftRadius": 0,
+                                        "borderBottomRightRadius": 20,
+                                      },
+                                      {},
+                                      {},
+                                      {},
+                                    ]
+                                  }
+                                  testID="message-content-wrapper"
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "gap": 8,
+                                          "paddingBottom": 0,
+                                          "paddingHorizontal": 8,
+                                          "paddingTop": 0,
+                                        },
+                                        {},
+                                      ]
+                                    }
+                                  />
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "maxWidth": 256,
+                                          "paddingHorizontal": 12,
+                                        },
+                                        {},
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="message-text-container"
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignSelf": "stretch",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "alignItems": "flex-start",
+                                            "flexDirection": "row",
+                                            "flexWrap": "wrap",
+                                            "fontSize": 17,
+                                            "justifyContent": "flex-start",
+                                            "lineHeight": 20,
+                                            "marginBottom": 8,
+                                            "marginTop": 8,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            {
+                                              "color": "#1a1b25",
+                                              "fontSize": 17,
+                                              "lineHeight": 20,
+                                              "writingDirection": "ltr",
+                                            }
+                                          }
+                                        >
+                                          Message6
+                                        </Text>
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              {
+                                "marginTop": -4,
+                                "zIndex": 0,
+                              }
+                            }
+                          />
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "gap": 4,
+                                  "justifyContent": "center",
+                                  "maxWidth": "100%",
+                                  "paddingVertical": 4,
+                                },
+                                {},
+                              ]
+                            }
+                            testID="message-status-time"
+                          >
+                            <Text
+                              style={
+                                {
+                                  "color": "#687385",
+                                  "fontSize": 13,
+                                  "fontWeight": 400,
+                                  "lineHeight": 16,
+                                }
+                              }
+                            >
+                              2:50 PM
+                            </Text>
+                            <Text
+                              style={
+                                [
                                   {
                                     "color": "#687385",
                                     "fontSize": 13,
                                     "fontWeight": 400,
                                     "lineHeight": 16,
-                                  }
-                                }
-                              >
-                                2:50 PM
-                              </Text>
-                              <Text
-                                style={
-                                  [
-                                    {
-                                      "color": "#687385",
-                                      "fontSize": 13,
-                                      "fontWeight": 400,
-                                      "lineHeight": 16,
-                                    },
-                                    {},
-                                  ]
-                                }
-                              >
-                                Edited
-                              </Text>
-                            </View>
+                                  },
+                                  {},
+                                ]
+                              }
+                            >
+                              Edited
+                            </Text>
                           </View>
                         </View>
                       </View>
                     </View>
                   </View>
-                  <View />
                 </View>
+                <View />
               </View>
             </View>
           </View>
@@ -674,325 +670,321 @@ exports[`Thread should match thread snapshot 1`] = `
               testID="message-list-item-516efa25-5d29-5c9a-ad2d-4cc183e785bd"
             >
               <View
-                testID="message-list-item-516efa25-5d29-5c9a-ad2d-4cc183e785bd"
-              >
-                <View
-                  style={
+                style={
+                  [
                     [
-                      [
-                        {},
-                      ],
-                      {
-                        "paddingHorizontal": 16,
-                      },
-                    ]
-                  }
-                  testID="message-wrapper"
-                >
-                  <View />
-                  <View>
+                      {},
+                    ],
+                    {
+                      "paddingHorizontal": 16,
+                    },
+                  ]
+                }
+                testID="message-wrapper"
+              >
+                <View />
+                <View>
+                  <View
+                    collapsable={false}
+                  >
                     <View
                       collapsable={false}
+                      hitSlop={
+                        {
+                          "left": 750,
+                          "right": 750,
+                        }
+                      }
+                      style={
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "zIndex": 1,
+                        }
+                      }
                     >
                       <View
-                        collapsable={false}
-                        hitSlop={
-                          {
-                            "left": 750,
-                            "right": 750,
-                          }
-                        }
+                        pointerEvents="box-none"
                         style={
                           {
-                            "alignItems": "center",
+                            "alignItems": "flex-end",
                             "flexDirection": "row",
-                            "zIndex": 1,
+                            "gap": 8,
+                            "paddingVertical": 8,
+                            "width": "100%",
                           }
                         }
+                        testID="message-item-view-wrapper"
                       >
                         <View
-                          pointerEvents="box-none"
-                          style={
-                            {
-                              "alignItems": "flex-end",
-                              "flexDirection": "row",
-                              "gap": 8,
-                              "paddingVertical": 8,
-                              "width": "100%",
-                            }
-                          }
-                          testID="message-item-view-wrapper"
+                          style={{}}
+                          testID="message-author"
                         >
                           <View
-                            style={{}}
-                            testID="message-author"
+                            testID="user-avatar"
                           >
-                            <View
-                              testID="user-avatar"
-                            >
-                              <View
-                                style={
-                                  [
-                                    {
-                                      "alignItems": "center",
-                                      "borderRadius": 9999,
-                                      "justifyContent": "center",
-                                      "overflow": "hidden",
-                                    },
-                                    {
-                                      "height": 32,
-                                      "width": 32,
-                                    },
-                                    {
-                                      "backgroundColor": "#8febbd",
-                                    },
-                                    {
-                                      "borderColor": "rgba(26, 27, 37, 0.1)",
-                                      "borderWidth": 1,
-                                    },
-                                    undefined,
-                                  ]
-                                }
-                                testID="avatar-image"
-                              >
-                                <Image
-                                  accessibilityElementsHidden={true}
-                                  importantForAccessibility="no"
-                                  onError={[Function]}
-                                  source={
-                                    {
-                                      "uri": "https://i.imgur.com/spueyAP.png",
-                                    }
-                                  }
-                                  style={
-                                    [
-                                      {},
-                                      {
-                                        "height": 32,
-                                        "width": 32,
-                                      },
-                                    ]
-                                  }
-                                />
-                              </View>
-                            </View>
-                          </View>
-                          <View
-                            style={
-                              [
-                                {
-                                  "gap": 4,
-                                },
-                                {
-                                  "alignItems": "flex-start",
-                                },
-                                {},
-                              ]
-                            }
-                            testID="message-components"
-                          >
-                            <View
-                              style={
-                                {
-                                  "zIndex": 1,
-                                }
-                              }
-                            >
-                              <View
-                                style={
-                                  {
-                                    "alignSelf": "flex-end",
-                                  }
-                                }
-                              />
-                              <View
-                                style={
-                                  {
-                                    "alignSelf": "flex-start",
-                                  }
-                                }
-                              >
-                                <View
-                                  accessibilityState={
-                                    {
-                                      "busy": undefined,
-                                      "checked": undefined,
-                                      "disabled": undefined,
-                                      "expanded": undefined,
-                                      "selected": undefined,
-                                    }
-                                  }
-                                  accessibilityValue={
-                                    {
-                                      "max": undefined,
-                                      "min": undefined,
-                                      "now": undefined,
-                                      "text": undefined,
-                                    }
-                                  }
-                                  accessible={true}
-                                  collapsable={false}
-                                  focusable={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onResponderGrant={[Function]}
-                                  onResponderMove={[Function]}
-                                  onResponderRelease={[Function]}
-                                  onResponderTerminate={[Function]}
-                                  onResponderTerminationRequest={[Function]}
-                                  onStartShouldSetResponder={[Function]}
-                                  style={{}}
-                                >
-                                  <View
-                                    style={
-                                      [
-                                        {
-                                          "borderTopLeftRadius": 20,
-                                          "borderTopRightRadius": 20,
-                                          "borderWidth": 0,
-                                          "overflow": "hidden",
-                                        },
-                                        {
-                                          "backgroundColor": "#ebeef1",
-                                          "borderBottomLeftRadius": 0,
-                                          "borderBottomRightRadius": 20,
-                                        },
-                                        {},
-                                        {},
-                                        {},
-                                      ]
-                                    }
-                                    testID="message-content-wrapper"
-                                  >
-                                    <View
-                                      style={
-                                        [
-                                          {
-                                            "gap": 8,
-                                            "paddingBottom": 0,
-                                            "paddingHorizontal": 8,
-                                            "paddingTop": 0,
-                                          },
-                                          {},
-                                        ]
-                                      }
-                                    />
-                                    <View
-                                      style={
-                                        [
-                                          {
-                                            "maxWidth": 256,
-                                            "paddingHorizontal": 12,
-                                          },
-                                          {},
-                                          undefined,
-                                        ]
-                                      }
-                                      testID="message-text-container"
-                                    >
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "alignSelf": "stretch",
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <Text
-                                          style={
-                                            {
-                                              "alignItems": "flex-start",
-                                              "flexDirection": "row",
-                                              "flexWrap": "wrap",
-                                              "fontSize": 17,
-                                              "justifyContent": "flex-start",
-                                              "lineHeight": 20,
-                                              "marginBottom": 8,
-                                              "marginTop": 8,
-                                            }
-                                          }
-                                        >
-                                          <Text
-                                            style={
-                                              {
-                                                "color": "#1a1b25",
-                                                "fontSize": 17,
-                                                "lineHeight": 20,
-                                                "writingDirection": "ltr",
-                                              }
-                                            }
-                                          >
-                                            Message5
-                                          </Text>
-                                        </Text>
-                                      </View>
-                                    </View>
-                                  </View>
-                                </View>
-                              </View>
-                            </View>
-                            <View
-                              style={
-                                {
-                                  "marginTop": -4,
-                                  "zIndex": 0,
-                                }
-                              }
-                            />
                             <View
                               style={
                                 [
                                   {
                                     "alignItems": "center",
-                                    "flexDirection": "row",
-                                    "gap": 4,
+                                    "borderRadius": 9999,
                                     "justifyContent": "center",
-                                    "maxWidth": "100%",
-                                    "paddingVertical": 4,
+                                    "overflow": "hidden",
                                   },
-                                  {},
+                                  {
+                                    "height": 32,
+                                    "width": 32,
+                                  },
+                                  {
+                                    "backgroundColor": "#8febbd",
+                                  },
+                                  {
+                                    "borderColor": "rgba(26, 27, 37, 0.1)",
+                                    "borderWidth": 1,
+                                  },
+                                  undefined,
                                 ]
                               }
-                              testID="message-status-time"
+                              testID="avatar-image"
                             >
-                              <Text
+                              <Image
+                                accessibilityElementsHidden={true}
+                                importantForAccessibility="no"
+                                onError={[Function]}
+                                source={
+                                  {
+                                    "uri": "https://i.imgur.com/spueyAP.png",
+                                  }
+                                }
                                 style={
+                                  [
+                                    {},
+                                    {
+                                      "height": 32,
+                                      "width": 32,
+                                    },
+                                  ]
+                                }
+                              />
+                            </View>
+                          </View>
+                        </View>
+                        <View
+                          style={
+                            [
+                              {
+                                "gap": 4,
+                              },
+                              {
+                                "alignItems": "flex-start",
+                              },
+                              {},
+                            ]
+                          }
+                          testID="message-components"
+                        >
+                          <View
+                            style={
+                              {
+                                "zIndex": 1,
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "alignSelf": "flex-end",
+                                }
+                              }
+                            />
+                            <View
+                              style={
+                                {
+                                  "alignSelf": "flex-start",
+                                }
+                              }
+                            >
+                              <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={{}}
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "borderTopLeftRadius": 20,
+                                        "borderTopRightRadius": 20,
+                                        "borderWidth": 0,
+                                        "overflow": "hidden",
+                                      },
+                                      {
+                                        "backgroundColor": "#ebeef1",
+                                        "borderBottomLeftRadius": 0,
+                                        "borderBottomRightRadius": 20,
+                                      },
+                                      {},
+                                      {},
+                                      {},
+                                    ]
+                                  }
+                                  testID="message-content-wrapper"
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "gap": 8,
+                                          "paddingBottom": 0,
+                                          "paddingHorizontal": 8,
+                                          "paddingTop": 0,
+                                        },
+                                        {},
+                                      ]
+                                    }
+                                  />
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "maxWidth": 256,
+                                          "paddingHorizontal": 12,
+                                        },
+                                        {},
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="message-text-container"
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignSelf": "stretch",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "alignItems": "flex-start",
+                                            "flexDirection": "row",
+                                            "flexWrap": "wrap",
+                                            "fontSize": 17,
+                                            "justifyContent": "flex-start",
+                                            "lineHeight": 20,
+                                            "marginBottom": 8,
+                                            "marginTop": 8,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            {
+                                              "color": "#1a1b25",
+                                              "fontSize": 17,
+                                              "lineHeight": 20,
+                                              "writingDirection": "ltr",
+                                            }
+                                          }
+                                        >
+                                          Message5
+                                        </Text>
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              {
+                                "marginTop": -4,
+                                "zIndex": 0,
+                              }
+                            }
+                          />
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "gap": 4,
+                                  "justifyContent": "center",
+                                  "maxWidth": "100%",
+                                  "paddingVertical": 4,
+                                },
+                                {},
+                              ]
+                            }
+                            testID="message-status-time"
+                          >
+                            <Text
+                              style={
+                                {
+                                  "color": "#687385",
+                                  "fontSize": 13,
+                                  "fontWeight": 400,
+                                  "lineHeight": 16,
+                                }
+                              }
+                            >
+                              2:50 PM
+                            </Text>
+                            <Text
+                              style={
+                                [
                                   {
                                     "color": "#687385",
                                     "fontSize": 13,
                                     "fontWeight": 400,
                                     "lineHeight": 16,
-                                  }
-                                }
-                              >
-                                2:50 PM
-                              </Text>
-                              <Text
-                                style={
-                                  [
-                                    {
-                                      "color": "#687385",
-                                      "fontSize": 13,
-                                      "fontWeight": 400,
-                                      "lineHeight": 16,
-                                    },
-                                    {},
-                                  ]
-                                }
-                              >
-                                Edited
-                              </Text>
-                            </View>
+                                  },
+                                  {},
+                                ]
+                              }
+                            >
+                              Edited
+                            </Text>
                           </View>
                         </View>
                       </View>
                     </View>
                   </View>
-                  <View />
                 </View>
+                <View />
               </View>
             </View>
           </View>
@@ -1018,358 +1010,354 @@ exports[`Thread should match thread snapshot 1`] = `
               testID="message-list-item-82a83b16-b611-527c-b3ac-765ef6220490"
             >
               <View
-                testID="message-list-item-82a83b16-b611-527c-b3ac-765ef6220490"
+                style={
+                  {
+                    "paddingVertical": 8,
+                  }
+                }
               >
                 <View
                   style={
                     {
-                      "paddingVertical": 8,
+                      "alignSelf": "center",
+                      "backgroundColor": "#f6f8fa",
+                      "borderRadius": 9999,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
                     }
                   }
+                  testID="date-separator"
                 >
-                  <View
+                  <Text
                     style={
                       {
-                        "alignSelf": "center",
-                        "backgroundColor": "#f6f8fa",
-                        "borderRadius": 9999,
-                        "paddingHorizontal": 12,
-                        "paddingVertical": 4,
+                        "color": "#414552",
+                        "fontSize": 13,
+                        "fontWeight": 600,
+                        "lineHeight": 16,
                       }
                     }
-                    testID="date-separator"
                   >
-                    <Text
+                    05/05/2020
+                  </Text>
+                </View>
+              </View>
+              <View
+                style={
+                  [
+                    [
+                      {},
+                    ],
+                    {
+                      "paddingHorizontal": 16,
+                    },
+                  ]
+                }
+                testID="message-wrapper"
+              >
+                <View />
+                <View>
+                  <View
+                    collapsable={false}
+                  >
+                    <View
+                      collapsable={false}
+                      hitSlop={
+                        {
+                          "left": 750,
+                          "right": 750,
+                        }
+                      }
                       style={
                         {
-                          "color": "#414552",
-                          "fontSize": 13,
-                          "fontWeight": 600,
-                          "lineHeight": 16,
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "zIndex": 1,
                         }
                       }
                     >
-                      05/05/2020
-                    </Text>
-                  </View>
-                </View>
-                <View
-                  style={
-                    [
-                      [
-                        {},
-                      ],
-                      {
-                        "paddingHorizontal": 16,
-                      },
-                    ]
-                  }
-                  testID="message-wrapper"
-                >
-                  <View />
-                  <View>
-                    <View
-                      collapsable={false}
-                    >
                       <View
-                        collapsable={false}
-                        hitSlop={
-                          {
-                            "left": 750,
-                            "right": 750,
-                          }
-                        }
+                        pointerEvents="box-none"
                         style={
                           {
-                            "alignItems": "center",
+                            "alignItems": "flex-end",
                             "flexDirection": "row",
-                            "zIndex": 1,
+                            "gap": 8,
+                            "paddingVertical": 8,
+                            "width": "100%",
                           }
                         }
+                        testID="message-item-view-wrapper"
                       >
                         <View
-                          pointerEvents="box-none"
-                          style={
-                            {
-                              "alignItems": "flex-end",
-                              "flexDirection": "row",
-                              "gap": 8,
-                              "paddingVertical": 8,
-                              "width": "100%",
-                            }
-                          }
-                          testID="message-item-view-wrapper"
+                          style={{}}
+                          testID="message-author"
                         >
                           <View
-                            style={{}}
-                            testID="message-author"
+                            testID="user-avatar"
                           >
-                            <View
-                              testID="user-avatar"
-                            >
-                              <View
-                                style={
-                                  [
-                                    {
-                                      "alignItems": "center",
-                                      "borderRadius": 9999,
-                                      "justifyContent": "center",
-                                      "overflow": "hidden",
-                                    },
-                                    {
-                                      "height": 32,
-                                      "width": 32,
-                                    },
-                                    {
-                                      "backgroundColor": "#fcd579",
-                                    },
-                                    {
-                                      "borderColor": "rgba(26, 27, 37, 0.1)",
-                                      "borderWidth": 1,
-                                    },
-                                    undefined,
-                                  ]
-                                }
-                                testID="avatar-image"
-                              >
-                                <Image
-                                  accessibilityElementsHidden={true}
-                                  importantForAccessibility="no"
-                                  onError={[Function]}
-                                  source={
-                                    {
-                                      "uri": "https://i.imgur.com/LuuGvh0.png",
-                                    }
-                                  }
-                                  style={
-                                    [
-                                      {},
-                                      {
-                                        "height": 32,
-                                        "width": 32,
-                                      },
-                                    ]
-                                  }
-                                />
-                              </View>
-                            </View>
-                          </View>
-                          <View
-                            style={
-                              [
-                                {
-                                  "gap": 4,
-                                },
-                                {
-                                  "alignItems": "flex-start",
-                                },
-                                {},
-                              ]
-                            }
-                            testID="message-components"
-                          >
-                            <View
-                              style={
-                                {
-                                  "zIndex": 1,
-                                }
-                              }
-                            >
-                              <View
-                                style={
-                                  {
-                                    "alignSelf": "flex-end",
-                                  }
-                                }
-                              />
-                              <View
-                                style={
-                                  {
-                                    "alignSelf": "flex-start",
-                                  }
-                                }
-                              >
-                                <View
-                                  accessibilityState={
-                                    {
-                                      "busy": undefined,
-                                      "checked": undefined,
-                                      "disabled": undefined,
-                                      "expanded": undefined,
-                                      "selected": undefined,
-                                    }
-                                  }
-                                  accessibilityValue={
-                                    {
-                                      "max": undefined,
-                                      "min": undefined,
-                                      "now": undefined,
-                                      "text": undefined,
-                                    }
-                                  }
-                                  accessible={true}
-                                  collapsable={false}
-                                  focusable={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onResponderGrant={[Function]}
-                                  onResponderMove={[Function]}
-                                  onResponderRelease={[Function]}
-                                  onResponderTerminate={[Function]}
-                                  onResponderTerminationRequest={[Function]}
-                                  onStartShouldSetResponder={[Function]}
-                                  style={{}}
-                                >
-                                  <View
-                                    style={
-                                      [
-                                        {
-                                          "borderTopLeftRadius": 20,
-                                          "borderTopRightRadius": 20,
-                                          "borderWidth": 0,
-                                          "overflow": "hidden",
-                                        },
-                                        {
-                                          "backgroundColor": "#ebeef1",
-                                          "borderBottomLeftRadius": 0,
-                                          "borderBottomRightRadius": 20,
-                                        },
-                                        {},
-                                        {},
-                                        {},
-                                      ]
-                                    }
-                                    testID="message-content-wrapper"
-                                  >
-                                    <View
-                                      style={
-                                        [
-                                          {
-                                            "gap": 8,
-                                            "paddingBottom": 0,
-                                            "paddingHorizontal": 8,
-                                            "paddingTop": 0,
-                                          },
-                                          {},
-                                        ]
-                                      }
-                                    />
-                                    <View
-                                      style={
-                                        [
-                                          {
-                                            "maxWidth": 256,
-                                            "paddingHorizontal": 12,
-                                          },
-                                          {},
-                                          undefined,
-                                        ]
-                                      }
-                                      testID="message-text-container"
-                                    >
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "alignSelf": "stretch",
-                                            },
-                                            undefined,
-                                          ]
-                                        }
-                                      >
-                                        <Text
-                                          style={
-                                            {
-                                              "alignItems": "flex-start",
-                                              "flexDirection": "row",
-                                              "flexWrap": "wrap",
-                                              "fontSize": 17,
-                                              "justifyContent": "flex-start",
-                                              "lineHeight": 20,
-                                              "marginBottom": 8,
-                                              "marginTop": 8,
-                                            }
-                                          }
-                                        >
-                                          <Text
-                                            style={
-                                              {
-                                                "color": "#1a1b25",
-                                                "fontSize": 17,
-                                                "lineHeight": 20,
-                                                "writingDirection": "ltr",
-                                              }
-                                            }
-                                          >
-                                            Message4
-                                          </Text>
-                                        </Text>
-                                      </View>
-                                    </View>
-                                  </View>
-                                </View>
-                              </View>
-                            </View>
-                            <View
-                              style={
-                                {
-                                  "marginTop": -4,
-                                  "zIndex": 0,
-                                }
-                              }
-                            />
                             <View
                               style={
                                 [
                                   {
                                     "alignItems": "center",
-                                    "flexDirection": "row",
-                                    "gap": 4,
+                                    "borderRadius": 9999,
                                     "justifyContent": "center",
-                                    "maxWidth": "100%",
-                                    "paddingVertical": 4,
+                                    "overflow": "hidden",
                                   },
-                                  {},
+                                  {
+                                    "height": 32,
+                                    "width": 32,
+                                  },
+                                  {
+                                    "backgroundColor": "#fcd579",
+                                  },
+                                  {
+                                    "borderColor": "rgba(26, 27, 37, 0.1)",
+                                    "borderWidth": 1,
+                                  },
+                                  undefined,
                                 ]
                               }
-                              testID="message-status-time"
+                              testID="avatar-image"
                             >
-                              <Text
+                              <Image
+                                accessibilityElementsHidden={true}
+                                importantForAccessibility="no"
+                                onError={[Function]}
+                                source={
+                                  {
+                                    "uri": "https://i.imgur.com/LuuGvh0.png",
+                                  }
+                                }
                                 style={
+                                  [
+                                    {},
+                                    {
+                                      "height": 32,
+                                      "width": 32,
+                                    },
+                                  ]
+                                }
+                              />
+                            </View>
+                          </View>
+                        </View>
+                        <View
+                          style={
+                            [
+                              {
+                                "gap": 4,
+                              },
+                              {
+                                "alignItems": "flex-start",
+                              },
+                              {},
+                            ]
+                          }
+                          testID="message-components"
+                        >
+                          <View
+                            style={
+                              {
+                                "zIndex": 1,
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "alignSelf": "flex-end",
+                                }
+                              }
+                            />
+                            <View
+                              style={
+                                {
+                                  "alignSelf": "flex-start",
+                                }
+                              }
+                            >
+                              <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={{}}
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "borderTopLeftRadius": 20,
+                                        "borderTopRightRadius": 20,
+                                        "borderWidth": 0,
+                                        "overflow": "hidden",
+                                      },
+                                      {
+                                        "backgroundColor": "#ebeef1",
+                                        "borderBottomLeftRadius": 0,
+                                        "borderBottomRightRadius": 20,
+                                      },
+                                      {},
+                                      {},
+                                      {},
+                                    ]
+                                  }
+                                  testID="message-content-wrapper"
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "gap": 8,
+                                          "paddingBottom": 0,
+                                          "paddingHorizontal": 8,
+                                          "paddingTop": 0,
+                                        },
+                                        {},
+                                      ]
+                                    }
+                                  />
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "maxWidth": 256,
+                                          "paddingHorizontal": 12,
+                                        },
+                                        {},
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="message-text-container"
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignSelf": "stretch",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          {
+                                            "alignItems": "flex-start",
+                                            "flexDirection": "row",
+                                            "flexWrap": "wrap",
+                                            "fontSize": 17,
+                                            "justifyContent": "flex-start",
+                                            "lineHeight": 20,
+                                            "marginBottom": 8,
+                                            "marginTop": 8,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            {
+                                              "color": "#1a1b25",
+                                              "fontSize": 17,
+                                              "lineHeight": 20,
+                                              "writingDirection": "ltr",
+                                            }
+                                          }
+                                        >
+                                          Message4
+                                        </Text>
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              {
+                                "marginTop": -4,
+                                "zIndex": 0,
+                              }
+                            }
+                          />
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "gap": 4,
+                                  "justifyContent": "center",
+                                  "maxWidth": "100%",
+                                  "paddingVertical": 4,
+                                },
+                                {},
+                              ]
+                            }
+                            testID="message-status-time"
+                          >
+                            <Text
+                              style={
+                                {
+                                  "color": "#687385",
+                                  "fontSize": 13,
+                                  "fontWeight": 400,
+                                  "lineHeight": 16,
+                                }
+                              }
+                            >
+                              2:50 PM
+                            </Text>
+                            <Text
+                              style={
+                                [
                                   {
                                     "color": "#687385",
                                     "fontSize": 13,
                                     "fontWeight": 400,
                                     "lineHeight": 16,
-                                  }
-                                }
-                              >
-                                2:50 PM
-                              </Text>
-                              <Text
-                                style={
-                                  [
-                                    {
-                                      "color": "#687385",
-                                      "fontSize": 13,
-                                      "fontWeight": 400,
-                                      "lineHeight": 16,
-                                    },
-                                    {},
-                                  ]
-                                }
-                              >
-                                Edited
-                              </Text>
-                            </View>
+                                  },
+                                  {},
+                                ]
+                              }
+                            >
+                              Edited
+                            </Text>
                           </View>
                         </View>
                       </View>
                     </View>
                   </View>
-                  <View />
                 </View>
+                <View />
               </View>
             </View>
           </View>


### PR DESCRIPTION
## 🎯 Goal

This PR removes redundant views for a large portion of `Message` components which will simply not be hit very often (but still result in a `yoga` measurement/`ShadowNode` since they will not be collapsed).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


