### PR TITLE
fix: a11y follow up fixes

### DIFF
--- a/package/src/components/Accessibility/OverlayA11yShield.tsx
+++ b/package/src/components/Accessibility/OverlayA11yShield.tsx
@@ -1,0 +1,49 @@
+import React, { PropsWithChildren } from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+
+import { useOverlayContext } from '../../contexts/overlayContext/OverlayContext';
+import { useStateStore } from '../../hooks';
+import { overlayStore } from '../../state-store/message-overlay-store';
+
+const messageOverlayActiveSelector = (state: { id: string | undefined }) => ({
+  isMessageOverlayActive: state.id !== undefined,
+});
+
+/**
+ * Android only accessibility focus trap for the OverlayProvider's children
+ * tree. iOS handles modal focus traps natively via `accessibilityViewIsModal`
+ * on each overlay's root, but Android has no equivalent prop - the only
+ * JS side mechanism is to mark siblings as `'no-hide-descendants'`.
+ *
+ * The shield wraps `{children}` in a single View whose `importantForAccessibility`
+ * flips to `'no-hide-descendants'` whenever any focus trapping overlay is
+ * active (the full screen image/video gallery or the message context menu).
+ * When closed, the wrapper is a transparent passthrough.
+ *
+ * In terms of rerendering, only the wrapper View commits new props on overlay state
+ * transitions. The `{children}` element reference is stable across renders,
+ * so React reconciliation does not rerender any component below the wrapper.
+ *
+ * On iOS the wrapper is skipped entirely.
+ */
+export function OverlayA11yShield({ children }: PropsWithChildren) {
+  const { overlay } = useOverlayContext();
+  const { isMessageOverlayActive } = useStateStore(overlayStore, messageOverlayActiveSelector);
+
+  if (Platform.OS !== 'android') {
+    return <>{children}</>;
+  }
+
+  const isAnyOverlayActive = overlay === 'gallery' || isMessageOverlayActive;
+
+  return (
+    <View
+      accessibilityElementsHidden={isAnyOverlayActive}
+      importantForAccessibility={isAnyOverlayActive ? 'no-hide-descendants' : 'auto'}
+      style={StyleSheet.absoluteFill}
+      testID='overlay-a11y-shield'
+    >
+      {children}
+    </View>
+  );
+}

--- a/package/src/components/Accessibility/__tests__/OverlayA11yShield.test.tsx
+++ b/package/src/components/Accessibility/__tests__/OverlayA11yShield.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Platform, Text } from 'react-native';
+
+import { act, render, screen } from '@testing-library/react-native';
+
+import { OverlayContext } from '../../../contexts/overlayContext/OverlayContext';
+import { overlayStore } from '../../../state-store/message-overlay-store';
+import { OverlayA11yShield } from '../OverlayA11yShield';
+
+const setPlatform = (os: 'android' | 'ios') => {
+  Object.defineProperty(Platform, 'OS', { configurable: true, get: () => os });
+};
+
+const renderShield = (overlay: 'none' | 'gallery' = 'none') =>
+  render(
+    <OverlayContext.Provider
+      value={
+        {
+          overlay,
+          setOverlay: () => undefined,
+          style: undefined,
+        } as never
+      }
+    >
+      <OverlayA11yShield>
+        <Text testID='child'>child</Text>
+      </OverlayA11yShield>
+    </OverlayContext.Provider>,
+  );
+
+// The wrapper sets `accessibilityElementsHidden` / `importantForAccessibility`
+// when an overlay is active — RTL v13 filters those elements out of a11y queries
+// by default. `includeHiddenElements: true` keeps them queryable for assertion.
+const wrapper = () => screen.queryByTestId('overlay-a11y-shield', { includeHiddenElements: true });
+
+describe('OverlayA11yShield', () => {
+  const originalOS = Platform.OS;
+  afterAll(() => setPlatform(originalOS));
+
+  beforeEach(() => {
+    act(() => {
+      overlayStore.partialNext({ closing: false, id: undefined, messageId: undefined });
+    });
+  });
+
+  describe('on Android', () => {
+    beforeAll(() => setPlatform('android'));
+
+    it('renders children inside the wrapper', () => {
+      renderShield();
+      expect(screen.getByTestId('child')).toBeTruthy();
+      expect(wrapper()).toBeTruthy();
+    });
+
+    it('does not hide descendants when no overlay is active', () => {
+      renderShield('none');
+      expect(wrapper()?.props.importantForAccessibility).toBe('auto');
+    });
+
+    it('hides descendants when the gallery overlay is active', () => {
+      renderShield('gallery');
+      expect(wrapper()?.props.importantForAccessibility).toBe('no-hide-descendants');
+    });
+
+    it('hides descendants when the message overlay opens', () => {
+      renderShield('none');
+      act(() => {
+        overlayStore.partialNext({ id: 'msg-1' });
+      });
+      expect(wrapper()?.props.importantForAccessibility).toBe('no-hide-descendants');
+    });
+  });
+
+  describe('on iOS', () => {
+    beforeAll(() => setPlatform('ios'));
+
+    it('renders children without a wrapper', () => {
+      renderShield();
+      expect(screen.getByTestId('child')).toBeTruthy();
+      expect(wrapper()).toBeNull();
+    });
+  });
+});

--- a/package/src/components/Accessibility/__tests__/OverlayA11yShield.test.tsx
+++ b/package/src/components/Accessibility/__tests__/OverlayA11yShield.test.tsx
@@ -7,7 +7,7 @@ import { OverlayContext } from '../../../contexts/overlayContext/OverlayContext'
 import { overlayStore } from '../../../state-store/message-overlay-store';
 import { OverlayA11yShield } from '../OverlayA11yShield';
 
-const setPlatform = (os: 'android' | 'ios') => {
+const setPlatform = (os: typeof Platform.OS) => {
   Object.defineProperty(Platform, 'OS', { configurable: true, get: () => os });
 };
 

--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -14,6 +14,7 @@ import {
 
 import { openUrlSafely } from './utils/openUrlSafely';
 
+import { useA11yLabel } from '../../a11y/hooks/useA11yLabel';
 import { useTranslationContext } from '../../contexts';
 import { useChatConfigContext } from '../../contexts/chatConfigContext/ChatConfigContext';
 import { useComponentsContext } from '../../contexts/componentsContext/ComponentsContext';
@@ -236,6 +237,11 @@ const GalleryThumbnail = ({
   } = useTheme();
   const { t } = useTranslationContext();
   const styles = useStyles();
+  const isVideo = thumbnail.type === FileTypes.Video;
+  const thumbnailAccessibilityLabel = useA11yLabel(
+    isVideo ? 'a11y/Gallery Video' : 'a11y/Gallery Image',
+  );
+  const thumbnailAccessibilityHint = useA11yLabel('a11y/Double tap to open');
   const openImageViewer = () => {
     if (!message) {
       return;
@@ -260,6 +266,9 @@ const GalleryThumbnail = ({
   };
   return (
     <Pressable
+      accessibilityHint={thumbnailAccessibilityHint}
+      accessibilityLabel={thumbnailAccessibilityLabel}
+      accessibilityRole='button'
       disabled={preventPress}
       key={`gallery-item-${message.id}/${colIndex}/${rowIndex}/${imagesAndVideos.length}`}
       onLongPress={(event) => {

--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import React, { useMemo, useRef } from 'react';
+import { findNodeHandle, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import type { Attachment, LocalMessage } from 'stream-chat';
 
@@ -242,12 +242,14 @@ const GalleryThumbnail = ({
     isVideo ? 'a11y/Gallery Video' : 'a11y/Gallery Image',
   );
   const thumbnailAccessibilityHint = useA11yLabel('a11y/Double tap to open');
+  const thumbnailRef = useRef<View>(null);
   const openImageViewer = () => {
     if (!message) {
       return;
     }
     imageGalleryStateStore.openImageGallery({
       messages: [message],
+      requesterNode: findNodeHandle(thumbnailRef.current),
       selectedAttachmentUrl: thumbnail.url,
     });
     setOverlay('gallery');
@@ -271,6 +273,7 @@ const GalleryThumbnail = ({
       accessibilityRole='button'
       disabled={preventPress}
       key={`gallery-item-${message.id}/${colIndex}/${rowIndex}/${imagesAndVideos.length}`}
+      ref={thumbnailRef}
       onLongPress={(event) => {
         if (onLongPress) {
           onLongPress({

--- a/package/src/components/Channel/__tests__/ownCapabilities.test.tsx
+++ b/package/src/components/Channel/__tests__/ownCapabilities.test.tsx
@@ -3,7 +3,7 @@ import { FlatList } from 'react-native';
 
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react-native';
 import type { Channel as ChannelType, LocalMessage, StreamChat } from 'stream-chat';
 
 import { OverlayProvider } from '../../../contexts/overlayContext/OverlayProvider';
@@ -16,6 +16,7 @@ import { generateMessage } from '../../../mock-builders/generator/message';
 import { generateUser } from '../../../mock-builders/generator/user';
 import { getTestClientWithUser } from '../../../mock-builders/mock';
 import { registerNativeHandlers } from '../../../native';
+import { closeOverlay, finalizeCloseOverlay } from '../../../state-store';
 import { Channel } from '../../Channel/Channel';
 import { Chat } from '../../Chat/Chat';
 import { MessageComposer } from '../../MessageInput/MessageComposer';
@@ -49,6 +50,15 @@ describe('Own capabilities', () => {
     });
   });
 
+  afterEach(() => {
+    cleanup();
+    // The overlay state-store is module-level, so an overlay opened by a
+    // previous test would still be `active` when the next test mounts.
+    // Reset it so each test starts with `isActive=false`.
+    closeOverlay();
+    finalizeCloseOverlay();
+  });
+
   const getComponent = (props: Partial<React.ComponentProps<typeof Channel>> = {}) => (
     <SafeAreaProvider>
       <OverlayProvider>
@@ -76,7 +86,20 @@ describe('Own capabilities', () => {
     targetMessage: LocalMessage,
     props: Partial<React.ComponentProps<typeof Channel>> = {},
   ) => {
-    const { findByTestId, queryByLabelText, queryByText, unmount } = render(getComponent(props));
+    const {
+      findByTestId,
+      queryByLabelText: rawQueryByLabelText,
+      queryByText,
+      unmount,
+    } = render(getComponent(props));
+    // After the overlay opens, the host layer's `accessibilityViewIsModal`
+    // marks the chat tree as hidden to RNTL. The message action list is
+    // Portal-teleported into the overlay but its React parent stays inside
+    // the chat, so the visible-elements filter excludes it. The list IS
+    // rendered (and visible in production); we pass `includeHiddenElements`
+    // to look past the modal-sibling heuristic.
+    const queryByLabelText: typeof rawQueryByLabelText = (text, options) =>
+      rawQueryByLabelText(text, { includeHiddenElements: true, ...options });
     await waitFor(() => queryByText(targetMessage.text as string));
 
     act(() => {

--- a/package/src/components/ChannelPreview/ChannelPreviewStatus.tsx
+++ b/package/src/components/ChannelPreview/ChannelPreviewStatus.tsx
@@ -9,7 +9,7 @@ import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
 
 import { primitives } from '../../theme';
-import { getDateString } from '../../utils/i18n/getDateString';
+import { getDateString, getDateStringForA11y } from '../../utils/i18n/getDateString';
 
 export type ChannelPreviewStatusProps = Pick<
   ChannelPreviewViewPropsWithContext,
@@ -19,7 +19,7 @@ export type ChannelPreviewStatusProps = Pick<
 
 export const ChannelPreviewStatus = (props: ChannelPreviewStatusProps) => {
   const { formatLatestMessageDate, lastMessage } = props;
-  const { t, tDateTimeParser } = useTranslationContext();
+  const { t, tDateTimeParser, userLanguage } = useTranslationContext();
   const styles = useStyles();
 
   const created_at = lastMessage?.created_at;
@@ -36,11 +36,25 @@ export const ChannelPreviewStatus = (props: ChannelPreviewStatusProps) => {
     [created_at, t, tDateTimeParser],
   );
 
+  const a11yDate = useMemo(
+    () =>
+      getDateStringForA11y({
+        calendarFormatOverrides: { sameDay: 'LT' },
+        date: created_at,
+        tDateTimeParser,
+        userLanguage,
+      }),
+    [created_at, tDateTimeParser, userLanguage],
+  );
+
   const visibleDate =
     formatLatestMessageDate && latestMessageDate
       ? formatLatestMessageDate(latestMessageDate).toString()
       : formattedDate;
-  const labelParams = useMemo(() => ({ date: visibleDate ?? '' }), [visibleDate]);
+  const labelParams = useMemo(
+    () => ({ date: a11yDate ?? visibleDate ?? '' }),
+    [a11yDate, visibleDate],
+  );
   const accessibilityLabel = useA11yLabel('a11y/Last message {{date}}', labelParams);
 
   return (

--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -284,6 +284,7 @@ export const ImageGalleryWithContext = (props: ImageGalleryWithContextProps) => 
     <Animated.View
       accessibilityLabel='Image Gallery'
       pointerEvents={'auto'}
+      accessibilityViewIsModal
       style={[StyleSheet.absoluteFill, showScreenStyle]}
     >
       <Animated.View style={[StyleSheet.absoluteFill, containerBackground]} />

--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Image, ImageStyle, StyleSheet, ViewStyle } from 'react-native';
+import {
+  AccessibilityInfo,
+  Image,
+  ImageStyle,
+  Platform,
+  StyleSheet,
+  ViewStyle,
+} from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 import Animated, {
@@ -322,6 +329,26 @@ export const ImageGalleryWithContext = (props: ImageGalleryWithContextProps) => 
     },
     [imageGalleryStateStore, isAccessibilityEnabled],
   );
+
+  useEffect(() => {
+    return () => {
+      const handle = imageGalleryStateStore.requesterNode;
+      if (handle == null) return;
+      imageGalleryStateStore.requesterNode = null;
+      // Because of the fact that iOS and Android handle supressing
+      // the content underneath differently, we have to wait a frame
+      // before iOS is allowed to attempt to refocus (it takes a frame
+      // for the native a11y tree to become aware that it no longer has
+      // an accessibilityViewIsModal sibling).
+      if (Platform.OS === 'android') {
+        AccessibilityInfo.setAccessibilityFocus(handle);
+      } else {
+        requestAnimationFrame(() => {
+          AccessibilityInfo.setAccessibilityFocus(handle);
+        });
+      }
+    };
+  }, [imageGalleryStateStore]);
 
   return (
     <Animated.View

--- a/package/src/components/ImageGallery/ImageGallery.tsx
+++ b/package/src/components/ImageGallery/ImageGallery.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Image, ImageStyle, StyleSheet, ViewStyle } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
@@ -21,6 +21,8 @@ import type {
 
 import { useImageGalleryGestures } from './hooks/useImageGalleryGestures';
 
+import { useA11yLabel } from '../../a11y/hooks/useA11yLabel';
+import { useAccessibilityContext } from '../../contexts/accessibilityContext/AccessibilityContext';
 import { useComponentsContext } from '../../contexts/componentsContext/ComponentsContext';
 import {
   ImageGalleryProviderProps,
@@ -280,14 +282,62 @@ export const ImageGalleryWithContext = (props: ImageGalleryWithContextProps) => 
     setIsGridViewVisible(true);
   };
 
+  const { enabled: isAccessibilityEnabled } = useAccessibilityContext();
+  const assetsCount = assets.length;
+  const isAdjustable = isAccessibilityEnabled;
+  const accessibilityValueParams = useMemo(
+    () => ({ count: assetsCount, position: currentIndex + 1 }),
+    [currentIndex, assetsCount],
+  );
+  const accessibilityValueText = useA11yLabel(
+    'a11y/{{position}} of {{count}}',
+    accessibilityValueParams,
+  );
+  const accessibilityValue = useMemo(
+    () => (accessibilityValueText ? { text: accessibilityValueText } : undefined),
+    [accessibilityValueText],
+  );
+  const adjustableActions = useMemo(
+    () =>
+      isAdjustable ? [{ name: 'increment' as const }, { name: 'decrement' as const }] : undefined,
+    [isAdjustable],
+  );
+
+  const onAccessibilityAction = useCallback(
+    (event: { nativeEvent: { actionName: string } }) => {
+      if (!isAccessibilityEnabled) return;
+      const latest = imageGalleryStateStore.state.getLatestValue();
+      const latestCount = latest.assets.length;
+      const latestIndex = latest.currentIndex;
+      if (latestCount <= 1) return;
+      if (event.nativeEvent.actionName === 'increment') {
+        if (latestIndex < latestCount - 1) {
+          imageGalleryStateStore.currentIndex = latestIndex + 1;
+        }
+      } else if (event.nativeEvent.actionName === 'decrement') {
+        if (latestIndex > 0) {
+          imageGalleryStateStore.currentIndex = latestIndex - 1;
+        }
+      }
+    },
+    [imageGalleryStateStore, isAccessibilityEnabled],
+  );
+
   return (
     <Animated.View
-      accessibilityLabel='Image Gallery'
-      pointerEvents={'auto'}
       accessibilityViewIsModal
+      pointerEvents={'auto'}
       style={[StyleSheet.absoluteFill, showScreenStyle]}
     >
-      <Animated.View style={[StyleSheet.absoluteFill, containerBackground]} />
+      <Animated.View
+        accessible
+        accessibilityActions={adjustableActions}
+        accessibilityLabel='Image Gallery'
+        accessibilityRole={isAdjustable ? 'adjustable' : undefined}
+        accessibilityValue={isAdjustable ? accessibilityValue : undefined}
+        onAccessibilityAction={isAdjustable ? onAccessibilityAction : undefined}
+        style={[StyleSheet.absoluteFill, containerBackground]}
+      />
       <GestureDetector gesture={Gesture.Simultaneous(singleTap, doubleTap, pinch, pan)}>
         <Animated.View style={StyleSheet.absoluteFill}>
           <Animated.View

--- a/package/src/components/ImageGallery/__tests__/ImageGallery.test.tsx
+++ b/package/src/components/ImageGallery/__tests__/ImageGallery.test.tsx
@@ -99,8 +99,16 @@ describe('ImageGallery', () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryAllByLabelText('Image Item')).toHaveLength(2);
-      expect(screen.queryAllByLabelText('Image Gallery Video')).toHaveLength(1);
+      // The pager subtree is marked `accessibilityElementsHidden` /
+      // `importantForAccessibility='no-hide-descendants'` so screen readers
+      // can't land on the silent shadow views inside it; the queries here
+      // opt back into hidden elements so tests can still find the assets.
+      expect(
+        screen.queryAllByLabelText('Image Item', { includeHiddenElements: true }),
+      ).toHaveLength(2);
+      expect(
+        screen.queryAllByLabelText('Image Gallery Video', { includeHiddenElements: true }),
+      ).toHaveLength(1);
     });
   });
 
@@ -116,7 +124,9 @@ describe('ImageGallery', () => {
     );
 
     await waitFor(() => {
-      const pagerStyle = StyleSheet.flatten(screen.getByTestId('image-gallery-pager').props.style);
+      const pagerStyle = StyleSheet.flatten(
+        screen.getByTestId('image-gallery-pager', { includeHiddenElements: true }).props.style,
+      );
       expect(pagerStyle.direction).toBe('ltr');
     });
   });

--- a/package/src/components/ImageGallery/__tests__/ImageGalleryAdjustable.test.tsx
+++ b/package/src/components/ImageGallery/__tests__/ImageGalleryAdjustable.test.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect } from 'react';
+
+import type { SharedValue } from 'react-native-reanimated';
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+import { LocalMessage } from 'stream-chat';
+
+import {
+  ImageGalleryContext,
+  ImageGalleryContextValue,
+} from '../../../contexts/imageGalleryContext/ImageGalleryContext';
+import { OverlayProvider } from '../../../contexts/overlayContext/OverlayProvider';
+import {
+  generateImageAttachment,
+  generateVideoAttachment,
+} from '../../../mock-builders/generator/attachment';
+import { generateMessage } from '../../../mock-builders/generator/message';
+import { ImageGalleryStateStore } from '../../../state-store/image-gallery-state-store';
+import { ImageGallery } from '../ImageGallery';
+
+jest.mock('../../../native.ts', () => {
+  const { View } = require('react-native');
+  return {
+    isFileSystemAvailable: jest.fn(() => true),
+    isImageMediaLibraryAvailable: jest.fn(() => true),
+    isShareImageAvailable: jest.fn(() => true),
+    isVideoPlayerAvailable: jest.fn(() => true),
+    NativeHandlers: { Video: View },
+  };
+});
+
+type HarnessProps = {
+  message: LocalMessage;
+  accessibilityEnabled?: boolean;
+  store: ImageGalleryStateStore;
+};
+
+const Harness = ({ accessibilityEnabled = true, message, store }: HarnessProps) => {
+  useEffect(() => {
+    const unsubscribe = store.registerSubscriptions();
+    return () => unsubscribe();
+  }, [store]);
+
+  const { attachments } = message;
+  store.openImageGallery({
+    messages: [message],
+    selectedAttachmentUrl: attachments?.[0]?.asset_url || attachments?.[0]?.image_url || '',
+  });
+
+  return (
+    <OverlayProvider
+      accessibility={{ enabled: accessibilityEnabled }}
+      value={{ overlayOpacity: { value: 1 } as SharedValue<number> }}
+    >
+      <ImageGalleryContext.Provider
+        value={{ imageGalleryStateStore: store } as unknown as ImageGalleryContextValue}
+      >
+        <ImageGallery />
+      </ImageGalleryContext.Provider>
+    </OverlayProvider>
+  );
+};
+
+const findGalleryRoot = () =>
+  screen.getByLabelText('Image Gallery', { includeHiddenElements: true });
+
+const fireAccessibilityAction = (actionName: 'increment' | 'decrement') => {
+  fireEvent(findGalleryRoot(), 'accessibilityAction', { nativeEvent: { actionName } });
+};
+
+const renderWithAssets = (assetsCount: number, accessibilityEnabled = true) => {
+  const attachments = [
+    ...Array.from({ length: Math.max(assetsCount - 1, 0) }, () => generateImageAttachment()),
+    ...(assetsCount > 0 ? [generateVideoAttachment({ type: 'video' })] : []),
+  ];
+  const message = generateMessage({ attachments });
+  const store = new ImageGalleryStateStore();
+  render(<Harness accessibilityEnabled={accessibilityEnabled} message={message} store={store} />);
+  return { store };
+};
+
+describe('ImageGallery adjustable cycling', () => {
+  it('marks the root as adjustable with the position value when a11y is enabled and there is more than one asset', async () => {
+    renderWithAssets(3);
+
+    await waitFor(() => {
+      const root = findGalleryRoot();
+      expect(root.props.accessibilityRole).toBe('adjustable');
+      expect(root.props.accessibilityValue).toEqual({ text: '1 of 3' });
+      expect(root.props.accessibilityActions).toEqual([
+        { name: 'increment' },
+        { name: 'decrement' },
+      ]);
+    });
+  });
+
+  it('does not apply the adjustable role when accessibility is disabled', async () => {
+    renderWithAssets(3, false);
+
+    await waitFor(() => {
+      const root = findGalleryRoot();
+      expect(root.props.accessibilityRole).toBeUndefined();
+      expect(root.props.accessibilityActions).toBeUndefined();
+    });
+  });
+
+  it('moves to the next asset on increment and clamps at the last asset', async () => {
+    const { store } = renderWithAssets(3);
+
+    await waitFor(() => expect(findGalleryRoot().props.accessibilityRole).toBe('adjustable'));
+
+    act(() => fireAccessibilityAction('increment'));
+    expect(store.state.getLatestValue().currentIndex).toBe(1);
+
+    act(() => fireAccessibilityAction('increment'));
+    expect(store.state.getLatestValue().currentIndex).toBe(2);
+
+    act(() => fireAccessibilityAction('increment'));
+    expect(store.state.getLatestValue().currentIndex).toBe(2);
+  });
+
+  it('moves to the previous asset on decrement and clamps at the first asset', async () => {
+    const { store } = renderWithAssets(3);
+
+    await waitFor(() => expect(findGalleryRoot().props.accessibilityRole).toBe('adjustable'));
+
+    act(() => fireAccessibilityAction('increment'));
+    act(() => fireAccessibilityAction('increment'));
+    expect(store.state.getLatestValue().currentIndex).toBe(2);
+
+    act(() => fireAccessibilityAction('decrement'));
+    expect(store.state.getLatestValue().currentIndex).toBe(1);
+
+    act(() => fireAccessibilityAction('decrement'));
+    expect(store.state.getLatestValue().currentIndex).toBe(0);
+
+    act(() => fireAccessibilityAction('decrement'));
+    expect(store.state.getLatestValue().currentIndex).toBe(0);
+  });
+});

--- a/package/src/components/Message/MessageItemView/Headers/MessageReminderHeader.tsx
+++ b/package/src/components/Message/MessageItemView/Headers/MessageReminderHeader.tsx
@@ -33,7 +33,13 @@ const MessageReminderHeaderWithContext = (props: MessageReminderHeaderPropsWithC
       <Text style={styles.label}>
         {isReminderTimeLeft ? t('Reminder set') : t('Reminder overdue')}
       </Text>
-      <Text style={styles.dot}>·</Text>
+      <Text
+        accessibilityElementsHidden
+        importantForAccessibility='no-hide-descendants'
+        style={styles.dot}
+      >
+        ·
+      </Text>
       <Text style={styles.time}>
         {t('duration/Message reminder', {
           milliseconds: timeLeftMs,

--- a/package/src/components/Message/MessageItemView/Headers/SentToChannelHeader.tsx
+++ b/package/src/components/Message/MessageItemView/Headers/SentToChannelHeader.tsx
@@ -43,7 +43,13 @@ const SentToChannelHeaderWithContext = (props: SentToChannelHeaderPropsWithConte
       </Text>
       {showViewText ? (
         <>
-          <Text style={styles.dot}>·</Text>
+          <Text
+            accessibilityElementsHidden
+            importantForAccessibility='no-hide-descendants'
+            style={styles.dot}
+          >
+            ·
+          </Text>
           <Pressable onPress={onPress}>
             <Text style={styles.link}>{t('View')}</Text>
           </Pressable>

--- a/package/src/components/Message/MessageItemView/MessageContent.tsx
+++ b/package/src/components/Message/MessageItemView/MessageContent.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { ColorValue, Pressable, StyleSheet, View, ViewStyle } from 'react-native';
+import { ColorValue, Platform, Pressable, StyleSheet, View, ViewStyle } from 'react-native';
 
 import { MessageTextContainer } from './MessageTextContainer';
 
@@ -129,6 +129,10 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
   } = props;
   const { client } = useChatContext();
   const accessibilityHint = useA11yLabel('a11y/Double tap and hold to activate contextual menu');
+  const a11ySenderLabel = useA11yLabel(
+    isMyMessage ? 'a11y/Message from you' : 'a11y/Message from {{sender}}',
+    isMyMessage ? undefined : { sender: message.user?.name || message.user?.id || '' },
+  );
   const {
     Attachment,
     FileAttachmentGroup,
@@ -329,8 +333,16 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
     message.shared_location
   );
 
+  const a11yPressableLabel = useMemo(() => {
+    if (!a11ySenderLabel) return undefined;
+    return message.text && !hasInteractiveContent
+      ? `${a11ySenderLabel}. ${message.text}`
+      : a11ySenderLabel;
+  }, [a11ySenderLabel, hasInteractiveContent, message.text]);
+
   return (
     <Pressable
+      accessibilityLabel={a11yPressableLabel}
       accessibilityHint={accessibilityHint}
       accessible={hasInteractiveContent ? false : undefined}
       disabled={preventPress}
@@ -382,6 +394,15 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
         ]}
         testID='message-content-wrapper'
       >
+        {a11ySenderLabel && Platform.OS !== 'android' && hasInteractiveContent ? (
+          <View
+            accessibilityLabel={a11ySenderLabel}
+            accessibilityHint={accessibilityHint}
+            accessible
+            pointerEvents='none'
+            style={StyleSheet.absoluteFill}
+          />
+        ) : null}
         {MessageContentTopView ? <MessageContentTopView /> : null}
         {hasContentSideViews ? (
           <View

--- a/package/src/components/Message/MessageItemView/MessageContent.tsx
+++ b/package/src/components/Message/MessageItemView/MessageContent.tsx
@@ -55,6 +55,7 @@ export type MessageContentPropsWithContext = Pick<
   | 'alignment'
   | 'goToMessage'
   | 'groupStyles'
+  | 'hasInteractiveAccessibilityContent'
   | 'isMyMessage'
   | 'message'
   | 'messageContentOrder'
@@ -111,6 +112,7 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
     enableMessageGroupingByUser,
     groupStyles,
     goToMessage,
+    hasInteractiveAccessibilityContent,
     isMessageAIGenerated,
     isMyMessage,
     isVeryLastMessage,
@@ -321,30 +323,18 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
       )}
     </>
   );
-
-  // Drop the Pressable's single-focus-stop behavior when the message contains
-  // interactive children (poll options, attachment cells, the quoted-reply
-  // navigator, shared location). Without this, VO/TalkBack subsume those
-  // children into the row's one announcement and they can't be activated.
-  const hasInteractiveContent = !!(
-    message.poll_id ||
-    message.quoted_message ||
-    message.attachments?.length ||
-    message.shared_location
-  );
-
   const a11yPressableLabel = useMemo(() => {
     if (!a11ySenderLabel) return undefined;
-    return message.text && !hasInteractiveContent
+    return message.text && !hasInteractiveAccessibilityContent
       ? `${a11ySenderLabel}. ${message.text}`
       : a11ySenderLabel;
-  }, [a11ySenderLabel, hasInteractiveContent, message.text]);
+  }, [a11ySenderLabel, hasInteractiveAccessibilityContent, message.text]);
 
   return (
     <Pressable
       accessibilityLabel={a11yPressableLabel}
       accessibilityHint={accessibilityHint}
-      accessible={hasInteractiveContent ? false : undefined}
+      accessible={hasInteractiveAccessibilityContent ? false : undefined}
       disabled={preventPress}
       onLongPress={(event) => {
         if (onLongPress) {
@@ -394,7 +384,7 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
         ]}
         testID='message-content-wrapper'
       >
-        {a11ySenderLabel && Platform.OS !== 'android' && hasInteractiveContent ? (
+        {a11ySenderLabel && Platform.OS !== 'android' && hasInteractiveAccessibilityContent ? (
           <View
             accessibilityLabel={a11ySenderLabel}
             accessibilityHint={accessibilityHint}
@@ -435,6 +425,7 @@ const areEqual = (
     preventPress: prevPreventPress,
     goToMessage: prevGoToMessage,
     groupStyles: prevGroupStyles,
+    hasInteractiveAccessibilityContent: prevHasInteractiveAccessibilityContent,
     isAttachmentEqual,
     message: prevMessage,
     messageContentOrder: prevMessageContentOrder,
@@ -448,12 +439,17 @@ const areEqual = (
     preventPress: nextPreventPress,
     goToMessage: nextGoToMessage,
     groupStyles: nextGroupStyles,
+    hasInteractiveAccessibilityContent: nextHasInteractiveAccessibilityContent,
     message: nextMessage,
     messageContentOrder: nextMessageContentOrder,
     myMessageTheme: nextMyMessageTheme,
     otherAttachments: nextOtherAttachments,
     t: nextT,
   } = nextProps;
+
+  if (prevHasInteractiveAccessibilityContent !== nextHasInteractiveAccessibilityContent) {
+    return false;
+  }
 
   if (prevBackgroundColor !== nextBackgroundColor) {
     return false;
@@ -590,8 +586,11 @@ export type MessageContentProps = Partial<MessageContentPropsWithContext>;
 export const MessageContent = (props: MessageContentProps) => {
   const {
     alignment,
+    files,
     goToMessage,
     groupStyles,
+    hasInteractiveAccessibilityContent,
+    images,
     isMessageAIGenerated,
     isMyMessage,
     message,
@@ -602,8 +601,6 @@ export const MessageContent = (props: MessageContentProps) => {
     otherAttachments,
     preventPress,
     threadList,
-    files,
-    images,
     videos,
   } = useMessageContext();
   const {
@@ -658,6 +655,7 @@ export const MessageContent = (props: MessageContentProps) => {
         enableMessageGroupingByUser,
         goToMessage,
         groupStyles,
+        hasInteractiveAccessibilityContent,
         isAttachmentEqual,
         isMessageAIGenerated,
         isMyMessage,

--- a/package/src/components/Message/MessageItemView/MessageReplies.tsx
+++ b/package/src/components/Message/MessageItemView/MessageReplies.tsx
@@ -75,10 +75,18 @@ const MessageRepliesWithContext = (props: MessageRepliesPropsWithContext) => {
     return null;
   }
 
+  const replyCountLabel =
+    message.reply_count === 1
+      ? t('1 Reply')
+      : t('{{ replyCount }} Replies', { replyCount: message.reply_count });
+
   return (
     <View style={[styles.container, container]}>
       {alignment === 'left' ? connector : null}
       <Pressable
+        accessibilityHint={t('a11y/Double tap to view thread')}
+        accessibilityLabel={replyCountLabel}
+        accessibilityRole='button'
         disabled={preventPress}
         onLongPress={(event) => {
           if (onLongPress) {
@@ -114,13 +122,7 @@ const MessageRepliesWithContext = (props: MessageRepliesPropsWithContext) => {
         testID='message-replies'
       >
         <MessageRepliesAvatars />
-        <Text style={[styles.messageRepliesText, messageRepliesText]}>
-          {message.reply_count === 1
-            ? t('1 Reply')
-            : t('{{ replyCount }} Replies', {
-                replyCount: message.reply_count,
-              })}
-        </Text>
+        <Text style={[styles.messageRepliesText, messageRepliesText]}>{replyCountLabel}</Text>
       </Pressable>
       {alignment === 'right' ? connector : null}
     </View>

--- a/package/src/components/Message/MessageItemView/MessageRepliesAvatars.tsx
+++ b/package/src/components/Message/MessageItemView/MessageRepliesAvatars.tsx
@@ -24,7 +24,11 @@ export const MessageRepliesAvatarsWithContext = (props: MessageRepliesAvatarsPro
   const avatars = message?.thread_participants || [];
 
   return (
-    <View style={avatarStackContainer}>
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility='no-hide-descendants'
+      style={avatarStackContainer}
+    >
       <UserAvatarStack users={avatars} avatarSize='sm' maxVisible={3} overlap={0.4} />
     </View>
   );

--- a/package/src/components/Message/MessageItemView/MessageTextContainer.tsx
+++ b/package/src/components/Message/MessageItemView/MessageTextContainer.tsx
@@ -79,8 +79,17 @@ const MessageTextContainerWithContext = (props: MessageTextContainerPropsWithCon
 
   const markdownStyles = { ...markdown, ...markdownStylesProp };
 
+  const hasInteractiveContent = !!(
+    message.poll_id ||
+    message.quoted_message ||
+    message.attachments?.length ||
+    message.shared_location
+  );
+
   return (
     <View
+      accessible={hasInteractiveContent || undefined}
+      accessibilityRole={hasInteractiveContent ? 'text' : undefined}
       style={[styles.textContainer, textContainer, stylesProp.textContainer]}
       testID='message-text-container'
     >

--- a/package/src/components/Message/MessageItemView/MessageTextContainer.tsx
+++ b/package/src/components/Message/MessageItemView/MessageTextContainer.tsx
@@ -31,7 +31,13 @@ export type MessageTextProps = MessageTextContainerProps & {
 
 export type MessageTextContainerPropsWithContext = Pick<
   MessageContextValue,
-  'message' | 'onLongPress' | 'onlyEmojis' | 'onPress' | 'preventPress' | 'isMyMessage'
+  | 'hasInteractiveAccessibilityContent'
+  | 'isMyMessage'
+  | 'message'
+  | 'onLongPress'
+  | 'onlyEmojis'
+  | 'onPress'
+  | 'preventPress'
 > &
   Pick<MessagesContextValue, 'markdownRules' | 'myMessageTheme' | 'messageTextNumberOfLines'> & {
     markdownStyles?: MarkdownStyle;
@@ -45,6 +51,7 @@ const MessageTextContainerWithContext = (props: MessageTextContainerPropsWithCon
   const theme = useTheme();
 
   const {
+    hasInteractiveAccessibilityContent,
     isMyMessage,
     markdownRules,
     markdownStyles: markdownStylesProp = {},
@@ -79,17 +86,10 @@ const MessageTextContainerWithContext = (props: MessageTextContainerPropsWithCon
 
   const markdownStyles = { ...markdown, ...markdownStylesProp };
 
-  const hasInteractiveContent = !!(
-    message.poll_id ||
-    message.quoted_message ||
-    message.attachments?.length ||
-    message.shared_location
-  );
-
   return (
     <View
-      accessible={hasInteractiveContent || undefined}
-      accessibilityRole={hasInteractiveContent ? 'text' : undefined}
+      accessible={hasInteractiveAccessibilityContent || undefined}
+      accessibilityRole={hasInteractiveAccessibilityContent ? 'text' : undefined}
       style={[styles.textContainer, textContainer, stylesProp.textContainer]}
       testID='message-text-container'
     >
@@ -122,17 +122,23 @@ const areEqual = (
   nextProps: MessageTextContainerPropsWithContext,
 ) => {
   const {
+    hasInteractiveAccessibilityContent: prevHasInteractiveAccessibilityContent,
     markdownStyles: prevMarkdownStyles,
     message: prevMessage,
     myMessageTheme: prevMyMessageTheme,
     onlyEmojis: prevOnlyEmojis,
   } = prevProps;
   const {
+    hasInteractiveAccessibilityContent: nextHasInteractiveAccessibilityContent,
     markdownStyles: nextMarkdownStyles,
     message: nextMessage,
     myMessageTheme: nextMyMessageTheme,
     onlyEmojis: nextOnlyEmojis,
   } = nextProps;
+
+  if (prevHasInteractiveAccessibilityContent !== nextHasInteractiveAccessibilityContent) {
+    return false;
+  }
 
   const messageStatusEqual = prevMessage.status === nextMessage.status;
   if (!messageStatusEqual) {
@@ -191,16 +197,24 @@ const MemoizedMessageTextContainer = React.memo(
 export type MessageTextContainerProps = Partial<MessageTextContainerPropsWithContext>;
 
 export const MessageTextContainer = (props: MessageTextContainerProps) => {
-  const { message, onLongPress, onlyEmojis, onPress, preventPress, isMyMessage } =
-    useMessageContext();
+  const {
+    hasInteractiveAccessibilityContent,
+    isMyMessage,
+    message,
+    onLongPress,
+    onlyEmojis,
+    onPress,
+    preventPress,
+  } = useMessageContext();
   const { markdownRules, messageTextNumberOfLines, myMessageTheme } = useMessagesContext();
 
   return (
     <MemoizedMessageTextContainer
       {...{
+        hasInteractiveAccessibilityContent,
+        isMyMessage,
         markdownRules,
         message,
-        isMyMessage,
         messageTextNumberOfLines,
         myMessageTheme,
         onLongPress,

--- a/package/src/components/Message/MessageItemView/ReactionList/ReactionListItem.tsx
+++ b/package/src/components/Message/MessageItemView/ReactionList/ReactionListItem.tsx
@@ -72,6 +72,8 @@ export const ReactionListItem = (props: ReactionListItemProps) => {
 
   return (
     <ReactionListItemWrapper
+      accessibilityRole='button'
+      accessibilityState={{ selected }}
       disabled={preventPress}
       key={reaction.type}
       testID='reaction-list-item'

--- a/package/src/components/Message/MessageItemView/__tests__/Message.test.tsx
+++ b/package/src/components/Message/MessageItemView/__tests__/Message.test.tsx
@@ -171,10 +171,17 @@ describe('Message', () => {
 
     fireEvent(getByTestId('custom-overlay-trigger'), 'longPress');
 
+    // Once the overlay opens, the host layer's `accessibilityViewIsModal`
+    // marks the chat-side subtree as hidden to RNTL. The overlay target's
+    // children are Portal-teleported but their React parent stays in the
+    // chat, so default visibility filtering excludes them. Pass
+    // `includeHiddenElements` to look past the modal-sibling heuristic.
     await waitFor(() => {
-      expect(getByText('outside:normal')).toBeTruthy();
-      expect(getByText('inside:overlay')).toBeTruthy();
-      expect(getByTestId('custom-overlay-target-placeholder')).toBeTruthy();
+      expect(getByText('outside:normal', { includeHiddenElements: true })).toBeTruthy();
+      expect(getByText('inside:overlay', { includeHiddenElements: true })).toBeTruthy();
+      expect(
+        getByTestId('custom-overlay-target-placeholder', { includeHiddenElements: true }),
+      ).toBeTruthy();
     });
   });
 });

--- a/package/src/components/Message/MessageItemView/__tests__/MessageReplies.test.tsx
+++ b/package/src/components/Message/MessageItemView/__tests__/MessageReplies.test.tsx
@@ -33,7 +33,11 @@ describe('MessageReplies', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-replies')).toBeTruthy();
+      const pluralPressable = screen.getByTestId('message-replies');
+      expect(pluralPressable).toBeTruthy();
+      expect(pluralPressable.props.accessibilityRole).toBe('button');
+      expect(pluralPressable.props.accessibilityLabel).toBe('{{ replyCount }} Replies');
+      expect(pluralPressable.props.accessibilityHint).toBe('a11y/Double tap to view thread');
       expect(t).toHaveBeenCalledWith('{{ replyCount }} Replies', {
         replyCount: message.reply_count,
       });
@@ -57,7 +61,11 @@ describe('MessageReplies', () => {
 
     await waitFor(() => {
       expect(onPressMock).toHaveBeenCalled();
-      expect(screen.getByTestId('message-replies')).toBeTruthy();
+      const singularPressable = screen.getByTestId('message-replies');
+      expect(singularPressable).toBeTruthy();
+      expect(singularPressable.props.accessibilityRole).toBe('button');
+      expect(singularPressable.props.accessibilityLabel).toBe('1 Reply');
+      expect(singularPressable.props.accessibilityHint).toBe('a11y/Double tap to view thread');
       expect(t).toHaveBeenCalledWith('1 Reply');
       expect(screen.getByText('1 Reply')).toBeTruthy();
     });

--- a/package/src/components/Message/hooks/useCreateMessageContext.ts
+++ b/package/src/components/Message/hooks/useCreateMessageContext.ts
@@ -1,5 +1,6 @@
 import { useMemo, useRef } from 'react';
 
+import { useAccessibilityContext } from '../../../contexts/accessibilityContext/AccessibilityContext';
 import type { MessageContextValue } from '../../../contexts/messageContext/MessageContext';
 
 import { stringifyMessage } from '../../../utils/utils';
@@ -58,7 +59,7 @@ export const useCreateMessageContext = ({
   threadList,
   videos,
   setQuotedMessage,
-}: MessageContextValue) => {
+}: Omit<MessageContextValue, 'hasInteractiveAccessibilityContent'>) => {
   const stableGroupStyles = useStableRefValue(groupStyles);
   const reactionsValue = reactions.map(({ count, own, type }) => `${own}${type}${count}`).join();
   const stringifiedMessage = stringifyMessage({ message });
@@ -69,6 +70,14 @@ export const useCreateMessageContext = ({
   const stringifiedQuotedMessage = message.quoted_message
     ? stringifyMessage({ includeReactions: false, message: message.quoted_message })
     : '';
+
+  // Resolved here (not at each consumer) so the boolean lives on MessageContext
+  // and downstream components (MessageContent, MessageTextContainer) read it
+  // directly. The predicate's identity is stable in the default case; an
+  // integrator override is expected to be stable too (documented on the config).
+  const { hasInteractiveAccessibilityContent: hasInteractiveAccessibilityContentPredicate } =
+    useAccessibilityContext();
+  const hasInteractiveAccessibilityContent = hasInteractiveAccessibilityContentPredicate(message);
 
   const messageContext: MessageContextValue = useMemo(
     () => ({
@@ -85,6 +94,7 @@ export const useCreateMessageContext = ({
       hasAttachmentActions,
       handleReaction,
       handleToggleReaction,
+      hasInteractiveAccessibilityContent,
       hasReactions,
       messageHasOnlySingleAttachment,
       images,
@@ -123,6 +133,7 @@ export const useCreateMessageContext = ({
       goToMessage,
       stableGroupStyles,
       hasAttachmentActions,
+      hasInteractiveAccessibilityContent,
       hasReactions,
       messageHasOnlySingleAttachment,
       lastGroupMessage,

--- a/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.tsx.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.tsx.snap
@@ -818,6 +818,7 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
     </View>
   </View>
   <View
+    accessibilityViewIsModal={false}
     collapsable={false}
     pointerEvents="box-none"
     style={
@@ -1733,6 +1734,7 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
     </View>
   </View>
   <View
+    accessibilityViewIsModal={false}
     collapsable={false}
     pointerEvents="box-none"
     style={
@@ -2648,6 +2650,7 @@ exports[`AttachButton should render an disabled AttachButton 1`] = `
     </View>
   </View>
   <View
+    accessibilityViewIsModal={false}
     collapsable={false}
     pointerEvents="box-none"
     style={

--- a/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.tsx.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.tsx.snap
@@ -816,6 +816,7 @@ exports[`SendButton should render a SendButton 1`] = `
     </View>
   </View>
   <View
+    accessibilityViewIsModal={false}
     collapsable={false}
     pointerEvents="box-none"
     style={
@@ -1729,6 +1730,7 @@ exports[`SendButton should render a disabled SendButton 1`] = `
     </View>
   </View>
   <View
+    accessibilityViewIsModal={false}
     collapsable={false}
     pointerEvents="box-none"
     style={

--- a/package/src/components/MessageList/InlineDateSeparator.tsx
+++ b/package/src/components/MessageList/InlineDateSeparator.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useTranslationContext } from '../../contexts/translationContext/TranslationContext';
 import { primitives } from '../../theme';
-import { getDateString } from '../../utils/i18n/getDateString';
+import { getDateString, getDateStringForA11y } from '../../utils/i18n/getDateString';
 
 /**
  * Props for the `InlineDateSeparator` component.
@@ -17,7 +17,7 @@ export type InlineDateSeparatorProps = {
 };
 
 export const InlineDateSeparator = ({ date }: InlineDateSeparatorProps) => {
-  const { t, tDateTimeParser } = useTranslationContext();
+  const { t, tDateTimeParser, userLanguage } = useTranslationContext();
   const styles = useStyles();
 
   const dateString = useMemo(
@@ -31,9 +31,16 @@ export const InlineDateSeparator = ({ date }: InlineDateSeparatorProps) => {
     [date, t, tDateTimeParser],
   );
 
+  const a11yDateString = useMemo(
+    () => getDateStringForA11y({ date, tDateTimeParser, userLanguage }),
+    [date, tDateTimeParser, userLanguage],
+  );
+
   return (
     <View style={styles.container} testID='date-separator'>
-      <Text style={styles.text}>{dateString}</Text>
+      <Text accessibilityLabel={a11yDateString} style={styles.text}>
+        {dateString}
+      </Text>
     </View>
   );
 };

--- a/package/src/components/MessageMenu/ReactionButton.tsx
+++ b/package/src/components/MessageMenu/ReactionButton.tsx
@@ -49,17 +49,10 @@ export const ReactionButton = (props: ReactionButtonProps) => {
     () => <Icon size={reactionIconSize ?? 24} />,
     [Icon, reactionIconSize],
   );
-  const selectedLabelState = selected ? 'selected' : 'unselected';
-  const accessibilityLabelParams = useMemo(
-    () => ({ selected: selectedLabelState, type }),
-    [selectedLabelState, type],
-  );
 
   return (
     <View style={styles.reactionButton}>
       <Button
-        accessibilityLabelKey='a11y/reaction-button-{{type}}-{{selected}}'
-        accessibilityLabelParams={accessibilityLabelParams}
         variant={'secondary'}
         type={'outline'}
         iconOnly={!count}

--- a/package/src/components/MessageMenu/__tests__/ReactionButton.test.tsx
+++ b/package/src/components/MessageMenu/__tests__/ReactionButton.test.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import { Text } from 'react-native';
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { cleanup, fireEvent, render } from '@testing-library/react-native';
 
-import { OverlayProvider } from '../../../contexts/overlayContext/OverlayProvider';
 import { ThemeProvider } from '../../../contexts/themeContext/ThemeContext';
 import { defaultTheme } from '../../../contexts/themeContext/utils/theme';
 import { IconProps } from '../../../icons';
@@ -36,18 +35,6 @@ describe('ReactionButton', () => {
 
     // Check if the unselected pathFill color is rendered by the mock Icon
     expect(getByText('24')).toBeTruthy();
-  });
-
-  it('uses the released reaction button label when accessibility labels are translated', async () => {
-    render(
-      <OverlayProvider accessibility={{ enabled: true }}>
-        <ReactionButton {...defaultProps} />
-      </OverlayProvider>,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('reaction-button-like-unselected')).toBeTruthy();
-    });
   });
 
   it('should call onPress function with the correct reaction type when pressed', () => {

--- a/package/src/components/Poll/Poll.tsx
+++ b/package/src/components/Poll/Poll.tsx
@@ -50,7 +50,7 @@ export const PollHeader = () => {
   } = useTheme();
 
   return (
-    <View style={styles.headerContainer}>
+    <View accessible accessibilityRole='text' style={styles.headerContainer}>
       <Text style={[styles.headerTitle, header.title]}>{name}</Text>
       <Text style={[styles.headerSubtitle, header.subtitle]}>{subtitle}</Text>
     </View>

--- a/package/src/components/Poll/components/PollOption.tsx
+++ b/package/src/components/Poll/components/PollOption.tsx
@@ -92,6 +92,7 @@ export const PollAllOptions = ({
 
 export const PollOption = ({ option, showProgressBar = true, forceIncoming }: PollOptionProps) => {
   const { latestVotesByOption, voteCountsByOption, voteCount } = usePollState();
+  const { t } = useTranslationContext();
   const styles = useStyles();
 
   const relevantVotes = useMemo(
@@ -141,7 +142,12 @@ export const PollOption = ({ option, showProgressBar = true, forceIncoming }: Po
               />
             ) : null}
 
-            <Text style={[styles.votesText, votesText]}>{voteCountsByOption[option.id] || 0}</Text>
+            <Text
+              accessibilityLabel={t('{{count}} votes', { count: votes })}
+              style={[styles.votesText, votesText]}
+            >
+              {votes}
+            </Text>
           </View>
         </View>
         {showProgressBar ? (

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.tsx.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.tsx.snap
@@ -1017,6 +1017,7 @@ exports[`Thread should match thread snapshot 1`] = `
                   testID="date-separator"
                 >
                   <Text
+                    accessibilityLabel="May 5, 2020"
                     style={
                       {
                         "color": "#414552",

--- a/package/src/contexts/accessibilityContext/AccessibilityContext.tsx
+++ b/package/src/contexts/accessibilityContext/AccessibilityContext.tsx
@@ -162,38 +162,5 @@ export const AccessibilityProvider = ({
   );
 };
 
-export const useAccessibilityContext = (): ResolvedAccessibilityConfig => {
-  const {
-    announceConnectionState,
-    announceNewMessages,
-    announceTypingIndicator,
-    audioRecorderTapMode,
-    enabled,
-    forceScreenReaderMode,
-    imageGalleryScreenReaderMode,
-    messageActionsTrigger,
-  } = useContext(AccessibilityContext);
-
-  return useMemo(
-    () => ({
-      announceConnectionState,
-      announceNewMessages,
-      announceTypingIndicator,
-      audioRecorderTapMode,
-      enabled,
-      forceScreenReaderMode,
-      imageGalleryScreenReaderMode,
-      messageActionsTrigger,
-    }),
-    [
-      announceConnectionState,
-      announceNewMessages,
-      announceTypingIndicator,
-      audioRecorderTapMode,
-      enabled,
-      forceScreenReaderMode,
-      imageGalleryScreenReaderMode,
-      messageActionsTrigger,
-    ],
-  );
-};
+export const useAccessibilityContext = (): ResolvedAccessibilityConfig =>
+  useContext(AccessibilityContext);

--- a/package/src/contexts/accessibilityContext/AccessibilityContext.tsx
+++ b/package/src/contexts/accessibilityContext/AccessibilityContext.tsx
@@ -8,6 +8,8 @@ import React, {
 } from 'react';
 import { AccessibilityInfo } from 'react-native';
 
+import type { LocalMessage } from 'stream-chat';
+
 import { AccessibilityAnnouncerContext } from '../../components/Accessibility/useAccessibilityAnnouncer';
 import type {
   AccessibilityAnnounce,
@@ -23,6 +25,39 @@ type TimeoutByPriority = {
 
 /** Tri-state for gesture-alternative toggles. */
 export type A11yMode = 'auto' | 'always' | 'never';
+
+/**
+ * Resolved predicate stored on the context - consumers call `(message)` and
+ * receive the boolean directly.
+ */
+export type HasInteractiveAccessibilityContent = (message: LocalMessage) => boolean;
+
+/**
+ * Integrator facing override shape. Receives the SDK's baseline boolean as the
+ * second argument so overrides can extend rather than replace:
+ *
+ * ```
+ *   hasInteractiveAccessibilityContent: (message, defaultValue) =>
+ *     defaultValue || !!message.my_custom_field
+ * ```
+ *
+ * To replace fully, ignore the second argument. Must be stable across renders
+ * an unstable function will rerender every Message context consumer on every
+ * downstream render.
+ */
+export type HasInteractiveAccessibilityContentConfig = (
+  message: LocalMessage,
+  defaultValue: boolean,
+) => boolean;
+
+/** SDK baseline — true when the message renders interactive children. */
+const defaultHasInteractiveAccessibilityContent: HasInteractiveAccessibilityContent = (message) =>
+  !!(
+    message.poll_id ||
+    message.quoted_message ||
+    message.attachments?.length ||
+    message.shared_location
+  );
 
 export type AccessibilityConfig = {
   /**
@@ -45,10 +80,22 @@ export type AccessibilityConfig = {
   imageGalleryScreenReaderMode?: A11yMode;
   /** Message actions trigger. 'long-press' (no alt button), 'auto' (default — show button when SR is on), 'always-button'. */
   messageActionsTrigger?: 'long-press' | 'auto' | 'always-button';
+  /**
+   * Override the SDK's "this message has interactive children" decision.
+   * Will control what it means for a message to have interactive content.
+   * This affects the way we mark the message bubble as accessible and whether
+   * we let the children handle it on their own or whether we want the bubble to
+   * handle everything. See {@link HasInteractiveAccessibilityContentConfig}.
+   */
+  hasInteractiveAccessibilityContent?: HasInteractiveAccessibilityContentConfig;
 };
 
 /** Fully-resolved config — every field is populated with its default. */
-export type ResolvedAccessibilityConfig = Required<AccessibilityConfig>;
+export type ResolvedAccessibilityConfig = Required<
+  Omit<AccessibilityConfig, 'hasInteractiveAccessibilityContent'>
+> & {
+  hasInteractiveAccessibilityContent: HasInteractiveAccessibilityContent;
+};
 
 export const accessibilityContextDefaultValue: ResolvedAccessibilityConfig = {
   announceConnectionState: true,
@@ -57,6 +104,7 @@ export const accessibilityContextDefaultValue: ResolvedAccessibilityConfig = {
   audioRecorderTapMode: 'auto',
   enabled: false,
   forceScreenReaderMode: false,
+  hasInteractiveAccessibilityContent: defaultHasInteractiveAccessibilityContent,
   imageGalleryScreenReaderMode: 'auto',
   messageActionsTrigger: 'auto',
 };
@@ -124,6 +172,7 @@ export const AccessibilityProvider = ({
     audioRecorderTapMode = accessibilityContextDefaultValue.audioRecorderTapMode,
     enabled = accessibilityContextDefaultValue.enabled,
     forceScreenReaderMode = accessibilityContextDefaultValue.forceScreenReaderMode,
+    hasInteractiveAccessibilityContent,
     imageGalleryScreenReaderMode = accessibilityContextDefaultValue.imageGalleryScreenReaderMode,
     messageActionsTrigger = accessibilityContextDefaultValue.messageActionsTrigger,
   } = value ?? {};
@@ -136,6 +185,13 @@ export const AccessibilityProvider = ({
       audioRecorderTapMode,
       enabled,
       forceScreenReaderMode,
+      hasInteractiveAccessibilityContent: hasInteractiveAccessibilityContent
+        ? (message) =>
+            hasInteractiveAccessibilityContent(
+              message,
+              accessibilityContextDefaultValue.hasInteractiveAccessibilityContent(message),
+            )
+        : accessibilityContextDefaultValue.hasInteractiveAccessibilityContent,
       imageGalleryScreenReaderMode,
       messageActionsTrigger,
     }),
@@ -146,6 +202,7 @@ export const AccessibilityProvider = ({
       audioRecorderTapMode,
       enabled,
       forceScreenReaderMode,
+      hasInteractiveAccessibilityContent,
       imageGalleryScreenReaderMode,
       messageActionsTrigger,
     ],

--- a/package/src/contexts/messageContext/MessageContext.tsx
+++ b/package/src/contexts/messageContext/MessageContext.tsx
@@ -45,6 +45,14 @@ export type MessageContextValue = {
   /** Whether or not any message attachment exposes actions. */
   hasAttachmentActions: boolean;
   handleToggleReaction: (reactionType: string) => Promise<void>;
+  /**
+   * Whether the message renders interactive children (poll options, attachment
+   * cells, the quoted-reply navigator, shared location) and the row should
+   * therefore drop its single focusstop so VO/TalkBack can drill into them.
+   * Resolved from `AccessibilityContext.hasInteractiveAccessibilityContent` -
+   * integrators override there to include their own custom content.
+   */
+  hasInteractiveAccessibilityContent: boolean;
   /** Whether or not message has reactions */
   hasReactions: boolean;
   /** Whether or not message has only a single attachment */

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -269,7 +269,11 @@ export const MessageOverlayHostLayer = () => {
 
   return (
     <GestureDetector gesture={tap}>
-      <View pointerEvents='box-none' style={StyleSheet.absoluteFill}>
+      <View
+        accessibilityViewIsModal={isActive}
+        pointerEvents='box-none'
+        style={StyleSheet.absoluteFill}
+      >
         {isActive ? (
           <Animated.View pointerEvents='none' style={[StyleSheet.absoluteFill, backdropStyle]}>
             <OverlayBackground />

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -9,6 +9,7 @@ import { PortalProvider } from 'react-native-teleport';
 import { MessageOverlayHostLayer } from './MessageOverlayHostLayer';
 import { OverlayContext, OverlayProviderProps } from './OverlayContext';
 
+import { OverlayA11yShield } from '../../components/Accessibility/OverlayA11yShield';
 import { ImageGallery } from '../../components/ImageGallery/ImageGallery';
 import { useStreami18n } from '../../hooks/useStreami18n';
 
@@ -107,7 +108,7 @@ export const OverlayProvider = (props: PropsWithChildren<OverlayProviderProps>) 
           <ImageGalleryProvider value={imageGalleryProviderProps}>
             <ThemeProvider style={overlayContext.style}>
               <PortalProvider>
-                {children}
+                <OverlayA11yShield>{children}</OverlayA11yShield>
                 {overlay === 'gallery' && <ImageGallery overlayOpacity={overlayOpacity} />}
                 <MessageOverlayHostLayer />
               </PortalProvider>

--- a/package/src/i18n/ar.json
+++ b/package/src/i18n/ar.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "اسحب لليمين للتنقل بين الإجراءات المختلفة",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "{{count}} رسائل غير مقروءة"
+  "a11y/{{count}} unread messages": "{{count}} رسائل غير مقروءة",
+  "a11y/Message from you": "رسالة منك",
+  "a11y/Message from {{sender}}": "رسالة من {{sender}}"
 }

--- a/package/src/i18n/ar.json
+++ b/package/src/i18n/ar.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "محادثة مباشرة مع {{name}}",
   "a11y/Double tap to open": "انقر مرتين للفتح",
   "a11y/Double tap to view reactions": "انقر مرتين لعرض التفاعلات",
+  "a11y/Double tap to view thread": "انقر مرتين لعرض المحادثة الفرعية",
   "a11y/Editing message": "تعديل الرسالة",
   "a11y/Editing message: {{text}}": "تعديل الرسالة: {{text}}",
   "a11y/Last message {{date}}": "آخر رسالة {{date}}",

--- a/package/src/i18n/ar.json
+++ b/package/src/i18n/ar.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "{{count}} رسائل غير مقروءة",
   "a11y/Message from you": "رسالة منك",
-  "a11y/Message from {{sender}}": "رسالة من {{sender}}"
+  "a11y/Message from {{sender}}": "رسالة من {{sender}}",
+  "a11y/Gallery Image": "صورة من المعرض",
+  "a11y/Gallery Video": "فيديو من المعرض"
 }

--- a/package/src/i18n/ar.json
+++ b/package/src/i18n/ar.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "رسالة منك",
   "a11y/Message from {{sender}}": "رسالة من {{sender}}",
   "a11y/Gallery Image": "صورة من المعرض",
-  "a11y/Gallery Video": "فيديو من المعرض"
+  "a11y/Gallery Video": "فيديو من المعرض",
+  "a11y/{{position}} of {{count}}": "{{position}} من {{count}}"
 }

--- a/package/src/i18n/en.json
+++ b/package/src/i18n/en.json
@@ -266,6 +266,8 @@
   "a11y/Loading": "Loading",
   "a11y/Loading failed": "Loading failed",
   "a11y/Message actions": "Message actions",
+  "a11y/Message from you": "Message from you",
+  "a11y/Message from {{sender}}": "Message from {{sender}}",
   "a11y/Muted": "Muted",
   "a11y/New message from {{user}}": "New message from {{user}}",
   "a11y/Offline": "Offline",

--- a/package/src/i18n/en.json
+++ b/package/src/i18n/en.json
@@ -375,5 +375,6 @@
   "unsupported file type": "unsupported file type",
   "a11y/{{count}} unread messages": "{{count}} unread messages",
   "a11y/Gallery Image": "Gallery image",
-  "a11y/Gallery Video": "Gallery video"
+  "a11y/Gallery Video": "Gallery video",
+  "a11y/{{position}} of {{count}}": "{{position}} of {{count}}"
 }

--- a/package/src/i18n/en.json
+++ b/package/src/i18n/en.json
@@ -373,5 +373,7 @@
   "size limit": "size limit",
   "unknown error": "unknown error",
   "unsupported file type": "unsupported file type",
-  "a11y/{{count}} unread messages": "{{count}} unread messages"
+  "a11y/{{count}} unread messages": "{{count}} unread messages",
+  "a11y/Gallery Image": "Gallery image",
+  "a11y/Gallery Video": "Gallery video"
 }

--- a/package/src/i18n/en.json
+++ b/package/src/i18n/en.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "Direct chat with {{name}}",
   "a11y/Double tap to open": "Double tap to open",
   "a11y/Double tap to view reactions": "Double tap to view reactions",
+  "a11y/Double tap to view thread": "Double tap to view thread",
   "a11y/Editing message": "Editing message",
   "a11y/Editing message: {{text}}": "Editing message: {{text}}",
   "a11y/Last message {{date}}": "Last message {{date}}",

--- a/package/src/i18n/es.json
+++ b/package/src/i18n/es.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "Mensaje tuyo",
   "a11y/Message from {{sender}}": "Mensaje de {{sender}}",
   "a11y/Gallery Image": "Imagen de la galería",
-  "a11y/Gallery Video": "Vídeo de la galería"
+  "a11y/Gallery Video": "Vídeo de la galería",
+  "a11y/{{position}} of {{count}}": "{{position}} de {{count}}"
 }

--- a/package/src/i18n/es.json
+++ b/package/src/i18n/es.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "Desliza a la derecha para recorrer las diferentes acciones",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "{{count}} mensajes sin leer"
+  "a11y/{{count}} unread messages": "{{count}} mensajes sin leer",
+  "a11y/Message from you": "Mensaje tuyo",
+  "a11y/Message from {{sender}}": "Mensaje de {{sender}}"
 }

--- a/package/src/i18n/es.json
+++ b/package/src/i18n/es.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "Chat directo con {{name}}",
   "a11y/Double tap to open": "Toca dos veces para abrir",
   "a11y/Double tap to view reactions": "Toca dos veces para ver las reacciones",
+  "a11y/Double tap to view thread": "Toca dos veces para ver el hilo",
   "a11y/Editing message": "Editando mensaje",
   "a11y/Editing message: {{text}}": "Editando mensaje: {{text}}",
   "a11y/Last message {{date}}": "Último mensaje {{date}}",

--- a/package/src/i18n/es.json
+++ b/package/src/i18n/es.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "{{count}} mensajes sin leer",
   "a11y/Message from you": "Mensaje tuyo",
-  "a11y/Message from {{sender}}": "Mensaje de {{sender}}"
+  "a11y/Message from {{sender}}": "Mensaje de {{sender}}",
+  "a11y/Gallery Image": "Imagen de la galería",
+  "a11y/Gallery Video": "Vídeo de la galería"
 }

--- a/package/src/i18n/fr.json
+++ b/package/src/i18n/fr.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "Glissez vers la droite pour parcourir les différentes actions",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "{{count}} messages non lus"
+  "a11y/{{count}} unread messages": "{{count}} messages non lus",
+  "a11y/Message from you": "Votre message",
+  "a11y/Message from {{sender}}": "Message de {{sender}}"
 }

--- a/package/src/i18n/fr.json
+++ b/package/src/i18n/fr.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "{{count}} messages non lus",
   "a11y/Message from you": "Votre message",
-  "a11y/Message from {{sender}}": "Message de {{sender}}"
+  "a11y/Message from {{sender}}": "Message de {{sender}}",
+  "a11y/Gallery Image": "Image de la galerie",
+  "a11y/Gallery Video": "Vidéo de la galerie"
 }

--- a/package/src/i18n/fr.json
+++ b/package/src/i18n/fr.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "Discussion directe avec {{name}}",
   "a11y/Double tap to open": "Appuyez deux fois pour ouvrir",
   "a11y/Double tap to view reactions": "Appuyez deux fois pour voir les réactions",
+  "a11y/Double tap to view thread": "Appuyez deux fois pour voir le fil",
   "a11y/Editing message": "Modification du message",
   "a11y/Editing message: {{text}}": "Modification du message : {{text}}",
   "a11y/Last message {{date}}": "Dernier message {{date}}",

--- a/package/src/i18n/fr.json
+++ b/package/src/i18n/fr.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "Votre message",
   "a11y/Message from {{sender}}": "Message de {{sender}}",
   "a11y/Gallery Image": "Image de la galerie",
-  "a11y/Gallery Video": "Vidéo de la galerie"
+  "a11y/Gallery Video": "Vidéo de la galerie",
+  "a11y/{{position}} of {{count}}": "{{position}} sur {{count}}"
 }

--- a/package/src/i18n/he.json
+++ b/package/src/i18n/he.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "הודעה ממך",
   "a11y/Message from {{sender}}": "הודעה מאת {{sender}}",
   "a11y/Gallery Image": "תמונה מהגלריה",
-  "a11y/Gallery Video": "סרטון מהגלריה"
+  "a11y/Gallery Video": "סרטון מהגלריה",
+  "a11y/{{position}} of {{count}}": "{{position}} מתוך {{count}}"
 }

--- a/package/src/i18n/he.json
+++ b/package/src/i18n/he.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "צ׳אט ישיר עם {{name}}",
   "a11y/Double tap to open": "הקש פעמיים כדי לפתוח",
   "a11y/Double tap to view reactions": "הקש פעמיים כדי לראות תגובות",
+  "a11y/Double tap to view thread": "הקש פעמיים כדי לראות את השרשור",
   "a11y/Editing message": "עריכת הודעה",
   "a11y/Editing message: {{text}}": "עריכת הודעה: {{text}}",
   "a11y/Last message {{date}}": "הודעה אחרונה {{date}}",

--- a/package/src/i18n/he.json
+++ b/package/src/i18n/he.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "{{count}} הודעות שלא נקראו",
   "a11y/Message from you": "הודעה ממך",
-  "a11y/Message from {{sender}}": "הודעה מאת {{sender}}"
+  "a11y/Message from {{sender}}": "הודעה מאת {{sender}}",
+  "a11y/Gallery Image": "תמונה מהגלריה",
+  "a11y/Gallery Video": "סרטון מהגלריה"
 }

--- a/package/src/i18n/he.json
+++ b/package/src/i18n/he.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "החלק ימינה כדי לעבור בין הפעולות השונות",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "{{count}} הודעות שלא נקראו"
+  "a11y/{{count}} unread messages": "{{count}} הודעות שלא נקראו",
+  "a11y/Message from you": "הודעה ממך",
+  "a11y/Message from {{sender}}": "הודעה מאת {{sender}}"
 }

--- a/package/src/i18n/hi.json
+++ b/package/src/i18n/hi.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "विभिन्न क्रियाओं के बीच जाने के लिए दाएं स्वाइप करें",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "{{count}} अपठित संदेश"
+  "a11y/{{count}} unread messages": "{{count}} अपठित संदेश",
+  "a11y/Message from you": "आपका संदेश",
+  "a11y/Message from {{sender}}": "{{sender}} से संदेश"
 }

--- a/package/src/i18n/hi.json
+++ b/package/src/i18n/hi.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "{{name}} के साथ सीधी चैट",
   "a11y/Double tap to open": "खोलने के लिए दो बार टैप करें",
   "a11y/Double tap to view reactions": "प्रतिक्रियाएँ देखने के लिए दो बार टैप करें",
+  "a11y/Double tap to view thread": "थ्रेड देखने के लिए दो बार टैप करें",
   "a11y/Editing message": "संदेश संपादित कर रहे हैं",
   "a11y/Editing message: {{text}}": "संदेश संपादित कर रहे हैं: {{text}}",
   "a11y/Last message {{date}}": "अंतिम संदेश {{date}}",

--- a/package/src/i18n/hi.json
+++ b/package/src/i18n/hi.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "आपका संदेश",
   "a11y/Message from {{sender}}": "{{sender}} से संदेश",
   "a11y/Gallery Image": "गैलरी छवि",
-  "a11y/Gallery Video": "गैलरी वीडियो"
+  "a11y/Gallery Video": "गैलरी वीडियो",
+  "a11y/{{position}} of {{count}}": "{{count}} में से {{position}}"
 }

--- a/package/src/i18n/hi.json
+++ b/package/src/i18n/hi.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "{{count}} अपठित संदेश",
   "a11y/Message from you": "आपका संदेश",
-  "a11y/Message from {{sender}}": "{{sender}} से संदेश"
+  "a11y/Message from {{sender}}": "{{sender}} से संदेश",
+  "a11y/Gallery Image": "गैलरी छवि",
+  "a11y/Gallery Video": "गैलरी वीडियो"
 }

--- a/package/src/i18n/it.json
+++ b/package/src/i18n/it.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "Messaggio da te",
   "a11y/Message from {{sender}}": "Messaggio da {{sender}}",
   "a11y/Gallery Image": "Immagine della galleria",
-  "a11y/Gallery Video": "Video della galleria"
+  "a11y/Gallery Video": "Video della galleria",
+  "a11y/{{position}} of {{count}}": "{{position}} di {{count}}"
 }

--- a/package/src/i18n/it.json
+++ b/package/src/i18n/it.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "Scorri a destra per passare in rassegna le diverse azioni",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "{{count}} messaggi non letti"
+  "a11y/{{count}} unread messages": "{{count}} messaggi non letti",
+  "a11y/Message from you": "Messaggio da te",
+  "a11y/Message from {{sender}}": "Messaggio da {{sender}}"
 }

--- a/package/src/i18n/it.json
+++ b/package/src/i18n/it.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "{{count}} messaggi non letti",
   "a11y/Message from you": "Messaggio da te",
-  "a11y/Message from {{sender}}": "Messaggio da {{sender}}"
+  "a11y/Message from {{sender}}": "Messaggio da {{sender}}",
+  "a11y/Gallery Image": "Immagine della galleria",
+  "a11y/Gallery Video": "Video della galleria"
 }

--- a/package/src/i18n/it.json
+++ b/package/src/i18n/it.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "Chat diretta con {{name}}",
   "a11y/Double tap to open": "Tocca due volte per aprire",
   "a11y/Double tap to view reactions": "Tocca due volte per vedere le reazioni",
+  "a11y/Double tap to view thread": "Tocca due volte per vedere il thread",
   "a11y/Editing message": "Modifica del messaggio",
   "a11y/Editing message: {{text}}": "Modifica del messaggio: {{text}}",
   "a11y/Last message {{date}}": "Ultimo messaggio {{date}}",

--- a/package/src/i18n/ja.json
+++ b/package/src/i18n/ja.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "未読メッセージ{{count}}件",
   "a11y/Message from you": "あなたからのメッセージ",
-  "a11y/Message from {{sender}}": "{{sender}}からのメッセージ"
+  "a11y/Message from {{sender}}": "{{sender}}からのメッセージ",
+  "a11y/Gallery Image": "ギャラリー画像",
+  "a11y/Gallery Video": "ギャラリービデオ"
 }

--- a/package/src/i18n/ja.json
+++ b/package/src/i18n/ja.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "{{name}}とのダイレクトチャット",
   "a11y/Double tap to open": "ダブルタップで開く",
   "a11y/Double tap to view reactions": "ダブルタップでリアクションを表示",
+  "a11y/Double tap to view thread": "ダブルタップでスレッドを表示",
   "a11y/Editing message": "メッセージを編集中",
   "a11y/Editing message: {{text}}": "メッセージを編集中: {{text}}",
   "a11y/Last message {{date}}": "最後のメッセージ {{date}}",

--- a/package/src/i18n/ja.json
+++ b/package/src/i18n/ja.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "あなたからのメッセージ",
   "a11y/Message from {{sender}}": "{{sender}}からのメッセージ",
   "a11y/Gallery Image": "ギャラリー画像",
-  "a11y/Gallery Video": "ギャラリービデオ"
+  "a11y/Gallery Video": "ギャラリービデオ",
+  "a11y/{{position}} of {{count}}": "{{count}} 中 {{position}}"
 }

--- a/package/src/i18n/ja.json
+++ b/package/src/i18n/ja.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "右にスワイプして異なるアクションを切り替えます",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "未読メッセージ{{count}}件"
+  "a11y/{{count}} unread messages": "未読メッセージ{{count}}件",
+  "a11y/Message from you": "あなたからのメッセージ",
+  "a11y/Message from {{sender}}": "{{sender}}からのメッセージ"
 }

--- a/package/src/i18n/ko.json
+++ b/package/src/i18n/ko.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "내가 보낸 메시지",
   "a11y/Message from {{sender}}": "{{sender}}님의 메시지",
   "a11y/Gallery Image": "갤러리 이미지",
-  "a11y/Gallery Video": "갤러리 동영상"
+  "a11y/Gallery Video": "갤러리 동영상",
+  "a11y/{{position}} of {{count}}": "{{count}}개 중 {{position}}번째"
 }

--- a/package/src/i18n/ko.json
+++ b/package/src/i18n/ko.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "다른 작업을 탐색하려면 오른쪽으로 스와이프하세요",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "읽지 않은 메시지 {{count}}개"
+  "a11y/{{count}} unread messages": "읽지 않은 메시지 {{count}}개",
+  "a11y/Message from you": "내가 보낸 메시지",
+  "a11y/Message from {{sender}}": "{{sender}}님의 메시지"
 }

--- a/package/src/i18n/ko.json
+++ b/package/src/i18n/ko.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "{{name}}님과의 다이렉트 채팅",
   "a11y/Double tap to open": "두 번 탭하여 열기",
   "a11y/Double tap to view reactions": "두 번 탭하여 반응 보기",
+  "a11y/Double tap to view thread": "두 번 탭하여 스레드 보기",
   "a11y/Editing message": "메시지 편집 중",
   "a11y/Editing message: {{text}}": "메시지 편집 중: {{text}}",
   "a11y/Last message {{date}}": "마지막 메시지 {{date}}",

--- a/package/src/i18n/ko.json
+++ b/package/src/i18n/ko.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "읽지 않은 메시지 {{count}}개",
   "a11y/Message from you": "내가 보낸 메시지",
-  "a11y/Message from {{sender}}": "{{sender}}님의 메시지"
+  "a11y/Message from {{sender}}": "{{sender}}님의 메시지",
+  "a11y/Gallery Image": "갤러리 이미지",
+  "a11y/Gallery Video": "갤러리 동영상"
 }

--- a/package/src/i18n/nl.json
+++ b/package/src/i18n/nl.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "Bericht van jou",
   "a11y/Message from {{sender}}": "Bericht van {{sender}}",
   "a11y/Gallery Image": "Galerij-afbeelding",
-  "a11y/Gallery Video": "Galerij-video"
+  "a11y/Gallery Video": "Galerij-video",
+  "a11y/{{position}} of {{count}}": "{{position}} van {{count}}"
 }

--- a/package/src/i18n/nl.json
+++ b/package/src/i18n/nl.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "{{count}} ongelezen berichten",
   "a11y/Message from you": "Bericht van jou",
-  "a11y/Message from {{sender}}": "Bericht van {{sender}}"
+  "a11y/Message from {{sender}}": "Bericht van {{sender}}",
+  "a11y/Gallery Image": "Galerij-afbeelding",
+  "a11y/Gallery Video": "Galerij-video"
 }

--- a/package/src/i18n/nl.json
+++ b/package/src/i18n/nl.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "Direct chat met {{name}}",
   "a11y/Double tap to open": "Dubbeltik om te openen",
   "a11y/Double tap to view reactions": "Dubbeltik om reacties te bekijken",
+  "a11y/Double tap to view thread": "Dubbeltik om de thread te bekijken",
   "a11y/Editing message": "Bericht bewerken",
   "a11y/Editing message: {{text}}": "Bericht bewerken: {{text}}",
   "a11y/Last message {{date}}": "Laatste bericht {{date}}",

--- a/package/src/i18n/nl.json
+++ b/package/src/i18n/nl.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "Veeg naar rechts om door verschillende acties te bladeren",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "{{count}} ongelezen berichten"
+  "a11y/{{count}} unread messages": "{{count}} ongelezen berichten",
+  "a11y/Message from you": "Bericht van jou",
+  "a11y/Message from {{sender}}": "Bericht van {{sender}}"
 }

--- a/package/src/i18n/pt-br.json
+++ b/package/src/i18n/pt-br.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "Deslize para a direita para percorrer as diferentes ações",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "{{count}} mensagens não lidas"
+  "a11y/{{count}} unread messages": "{{count}} mensagens não lidas",
+  "a11y/Message from you": "Mensagem sua",
+  "a11y/Message from {{sender}}": "Mensagem de {{sender}}"
 }

--- a/package/src/i18n/pt-br.json
+++ b/package/src/i18n/pt-br.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "Chat direto com {{name}}",
   "a11y/Double tap to open": "Toque duas vezes para abrir",
   "a11y/Double tap to view reactions": "Toque duas vezes para ver as reações",
+  "a11y/Double tap to view thread": "Toque duas vezes para ver o tópico",
   "a11y/Editing message": "Editando mensagem",
   "a11y/Editing message: {{text}}": "Editando mensagem: {{text}}",
   "a11y/Last message {{date}}": "Última mensagem {{date}}",

--- a/package/src/i18n/pt-br.json
+++ b/package/src/i18n/pt-br.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "{{count}} mensagens não lidas",
   "a11y/Message from you": "Mensagem sua",
-  "a11y/Message from {{sender}}": "Mensagem de {{sender}}"
+  "a11y/Message from {{sender}}": "Mensagem de {{sender}}",
+  "a11y/Gallery Image": "Imagem da galeria",
+  "a11y/Gallery Video": "Vídeo da galeria"
 }

--- a/package/src/i18n/pt-br.json
+++ b/package/src/i18n/pt-br.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "Mensagem sua",
   "a11y/Message from {{sender}}": "Mensagem de {{sender}}",
   "a11y/Gallery Image": "Imagem da galeria",
-  "a11y/Gallery Video": "Vídeo da galeria"
+  "a11y/Gallery Video": "Vídeo da galeria",
+  "a11y/{{position}} of {{count}}": "{{position}} de {{count}}"
 }

--- a/package/src/i18n/ru.json
+++ b/package/src/i18n/ru.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "Прямой чат с {{name}}",
   "a11y/Double tap to open": "Дважды коснитесь, чтобы открыть",
   "a11y/Double tap to view reactions": "Дважды коснитесь, чтобы посмотреть реакции",
+  "a11y/Double tap to view thread": "Дважды коснитесь, чтобы посмотреть тред",
   "a11y/Editing message": "Редактирование сообщения",
   "a11y/Editing message: {{text}}": "Редактирование сообщения: {{text}}",
   "a11y/Last message {{date}}": "Последнее сообщение {{date}}",

--- a/package/src/i18n/ru.json
+++ b/package/src/i18n/ru.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "Смахните вправо, чтобы переключаться между действиями",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "{{count}} непрочитанных сообщений"
+  "a11y/{{count}} unread messages": "{{count}} непрочитанных сообщений",
+  "a11y/Message from you": "Сообщение от вас",
+  "a11y/Message from {{sender}}": "Сообщение от {{sender}}"
 }

--- a/package/src/i18n/ru.json
+++ b/package/src/i18n/ru.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "{{count}} непрочитанных сообщений",
   "a11y/Message from you": "Сообщение от вас",
-  "a11y/Message from {{sender}}": "Сообщение от {{sender}}"
+  "a11y/Message from {{sender}}": "Сообщение от {{sender}}",
+  "a11y/Gallery Image": "Изображение из галереи",
+  "a11y/Gallery Video": "Видео из галереи"
 }

--- a/package/src/i18n/ru.json
+++ b/package/src/i18n/ru.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "Сообщение от вас",
   "a11y/Message from {{sender}}": "Сообщение от {{sender}}",
   "a11y/Gallery Image": "Изображение из галереи",
-  "a11y/Gallery Video": "Видео из галереи"
+  "a11y/Gallery Video": "Видео из галереи",
+  "a11y/{{position}} of {{count}}": "{{position}} из {{count}}"
 }

--- a/package/src/i18n/tr.json
+++ b/package/src/i18n/tr.json
@@ -371,5 +371,7 @@
   "a11y/Swipe right to go through different actions": "Farklı eylemler arasında geçiş yapmak için sağa kaydır",
   "a11y/Close": "Close",
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
-  "a11y/{{count}} unread messages": "{{count}} okunmamış mesaj"
+  "a11y/{{count}} unread messages": "{{count}} okunmamış mesaj",
+  "a11y/Message from you": "Senden mesaj",
+  "a11y/Message from {{sender}}": "{{sender}} kullanıcısından mesaj"
 }

--- a/package/src/i18n/tr.json
+++ b/package/src/i18n/tr.json
@@ -260,6 +260,7 @@
   "a11y/Direct chat with {{name}}": "{{name}} ile doğrudan sohbet",
   "a11y/Double tap to open": "Açmak için iki kez dokun",
   "a11y/Double tap to view reactions": "Tepkileri görmek için iki kez dokun",
+  "a11y/Double tap to view thread": "Konuyu görmek için iki kez dokun",
   "a11y/Editing message": "Mesaj düzenleniyor",
   "a11y/Editing message: {{text}}": "Mesaj düzenleniyor: {{text}}",
   "a11y/Last message {{date}}": "Son mesaj {{date}}",

--- a/package/src/i18n/tr.json
+++ b/package/src/i18n/tr.json
@@ -375,5 +375,6 @@
   "a11y/Message from you": "Senden mesaj",
   "a11y/Message from {{sender}}": "{{sender}} kullanıcısından mesaj",
   "a11y/Gallery Image": "Galeri görüntüsü",
-  "a11y/Gallery Video": "Galeri videosu"
+  "a11y/Gallery Video": "Galeri videosu",
+  "a11y/{{position}} of {{count}}": "{{count}} öğeden {{position}}"
 }

--- a/package/src/i18n/tr.json
+++ b/package/src/i18n/tr.json
@@ -373,5 +373,7 @@
   "a11y/Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.": "Bottom sheet opened. Activate the close action or use the escape gesture to dismiss.",
   "a11y/{{count}} unread messages": "{{count}} okunmamış mesaj",
   "a11y/Message from you": "Senden mesaj",
-  "a11y/Message from {{sender}}": "{{sender}} kullanıcısından mesaj"
+  "a11y/Message from {{sender}}": "{{sender}} kullanıcısından mesaj",
+  "a11y/Gallery Image": "Galeri görüntüsü",
+  "a11y/Gallery Video": "Galeri videosu"
 }

--- a/package/src/state-store/__tests__/image-gallery-state-store.test.ts
+++ b/package/src/state-store/__tests__/image-gallery-state-store.test.ts
@@ -88,6 +88,7 @@ describe('ImageGalleryStateStore', () => {
         assets: [],
         currentIndex: 0,
         messages: [],
+        requesterNode: null,
         selectedAttachmentUrl: undefined,
       });
     });

--- a/package/src/state-store/image-gallery-state-store.ts
+++ b/package/src/state-store/image-gallery-state-store.ts
@@ -41,12 +41,14 @@ export type ImageGalleryState = {
   messages: LocalMessage[];
   selectedAttachmentUrl?: string;
   currentIndex: number;
+  requesterNode: number | null;
 };
 
 const INITIAL_STATE: ImageGalleryState = {
   assets: [],
   currentIndex: 0,
   messages: [],
+  requesterNode: null,
   selectedAttachmentUrl: undefined,
 };
 
@@ -78,6 +80,10 @@ export class ImageGalleryStateStore {
 
   get selectedAttachmentUrl() {
     return this.state.getLatestValue().selectedAttachmentUrl;
+  }
+
+  get requesterNode() {
+    return this.state.getLatestValue().requesterNode;
   }
 
   get attachmentsWithMessage() {
@@ -151,6 +157,10 @@ export class ImageGalleryStateStore {
     this.state.partialNext({ currentIndex });
   }
 
+  set requesterNode(requesterNode: number | null) {
+    this.state.partialNext({ requesterNode });
+  }
+
   // APIs for managing messages
   appendMessages = (messages: LocalMessage[]) => {
     this.state.partialNext({ messages: [...this.messages, ...messages] });
@@ -164,12 +174,14 @@ export class ImageGalleryStateStore {
 
   openImageGallery = ({
     messages,
+    requesterNode = null,
     selectedAttachmentUrl,
   }: {
     messages: LocalMessage[];
+    requesterNode?: number | null;
     selectedAttachmentUrl?: string;
   }) => {
-    this.state.partialNext({ messages, selectedAttachmentUrl });
+    this.state.partialNext({ messages, requesterNode, selectedAttachmentUrl });
   };
 
   subscribeToMessages = () => {

--- a/package/src/utils/i18n/getDateString.ts
+++ b/package/src/utils/i18n/getDateString.ts
@@ -1,3 +1,6 @@
+import type { TranslationLanguages } from 'stream-chat';
+
+import { calendarFormats } from './calendarFormats';
 import { TimestampFormatterOptions } from './types';
 
 import { TranslatorFunctions } from '../../contexts/translationContext';
@@ -74,3 +77,57 @@ export function getDateString({
 
   return new Date(date).toDateString();
 }
+
+type DateStringForA11yOptions = {
+  /**
+   * Optional calendar-format overrides applied on top of the locale defaults
+   * and the SDK's `sameElse: 'LL'` substitution. Use this when the visible
+   * date format diverges from the locale defaults (e.g. ChannelPreviewStatus
+   * uses `sameDay: 'LT'` to show the time instead of "Today").
+   */
+  calendarFormatOverrides?: Partial<{
+    lastDay: string;
+    lastWeek: string;
+    nextDay: string;
+    nextWeek: string;
+    sameDay: string;
+    sameElse: string;
+  }>;
+  date?: string | Date;
+  tDateTimeParser?: TranslatorFunctions['tDateTimeParser'];
+  userLanguage?: TranslationLanguages;
+};
+
+/**
+ * Produce a TTS-friendly calendar string. iOS VoiceOver reads numeric dates
+ * like "04/08/2026" character-by-character; substituting `LL` ("April 8, 2026")
+ * for the calendar `sameElse` slot fixes that. The relative slots
+ * (sameDay/lastDay/nextDay/lastWeek/nextWeek) are preserved from the locale,
+ * so "Today"/"Yesterday"/weekday names still come through.
+ */
+export const getDateStringForA11y = ({
+  calendarFormatOverrides,
+  date,
+  tDateTimeParser,
+  userLanguage,
+}: DateStringForA11yOptions): string | undefined => {
+  if (!date || (typeof date === 'string' && !Date.parse(date))) {
+    return undefined;
+  }
+  if (!tDateTimeParser) {
+    return undefined;
+  }
+
+  const parsedTime = tDateTimeParser(date);
+  if (!isDayOrMoment(parsedTime) || !parsedTime.calendar) {
+    return undefined;
+  }
+
+  const localeFormats = (userLanguage && calendarFormats[userLanguage]) || calendarFormats.en;
+
+  return parsedTime.calendar(undefined, {
+    ...localeFormats,
+    sameElse: 'LL',
+    ...calendarFormatOverrides,
+  });
+};


### PR DESCRIPTION
## 🎯 Goal                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                            
Follow up `a11y` pass on top of #3632. Covers the message row, the attachment thumbnail gallery, the full screen image/video gallery overlay, the reactions UI, the message cell annotations and date separators, the channel preview date, and the poll option row. VoiceOver and TalkBack now read each surface with proper labels, units and focus behavior and the gallery traps focus while open.                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                          
## 🛠 Implementation details                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                          
- Message row sender label - the bubble's `Pressable` now announces "Message from {sender}" / "Message from you". Messages with interactive children (poll, quoted message, attachments, shared location) opt out of being a single focus stop so VO/TalkBack can drill into the children; an iOS-only absolute-fill      
`View` carries the sender label so the speaker is still announced when focus lands inside the inner content.                                                                                                                                                                                                              
- `hasInteractiveAccessibilityContent` override - new field on `AccessibilityConfig` that receives the SDK's baseline boolean and lets integrators extend the "is this message interactive?" decision without losing the defaults. Resolved upstream in `useCreateMessageContext` and exposed as a stable boolean on      
`MessageContext`.                                                                                                                                                                                                                                                                                                         
- Android compose gate on text bodies - `MessageTextContainer` and the `Poll` header now set `accessible accessibilityRole='text'` so TalkBack auto-composes the descendant `<Text>` content. Conditional on `hasInteractiveAccessibilityContent` for the message text to avoid double-announce on plain messages.        
- Gallery thumbnails - the thumbnail `Pressable` now carries an `a11y/Gallery Image` or `a11y/Gallery Video` label (added across all 13 locales), explicit `role='button'`, and the existing `a11y/Double tap to open` hint. Announces as "Gallery video, button. Double tap to open."                                    
- Full-screen gallery modal trap - `accessibilityViewIsModal` on the `ImageGallery` root and the `MessageOverlayHostLayer` host on iOS. Android gets a new `OverlayA11yShield` sibling wrapper that flips `importantForAccessibility='no-hide-descendants'` when either the gallery or the message context menu is active.
- Full-screen gallery adjustable cycling - the gallery backdrop is now the focus target with `role='adjustable'`, `value={ text: 'N of M' }`, increment/decrement actions, and an `accessibilityLabel` of "Image Gallery". Swipe up/down cycles through assets.                                                           
- Gallery focus return on dismiss - the image gallery state store gained a `requesterNode` field. `Gallery.tsx` captures the thumbnail's node handle via `findNodeHandle` and passes it through `openImageGallery`; on unmount the gallery restores focus via `AccessibilityInfo.setAccessibilityFocus` inside an rAF.    
- Reaction announcements - `ReactionListItem` gains `role='button'` (trips the Android compose gate so TalkBack reads the emoji's CLDR name instead of the reaction `type` string) and `state.selected`. `ReactionButton` drops a broken `accessibilityLabelKey` that was literally untranslated across every locale.     
- Thread reply indicator - the `MessageReplies` `Pressable` now has `role='button'`, an `accessibilityLabel` reading the reply count ("1 Reply" / "N Replies"), and an `accessibilityHint` of "Double tap to view thread" (new i18n key across all 13 locales). Participant avatars in the indicator are hidden from the  
a11y tree so they no longer announce one-by-one.                                                                                                                                                                                                                                                                          
- Decorative dot separators - the middle dots in `SentToChannelHeader` ("Replied to a thread · View") and `MessageReminderHeader` ("Reminder set · 5 minutes left") are now marked decorative so focus moves directly from the label to the action.                                                                       
- Date announcements (iOS) - VoiceOver was reading numeric dates literally ("zero four slash zero eight..."). Added a `getDateStringForA11y` helper that substitutes `LL` for the calendar `sameElse` slot, preserving locale relative words like "Today" / "Yesterday". Wired into `InlineDateSeparator` (announces      
"April 8, 2026") and `ChannelPreviewStatus` (announces "10:30 AM" for same-day messages via a `sameDay: 'LT'` override). TalkBack honors the override too, no platform branching needed.                                                                                                                                  
- Poll option vote count - the bare count `Text` on each poll option row now carries an `accessibilityLabel` using the existing `{{count}} votes` plural key. Announces "0 votes" / "1 vote" / "N votes" instead of just the bare number.                                                                                 
                                                                                                                                                                                                                                                                                                                          
### New shared components and exports                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                          
- `OverlayA11yShield` (`package/src/components/Accessibility/`) - Android-only focus-trap shield. Subscribes to the overlay context and the message-overlay store to compute `isAnyOverlayActive`, then wraps `{children}` in a `View` that flips `importantForAccessibility='no-hide-descendants'` and                   
`accessibilityElementsHidden` while an overlay is active. On iOS it's a pure passthrough selected at module load.                                                                                                                                                                                                         
- `getDateStringForA11y` (`package/src/utils/i18n/getDateString.ts`) - sibling helper to `getDateString`. Produces a TTS-friendly calendar string by substituting `LL` for the `sameElse` slot in the locale's calendar formats, with an optional `calendarFormatOverrides` parameter for callers whose visible format    
diverges from the locale defaults.                                                                                                                                                                                                                                                                                        
- `AccessibilityConfig.hasInteractiveAccessibilityContent` - new override hook for integrators (see above).                                                                                                                                                                                                               
- `MessageContext.hasInteractiveAccessibilityContent` - new stable boolean field consumed by `MessageContent` and `MessageTextContainer`.                                                                                                                                                                                 
- `ImageGalleryState.requesterNode` and the matching `openImageGallery({ requesterNode? })` argument.         

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


