### PR TITLE
fix: audio attachment style edge cases

### DIFF
--- a/package/src/components/Attachment/Attachment.tsx
+++ b/package/src/components/Attachment/Attachment.tsx
@@ -224,16 +224,17 @@ const useAudioAttachmentStyles = () => {
   const messageHasSingleAttachment = message.attachments?.length === 1;
   const messageHasCaption = !!message.text?.trim();
   const messageIsQuotedReply = !!(message.quoted_message || message.quoted_message_id);
+  const shouldRemoveAudioAttachmentPadding =
+    messageIsQuotedReply && messageHasSingleAttachment && !messageHasCaption;
   const showBackgroundTransparent =
-    messageHasOnlySingleAttachment ||
-    (messageIsQuotedReply && messageHasSingleAttachment && !messageHasCaption);
+    messageHasOnlySingleAttachment || shouldRemoveAudioAttachmentPadding;
 
   return useMemo(() => {
     return StyleSheet.create({
       container: {
         paddingVertical: primitives.spacingXs,
-        paddingLeft: primitives.spacingXs,
-        paddingRight: primitives.spacingSm,
+        paddingLeft: shouldRemoveAudioAttachmentPadding ? 0 : primitives.spacingXs,
+        paddingRight: shouldRemoveAudioAttachmentPadding ? 0 : primitives.spacingSm,
         borderWidth: 0,
         backgroundColor: showBackgroundTransparent
           ? 'transparent'
@@ -255,6 +256,9 @@ const useAudioAttachmentStyles = () => {
         color: semantics.chatTextIncoming,
         fontWeight: primitives.typographyFontWeightSemiBold,
       },
+      leftContainer: {
+        padding: shouldRemoveAudioAttachmentPadding ? 0 : primitives.spacingXxs,
+      },
     });
-  }, [semantics, isMyMessage, showBackgroundTransparent]);
+  }, [shouldRemoveAudioAttachmentPadding, showBackgroundTransparent, isMyMessage, semantics]);
 };

--- a/package/src/components/Attachment/Audio/AudioAttachment.tsx
+++ b/package/src/components/Attachment/Audio/AudioAttachment.tsx
@@ -78,6 +78,7 @@ export type AudioAttachmentProps = {
     playPauseButton?: StyleProp<ViewStyle>;
     speedSettingsButton?: StyleProp<ViewStyle>;
     durationText?: StyleProp<TextStyle>;
+    leftContainer?: StyleProp<TextStyle>;
   };
 };
 
@@ -215,7 +216,7 @@ export const AudioAttachment = (props: AudioAttachmentProps) => {
       style={[styles.container, container, containerStyle, stylesProps?.container]}
       testID={testID}
     >
-      <View style={[styles.leftContainer, leftContainer]}>
+      <View style={[styles.leftContainer, stylesProps?.leftContainer, leftContainer]}>
         <PlayPauseButton
           isPlaying={isPlaying}
           accessibilityLabel='Play Pause Button'
@@ -341,9 +342,7 @@ const useStyles = () => {
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightTight,
       },
-      leftContainer: {
-        padding: primitives.spacingXxs,
-      },
+      leftContainer: {},
       progressControlContainer: {
         flex: 1,
       },


### PR DESCRIPTION
## 🎯 Goal

This PR fixes an edge case with audio recordings where purely quoted message recordings with a transparent background become visibly smaller (due to padding rules applied). This forces their container to work granularly.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


