### PR TITLE
fix: on selection change issues

### DIFF
--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -109,13 +109,41 @@ const AutoCompleteInputWithContext = (props: AutoCompleteInputPropsWithContext) 
   const { command, text } = useStateStore(textComposer.state, textComposerStateSelector);
   const { enabled } = useStateStore(messageComposer.configState, configStateSelector);
 
-  // Track the pre-keystroke text + selection so we can derive the real caret on
-  // the next onChangeText. RN's onChangeText doesn't carry cursor info, and
-  // onSelectionChange fires after onChangeText for typing — so we compute the
-  // new caret as `prevSelection.end + (newText.length - prevText.length)`,
-  // which is correct for inserts, deletes, and selection replacements.
-  const prevTextRef = useRef('');
-  const selectionRef = useRef<{ end: number; start: number }>({ end: 0, start: 0 });
+  // RN's onChangeText doesn't carry cursor info, and iOS / Android fire
+  // onChangeText vs onSelectionChange in different orders. Rather than derive
+  // the caret from a text-length delta (fragile — gets clobbered by re-renders
+  // and varies across platforms), we hold the latest values reported by native
+  // and call into the LLC once both have settled.
+  const latestTextRef = useRef('');
+  const latestSelectionRef = useRef<{ end: number; start: number }>({
+    end: 0,
+    start: 0,
+  });
+  const flushHandleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flushChange = useCallback(() => {
+    flushHandleRef.current = null;
+    textComposer.handleChange({
+      selection: latestSelectionRef.current,
+      text: latestTextRef.current,
+    });
+  }, [textComposer]);
+
+  // Defer to the next task so onChangeText and onSelectionChange both land
+  // before we forward to the LLC, regardless of platform ordering.
+  const scheduleChange = useCallback(() => {
+    if (flushHandleRef.current !== null) return;
+    flushHandleRef.current = setTimeout(flushChange, 0);
+  }, [flushChange]);
+
+  useEffect(() => {
+    return () => {
+      if (flushHandleRef.current !== null) {
+        clearTimeout(flushHandleRef.current);
+        flushHandleRef.current = null;
+      }
+    };
+  }, []);
 
   const maxMessageLength = useMemo(() => {
     return channel.getConfig()?.max_message_length;
@@ -127,8 +155,14 @@ const AutoCompleteInputWithContext = (props: AutoCompleteInputPropsWithContext) 
 
   useEffect(() => {
     setLocalText(text);
-    prevTextRef.current = text;
-    selectionRef.current = { end: text.length, start: text.length };
+    // Only resync the refs when the text change came from outside (clear after
+    // send, draft restore, programmatic setText). For changes we triggered
+    // ourselves, latestTextRef is already up to date and overwriting the
+    // selection would clobber what onSelectionChange just told us.
+    if (text !== latestTextRef.current) {
+      latestTextRef.current = text;
+      latestSelectionRef.current = { end: text.length, start: text.length };
+    }
   }, [text]);
 
   const clearState = useCallback(() => {
@@ -158,32 +192,20 @@ const AutoCompleteInputWithContext = (props: AutoCompleteInputPropsWithContext) 
   const handleSelectionChange = useCallback(
     (e: TextInputSelectionChangeEvent) => {
       const { selection } = e.nativeEvent;
-      selectionRef.current = selection;
+      latestSelectionRef.current = selection;
       textComposer.setSelection(selection);
+      scheduleChange();
     },
-    [textComposer],
+    [scheduleChange, textComposer],
   );
 
   const onChangeTextHandler = useCallback(
     (newText: string) => {
       setLocalText(newText);
-
-      const delta = newText.length - prevTextRef.current.length;
-      const projectedCursor = selectionRef.current.end + delta;
-      const newCursor = Math.max(0, Math.min(newText.length, projectedCursor));
-
-      prevTextRef.current = newText;
-      selectionRef.current = { end: newCursor, start: newCursor };
-
-      textComposer.handleChange({
-        selection: {
-          end: newCursor,
-          start: newCursor,
-        },
-        text: newText,
-      });
+      latestTextRef.current = newText;
+      scheduleChange();
     },
-    [textComposer],
+    [scheduleChange],
   );
 
   const {

--- a/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/package/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   I18nManager,
   Platform,
@@ -109,6 +109,14 @@ const AutoCompleteInputWithContext = (props: AutoCompleteInputPropsWithContext) 
   const { command, text } = useStateStore(textComposer.state, textComposerStateSelector);
   const { enabled } = useStateStore(messageComposer.configState, configStateSelector);
 
+  // Track the pre-keystroke text + selection so we can derive the real caret on
+  // the next onChangeText. RN's onChangeText doesn't carry cursor info, and
+  // onSelectionChange fires after onChangeText for typing — so we compute the
+  // new caret as `prevSelection.end + (newText.length - prevText.length)`,
+  // which is correct for inserts, deletes, and selection replacements.
+  const prevTextRef = useRef('');
+  const selectionRef = useRef<{ end: number; start: number }>({ end: 0, start: 0 });
+
   const maxMessageLength = useMemo(() => {
     return channel.getConfig()?.max_message_length;
   }, [channel]);
@@ -119,6 +127,8 @@ const AutoCompleteInputWithContext = (props: AutoCompleteInputPropsWithContext) 
 
   useEffect(() => {
     setLocalText(text);
+    prevTextRef.current = text;
+    selectionRef.current = { end: text.length, start: text.length };
   }, [text]);
 
   const clearState = useCallback(() => {
@@ -148,6 +158,7 @@ const AutoCompleteInputWithContext = (props: AutoCompleteInputPropsWithContext) 
   const handleSelectionChange = useCallback(
     (e: TextInputSelectionChangeEvent) => {
       const { selection } = e.nativeEvent;
+      selectionRef.current = selection;
       textComposer.setSelection(selection);
     },
     [textComposer],
@@ -157,10 +168,17 @@ const AutoCompleteInputWithContext = (props: AutoCompleteInputPropsWithContext) 
     (newText: string) => {
       setLocalText(newText);
 
+      const delta = newText.length - prevTextRef.current.length;
+      const projectedCursor = selectionRef.current.end + delta;
+      const newCursor = Math.max(0, Math.min(newText.length, projectedCursor));
+
+      prevTextRef.current = newText;
+      selectionRef.current = { end: newCursor, start: newCursor };
+
       textComposer.handleChange({
         selection: {
-          end: newText.length,
-          start: newText.length,
+          end: newCursor,
+          start: newCursor,
         },
         text: newText,
       });

--- a/package/src/components/AutoCompleteInput/__tests__/AutoCompleteInput.test.tsx
+++ b/package/src/components/AutoCompleteInput/__tests__/AutoCompleteInput.test.tsx
@@ -170,6 +170,53 @@ describe('AutoCompleteInput', () => {
     });
   });
 
+  it('forwards the real caret position to handleChange when typing in the middle of multi-line text', async () => {
+    // Regression: when the user inserts a character somewhere other than the
+    // end of the text (e.g. typing "@" between paragraphs), the previous
+    // implementation always passed selection.end = newText.length, which
+    // caused the LLC mention-trigger regex to miss "@" on multi-line input
+    // because it only tolerates one whitespace between "@" and end-of-string.
+    const { textComposer } = channel.messageComposer;
+    const spyHandleChange = jest.spyOn(textComposer, 'handleChange');
+
+    renderComponent({ channelProps: { channel }, client, props: {} });
+
+    const input = screen.getByTestId('auto-complete-text-input');
+
+    // Seed the input with some multi-line text.
+    const seeded = 'asdf\n\n\n\n dsfa';
+    act(() => {
+      fireEvent.changeText(input, seeded);
+    });
+
+    // Place the caret between the two leading newlines (position 6 — right
+    // after "asdf\n\n", before the trailing "\n\n dsfa").
+    const caret = 6;
+    act(() => {
+      fireEvent(input, 'selectionChange', {
+        nativeEvent: { selection: { end: caret, start: caret } },
+      });
+    });
+
+    spyHandleChange.mockClear();
+
+    // User types "@" at the caret position.
+    const inserted = 'asdf\n\n@\n\n dsfa';
+    act(() => {
+      fireEvent.changeText(input, inserted);
+    });
+
+    await waitFor(() => {
+      // The cursor should land right after the inserted "@", not at the end
+      // of the full string — otherwise the LLC's mention trigger regex won't
+      // detect the "@" because of the trailing "\n\n dsfa".
+      expect(spyHandleChange).toHaveBeenCalledWith({
+        selection: { end: caret + 1, start: caret + 1 },
+        text: inserted,
+      });
+    });
+  });
+
   it('should call the textComposer setSelection when the onSelectionChange is triggered', async () => {
     const { textComposer } = channel.messageComposer;
 

--- a/package/src/components/AutoCompleteInput/__tests__/AutoCompleteInput.test.tsx
+++ b/package/src/components/AutoCompleteInput/__tests__/AutoCompleteInput.test.tsx
@@ -112,8 +112,13 @@ describe('AutoCompleteInput', () => {
 
     const input = queryByTestId('auto-complete-text-input')!;
 
+    // RN fires both events for every keystroke; we forward to the LLC once
+    // both have settled, so the test mirrors that.
     act(() => {
       fireEvent.changeText(input, 'hello');
+      fireEvent(input, 'selectionChange', {
+        nativeEvent: { selection: { end: 5, start: 5 } },
+      });
     });
 
     await waitFor(() => {
@@ -172,10 +177,10 @@ describe('AutoCompleteInput', () => {
 
   it('forwards the real caret position to handleChange when typing in the middle of multi-line text', async () => {
     // Regression: when the user inserts a character somewhere other than the
-    // end of the text (e.g. typing "@" between paragraphs), the previous
-    // implementation always passed selection.end = newText.length, which
-    // caused the LLC mention-trigger regex to miss "@" on multi-line input
-    // because it only tolerates one whitespace between "@" and end-of-string.
+    // end of the text (e.g. typing "@" between paragraphs), the original
+    // implementation passed selection.end = newText.length, which caused the
+    // LLC mention-trigger regex to miss "@" on multi-line input because it
+    // only tolerates one whitespace between "@" and end-of-string.
     const { textComposer } = channel.messageComposer;
     const spyHandleChange = jest.spyOn(textComposer, 'handleChange');
 
@@ -183,36 +188,102 @@ describe('AutoCompleteInput', () => {
 
     const input = screen.getByTestId('auto-complete-text-input');
 
-    // Seed the input with some multi-line text.
+    // Seed the input with some multi-line text and place the caret between
+    // the two leading newlines (position 6 — right after "asdf\n\n", before
+    // the trailing "\n\n dsfa").
     const seeded = 'asdf\n\n\n\n dsfa';
-    act(() => {
-      fireEvent.changeText(input, seeded);
-    });
-
-    // Place the caret between the two leading newlines (position 6 — right
-    // after "asdf\n\n", before the trailing "\n\n dsfa").
     const caret = 6;
     act(() => {
+      fireEvent.changeText(input, seeded);
       fireEvent(input, 'selectionChange', {
         nativeEvent: { selection: { end: caret, start: caret } },
       });
     });
 
+    await waitFor(() => {
+      expect(spyHandleChange).toHaveBeenCalledWith({
+        selection: { end: caret, start: caret },
+        text: seeded,
+      });
+    });
+
     spyHandleChange.mockClear();
 
-    // User types "@" at the caret position.
+    // User types "@" at the caret. Both events fire in a single keystroke.
     const inserted = 'asdf\n\n@\n\n dsfa';
+    const newCaret = caret + 1;
     act(() => {
       fireEvent.changeText(input, inserted);
+      fireEvent(input, 'selectionChange', {
+        nativeEvent: { selection: { end: newCaret, start: newCaret } },
+      });
     });
 
     await waitFor(() => {
-      // The cursor should land right after the inserted "@", not at the end
-      // of the full string — otherwise the LLC's mention trigger regex won't
-      // detect the "@" because of the trailing "\n\n dsfa".
+      // Must land right after the inserted "@", not at end-of-string —
+      // otherwise the LLC mention regex misses "@" because of the trailing
+      // "\n\n dsfa".
       expect(spyHandleChange).toHaveBeenCalledWith({
-        selection: { end: caret + 1, start: caret + 1 },
+        selection: { end: newCaret, start: newCaret },
         text: inserted,
+      });
+    });
+  });
+
+  it('forwards the real caret to handleChange when the user deletes "@" and retypes it', async () => {
+    // Regression: deleting "@" and retyping it on the same single line caused
+    // the picker to stay hidden on iOS — and on Android even with newlines.
+    // The bug was that we derived the caret from a text-length delta plus a
+    // stale ref; the coalesced flush now uses whatever native actually
+    // reported via onSelectionChange.
+    const { textComposer } = channel.messageComposer;
+    const spyHandleChange = jest.spyOn(textComposer, 'handleChange');
+
+    renderComponent({ channelProps: { channel }, client, props: {} });
+
+    const input = screen.getByTestId('auto-complete-text-input');
+
+    // 1. Seed "asdf @ dsfa" with the caret right after "@".
+    act(() => {
+      fireEvent.changeText(input, 'asdf @ dsfa');
+      fireEvent(input, 'selectionChange', {
+        nativeEvent: { selection: { end: 6, start: 6 } },
+      });
+    });
+
+    await waitFor(() => {
+      expect(spyHandleChange).toHaveBeenCalledWith({
+        selection: { end: 6, start: 6 },
+        text: 'asdf @ dsfa',
+      });
+    });
+
+    // 2. Delete the "@" — text shrinks by one, caret moves to position 5.
+    act(() => {
+      fireEvent.changeText(input, 'asdf  dsfa');
+      fireEvent(input, 'selectionChange', {
+        nativeEvent: { selection: { end: 5, start: 5 } },
+      });
+    });
+
+    spyHandleChange.mockClear();
+
+    // 3. Retype "@" at position 5.
+    act(() => {
+      fireEvent.changeText(input, 'asdf @ dsfa');
+      fireEvent(input, 'selectionChange', {
+        nativeEvent: { selection: { end: 6, start: 6 } },
+      });
+    });
+
+    await waitFor(() => {
+      // The cursor must be reported at 6 (right after the new "@"), not
+      // somewhere stale. With a wrong caret, the LLC slice would include
+      // " dsfa" after the "@" and the query would be " dsfa" instead of "",
+      // which returns zero users → picker stays hidden.
+      expect(spyHandleChange).toHaveBeenCalledWith({
+        selection: { end: 6, start: 6 },
+        text: 'asdf @ dsfa',
       });
     });
   });


### PR DESCRIPTION
## 🎯 Goal

This PR fixes a long standing bug in the `AutoCompleteInput` where typing `@` to open the mention picker silently fails in several scenarios, most reproducibly when:

- the `@` is typed between text and a newline block (e.g. `"asdf\n\n@\n\n dsfa"`),
- the user deletes an existing `@` and retypes it on the same line (single line case is `iOS` reproducible, multiline case is `Android` reproducible).

Should close [this ticket](https://app.zendesk.com/agent/tickets/81034).

## 🛠 Implementation details

The LLC's mention/command/emoji detection operates on `text.slice(0, selection.end)`. The RN composer was always passing `selection.end = newText.length` to `textComposer.handleChange(...)`, regardless of where the caret actually was. The LLC's mention trigger regex `(/(?!^|\W)?[@][^\s@]*\s?[^\s@]*$/)` only tolerates a single whitespace between `@` (as it should, this is correct) and end of string, so any extra trailing whitespace (newlines, `"asdf @ dsfa more"`, etc.) caused the trigger to be missed. 

To fix this, we stop trying to invent a caret position. `AutoCompleteInput` now holds two refs that mirror whatever native most recently reported - `latestTextRef` from `onChangeText` and `latestSelectionRef` from `onSelectionChange`  and forwards both into the LLC together via a coalesced flush:

- Each event updates its `ref` and calls `scheduleChange()`
- `scheduleChange()` does a `setTimeout(flushChange, 0)`, and is idempotent - if a flush is already pending, the second event piggybacks on it
  - Because `onChangeText` and `onSelectionChange` fire as separate events in different orders on `iOS` vs `Android`, the `setTimeout(0)` defers the LLC call to the next task so both refs are populated with the keystroke's final values regardless of which event landed first
  - Sadly, on RN the order of these events is so unpredictable we need to do this and potentially wait for (almost) a single frame; as sometimes both of these callbacks arrive in different order, `Android` sometimes fires it twice and sometimes `onSelectionChange` simply doesn't even fire on `iOS`
- `flushChange()` calls `textComposer.handleChange({ text, selection })` with whatever the refs hold at that moment

Because both events for the same keystroke land in the current event loop task batch, in whichever order iOS or Android happens to dispatch them, the deferred flush always sees the freshest text and the freshest selection together.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


