### PR TITLE
fix: android flicker on a11y tree traversal

### DIFF
--- a/package/src/a11y/hooks/useAccessibilityServiceEnabled.ts
+++ b/package/src/a11y/hooks/useAccessibilityServiceEnabled.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo, AppState, Platform } from 'react-native';
+
+import { useAccessibilityContext } from '../../contexts/accessibilityContext/AccessibilityContext';
+
+/**
+ * Subscribes to Android accessibility-service availability and returns the live state.
+ *
+ * `AccessibilityInfo.isAccessibilityServiceEnabled` reports whether ANY a11y service is
+ * running - TalkBack, Switch Access, Voice Access, Select to Speak, etc.  not just
+ * screen readers. The signal is Android only; iOS doesn't expose it (and doesn't need to,
+ * since the SDK's iOS overlay trap uses `accessibilityViewIsModal`).
+ *
+ * React Native does not emit a dedicated change event for this signal, so the hook
+ * re-polls when the app returns to the foreground - which is the realistic path for a
+ * user toggling Accessibility settings and coming back to the app. The most common
+ * single-service change (TalkBack on / off) is also covered by the `screenReaderChanged`
+ * listener.
+ *
+ * Returns false on non-Android platforms without subscribing.
+ * Returns false when the AccessibilityContext is disabled so consumers don't pay the
+ * listener cost when the SDK's a11y is opted out.
+ */
+export const useAccessibilityServiceEnabled = (): boolean => {
+  const { enabled } = useAccessibilityContext();
+  const [isEnabled, setIsEnabled] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (Platform.OS !== 'android' || !enabled) {
+      setIsEnabled(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const refresh = () => {
+      AccessibilityInfo.isAccessibilityServiceEnabled?.()
+        .then((value) => {
+          if (!cancelled) setIsEnabled(value);
+        })
+        .catch(() => {
+          // Older RN versions / certain environments may not implement this; fall back to false.
+        });
+    };
+
+    refresh();
+
+    const screenReaderSubscription = AccessibilityInfo.addEventListener(
+      'screenReaderChanged',
+      refresh,
+    );
+
+    const appStateSubscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') refresh();
+    });
+
+    return () => {
+      cancelled = true;
+      screenReaderSubscription?.remove?.();
+      appStateSubscription?.remove?.();
+    };
+  }, [enabled]);
+
+  if (Platform.OS !== 'android' || !enabled) return false;
+  return isEnabled;
+};

--- a/package/src/a11y/hooks/useAccessibilityServiceEnabled.ts
+++ b/package/src/a11y/hooks/useAccessibilityServiceEnabled.ts
@@ -4,7 +4,7 @@ import { AccessibilityInfo, AppState, Platform } from 'react-native';
 import { useAccessibilityContext } from '../../contexts/accessibilityContext/AccessibilityContext';
 
 /**
- * Subscribes to Android accessibility-service availability and returns the live state.
+ * Subscribes to Android accessibility service availability and returns the live state.
  *
  * `AccessibilityInfo.isAccessibilityServiceEnabled` reports whether ANY a11y service is
  * running - TalkBack, Switch Access, Voice Access, Select to Speak, etc.  not just
@@ -14,11 +14,11 @@ import { useAccessibilityContext } from '../../contexts/accessibilityContext/Acc
  * React Native does not emit a dedicated change event for this signal, so the hook
  * re-polls when the app returns to the foreground - which is the realistic path for a
  * user toggling Accessibility settings and coming back to the app. The most common
- * single-service change (TalkBack on / off) is also covered by the `screenReaderChanged`
+ * single service change (TalkBack on/off) is also covered by the `screenReaderChanged`
  * listener.
  *
  * Returns false on non-Android platforms without subscribing.
- * Returns false when the AccessibilityContext is disabled so consumers don't pay the
+ * Returns false when the `AccessibilityContext` is disabled so consumers don't pay the
  * listener cost when the SDK's a11y is opted out.
  */
 export const useAccessibilityServiceEnabled = (): boolean => {

--- a/package/src/a11y/index.ts
+++ b/package/src/a11y/index.ts
@@ -1,5 +1,6 @@
 export * from './a11yUtils';
 export * from './hooks/useScreenReaderEnabled';
+export * from './hooks/useAccessibilityServiceEnabled';
 export * from './hooks/useReducedMotionPreference';
 export * from './hooks/useResolvedModalAccessibilityProps';
 export * from './hooks/useAnnounceOnStateChange';

--- a/package/src/components/Accessibility/OverlayA11yShield.tsx
+++ b/package/src/components/Accessibility/OverlayA11yShield.tsx
@@ -1,6 +1,8 @@
 import React, { PropsWithChildren } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 
+import { useAccessibilityServiceEnabled } from '../../a11y';
+import { useAccessibilityContext } from '../../contexts/accessibilityContext/AccessibilityContext';
 import { useOverlayContext } from '../../contexts/overlayContext/OverlayContext';
 import { useStateStore } from '../../hooks';
 import { overlayStore } from '../../state-store/message-overlay-store';
@@ -8,6 +10,15 @@ import { overlayStore } from '../../state-store/message-overlay-store';
 const messageOverlayActiveSelector = (state: { id: string | undefined }) => ({
   isMessageOverlayActive: state.id !== undefined,
 });
+
+const useShouldActivateTrap = (): boolean => {
+  const { enabled: a11yEnabled } = useAccessibilityContext();
+  const { overlay } = useOverlayContext();
+  const { isMessageOverlayActive } = useStateStore(overlayStore, messageOverlayActiveSelector);
+  const a11yServiceEnabled = useAccessibilityServiceEnabled();
+
+  return a11yEnabled && (overlay === 'gallery' || isMessageOverlayActive) && a11yServiceEnabled;
+};
 
 /**
  * Android only accessibility focus trap for the OverlayProvider's children
@@ -27,20 +38,17 @@ const messageOverlayActiveSelector = (state: { id: string | undefined }) => ({
  * On iOS the wrapper is skipped entirely.
  */
 export function OverlayA11yShield({ children }: PropsWithChildren) {
-  const { overlay } = useOverlayContext();
-  const { isMessageOverlayActive } = useStateStore(overlayStore, messageOverlayActiveSelector);
+  const shouldActivateTrap = useShouldActivateTrap();
 
   if (Platform.OS !== 'android') {
     return <>{children}</>;
   }
 
-  const isAnyOverlayActive = overlay === 'gallery' || isMessageOverlayActive;
-
   return (
     <View
-      accessibilityElementsHidden={isAnyOverlayActive}
-      importantForAccessibility={isAnyOverlayActive ? 'no-hide-descendants' : 'auto'}
+      importantForAccessibility={shouldActivateTrap ? 'no-hide-descendants' : undefined}
       style={StyleSheet.absoluteFill}
+      pointerEvents='box-none'
       testID='overlay-a11y-shield'
     >
       {children}

--- a/package/src/components/Accessibility/__tests__/OverlayA11yShield.test.tsx
+++ b/package/src/components/Accessibility/__tests__/OverlayA11yShield.test.tsx
@@ -1,11 +1,23 @@
 import React from 'react';
-import { Platform, Text } from 'react-native';
+import { AccessibilityInfo, Platform, Text } from 'react-native';
 
-import { act, render, screen } from '@testing-library/react-native';
+import { act, render, screen, waitFor } from '@testing-library/react-native';
 
+import { AccessibilityProvider } from '../../../contexts/accessibilityContext/AccessibilityContext';
 import { OverlayContext } from '../../../contexts/overlayContext/OverlayContext';
 import { overlayStore } from '../../../state-store/message-overlay-store';
 import { OverlayA11yShield } from '../OverlayA11yShield';
+
+jest.mock('react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo', () => ({
+  __esModule: true,
+  default: {
+    addEventListener: jest.fn().mockReturnValue({ remove: jest.fn() }),
+    announceForAccessibility: jest.fn(),
+    isAccessibilityServiceEnabled: jest.fn().mockResolvedValue(true),
+    isReduceMotionEnabled: jest.fn().mockResolvedValue(false),
+    isScreenReaderEnabled: jest.fn().mockResolvedValue(false),
+  },
+}));
 
 const setPlatform = (os: typeof Platform.OS) => {
   Object.defineProperty(Platform, 'OS', { configurable: true, get: () => os });
@@ -13,19 +25,21 @@ const setPlatform = (os: typeof Platform.OS) => {
 
 const renderShield = (overlay: 'none' | 'gallery' = 'none') =>
   render(
-    <OverlayContext.Provider
-      value={
-        {
-          overlay,
-          setOverlay: () => undefined,
-          style: undefined,
-        } as never
-      }
-    >
-      <OverlayA11yShield>
-        <Text testID='child'>child</Text>
-      </OverlayA11yShield>
-    </OverlayContext.Provider>,
+    <AccessibilityProvider value={{ enabled: true }}>
+      <OverlayContext.Provider
+        value={
+          {
+            overlay,
+            setOverlay: () => undefined,
+            style: undefined,
+          } as never
+        }
+      >
+        <OverlayA11yShield>
+          <Text testID='child'>child</Text>
+        </OverlayA11yShield>
+      </OverlayContext.Provider>
+    </AccessibilityProvider>,
   );
 
 // The wrapper sets `accessibilityElementsHidden` / `importantForAccessibility`
@@ -38,6 +52,7 @@ describe('OverlayA11yShield', () => {
   afterAll(() => setPlatform(originalOS));
 
   beforeEach(() => {
+    (AccessibilityInfo.isAccessibilityServiceEnabled as jest.Mock).mockResolvedValue(true);
     act(() => {
       overlayStore.partialNext({ closing: false, id: undefined, messageId: undefined });
     });
@@ -46,28 +61,48 @@ describe('OverlayA11yShield', () => {
   describe('on Android', () => {
     beforeAll(() => setPlatform('android'));
 
-    it('renders children inside the wrapper', () => {
+    it('renders children inside the wrapper', async () => {
       renderShield();
+      await act(async () => {
+        await Promise.resolve();
+      });
       expect(screen.getByTestId('child')).toBeTruthy();
       expect(wrapper()).toBeTruthy();
     });
 
-    it('does not hide descendants when no overlay is active', () => {
+    it('does not hide descendants when no overlay is active', async () => {
       renderShield('none');
-      expect(wrapper()?.props.importantForAccessibility).toBe('auto');
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(wrapper()?.props.importantForAccessibility).toBeUndefined();
     });
 
-    it('hides descendants when the gallery overlay is active', () => {
+    it('hides descendants when the gallery overlay is active and an a11y service is on', async () => {
       renderShield('gallery');
-      expect(wrapper()?.props.importantForAccessibility).toBe('no-hide-descendants');
+      await waitFor(() => {
+        expect(wrapper()?.props.importantForAccessibility).toBe('no-hide-descendants');
+      });
     });
 
-    it('hides descendants when the message overlay opens', () => {
+    it('hides descendants when the message overlay opens and an a11y service is on', async () => {
       renderShield('none');
       act(() => {
         overlayStore.partialNext({ id: 'msg-1' });
       });
-      expect(wrapper()?.props.importantForAccessibility).toBe('no-hide-descendants');
+      await waitFor(() => {
+        expect(wrapper()?.props.importantForAccessibility).toBe('no-hide-descendants');
+      });
+    });
+
+    it('does not flip the prop when no a11y service is running, even with an overlay active', async () => {
+      (AccessibilityInfo.isAccessibilityServiceEnabled as jest.Mock).mockResolvedValue(false);
+      renderShield('gallery');
+      // Allow the async isAccessibilityServiceEnabled() resolution to settle.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(wrapper()?.props.importantForAccessibility).toBeUndefined();
     });
   });
 

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -108,7 +108,11 @@ export const OverlayProvider = (props: PropsWithChildren<OverlayProviderProps>) 
           <ImageGalleryProvider value={imageGalleryProviderProps}>
             <ThemeProvider style={overlayContext.style}>
               <PortalProvider>
-                <OverlayA11yShield>{children}</OverlayA11yShield>
+                {accessibility?.enabled ? (
+                  <OverlayA11yShield>{children}</OverlayA11yShield>
+                ) : (
+                  children
+                )}
                 {overlay === 'gallery' && <ImageGallery overlayOpacity={overlayOpacity} />}
                 <MessageOverlayHostLayer />
               </PortalProvider>


### PR DESCRIPTION
## 🎯 Goal                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                          
This PR fixes an Android only full screen flash that occurs when closing the message context menu, unfortunately introduced alongside the focus trap work in #3634. Fortunately though it was caught early.                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                          
The flash is the Android framework rewalking the wrapped subtree's accessibility nodes when `importantForAccessibility` flips back off on `OverlayA11yShield`. That rewalk lands on the same frame as `react-native-teleport`'s reparent back of the message subtree and the closing portal hosts, and is visible as a fullscreen flicker. The gallery doesn't show it for two reasons: it doesn't use the teleport mechanism on close and its fullscreen overlay visually masks the same window. 
                                                                                                                                                                                                                                                                                                                          
The native rewalk isn't avoidable while the prop toggles - but most users don't need the prop to toggle at all. The trap exists to keep `TalkBack` / `Switch Access` / `Voice Access` focus inside the overlay; everyone else gains nothing from it and shouldn't pay for it.                                                  
                                                                                                                                                                                                                                                                                                                          
## 🛠 Implementation details                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                          
Three layer gate on whether the shield's `importantForAccessibility` ever flips:                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                          
1. Integrator optin (`accessibility.enabled`). Moved to the `OverlayProvider` call site so the shield isn't even mounted in the tree when the integrator hasn't opted into `a11y`. Apps that don't pass `accessibility={{ enabled: true }}` to `OverlayProvider` see zero overhead and no extra `View`, no hook subscriptions, no native prop ever touched. This naturally means that if we change the `accessibility.enabled` configuration on the fly we'll see a remount but we anyway do not recommend doing this nor is this something intended to go back and forth.
2. Android `a11y` service running. The new `useAccessibilityServiceEnabled` hook at mirrors the shape of the existing `useScreenReaderEnabled` except it covers all services. Wraps Android's `AccessibilityInfo.isAccessibilityServiceEnabled` - which reports any `a11y` service, not just screen readers, so the trap covers TalkBack, Switch Access, Voice Access, Select to Speak, etc. RN does not emit a dedicated change event for this signal, so the hook repolls on `screenReaderChanged` and on `AppState` foreground transitions (the realistic path for a user toggling `Accessibility` settings and returning to the app).                                                                                                                                                                                                          
3. Overlay actually open. The gallery or the message context menu has to be the thing on screen.                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                          
All three are checked in the new private `useShouldActivateTrap` hook in `OverlayA11yShield.tsx`. The wrapper stays unconditionally mounted on Android (within the `accessibility.enabled` branch); only the `importantForAccessibility` prop toggles. Mounting the wrapper unconditionally was deliberate - gating the wrapper itself on per overlay state remounts the entire chat subtree on every menu open/close, which manifests as a visible chat tree reset. Also remounting when screen readers get enabled/disabled feels off, so for now we'll stick to this. 
                                                                                                                                                                                                                                                                                                                          
If we think about it we only need the trap for when `a11y` services are enabled, not particularly in the normal scenarios. Its sole purpose is anyway to not let your `a11y` cursor get away from the overlays as compensation for the lack of `accessibilityViewIsModal` as we have for iOS.                                         
                                                                                                                                                                                                                                                                                                                          
Also adds `pointerEvents='none'` on the wrapper for good measure so it can never intercept a touch from sibling overlays.

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


