### PR TITLE
fix: nitro sound audio recording

### DIFF
--- a/package/native-package/src/optionalDependencies/Audio.ts
+++ b/package/native-package/src/optionalDependencies/Audio.ts
@@ -111,6 +111,15 @@ class _Audio {
       audioSet: {
         // Android specific properties
         AudioEncoderAndroid: AudioEncoderAndroidType.AAC,
+        // Pin nitro-sound 0.2.10+'s bitrate to 128 kbps. Its `.high` quality
+        // preset otherwise defaults to (48 kHz, 2ch, 192 kbps), a combination
+        // the iOS hardware AAC encoder rejects with
+        // kAudioFormatUnsupportedDataFormatError ('fmt?', OSStatus 1718449215)
+        // in AppStore signed binaries.
+        // https://www.osstatus.com/search/results?search=1718449215
+        // Older nitro-sound and the legacy `react-native-audio-recorder-player`
+        // ignore this key.
+        AudioEncodingBitRate: 128000,
         AudioSourceAndroid: AudioSourceAndroidType.MIC,
         OutputFormatAndroid: OutputFormatAndroidType.AAC_ADTS,
 
@@ -121,6 +130,11 @@ class _Audio {
           ? AVModeIOSOptionNitroSound.spokenaudio
           : AVModeIOSOption.spokenaudio,
         AVNumberOfChannelsKeyIOS: 2,
+        // Pair with `AudioEncodingBitRate` above override nitro-sound 0.2.10+'s
+        // 48 kHz default back to 44.1 kHz so the encoder gets the combo that
+        // 0.2.9 was implicitly using. Idempotent for older nitro-sound and the
+        // legacy lib (their default is already 44.1 kHz).
+        AVSampleRateKeyIOS: 44100,
       },
       isMeteringEnabled: true,
     },

--- a/package/src/types/types.ts
+++ b/package/src/types/types.ts
@@ -501,6 +501,15 @@ type AVEncodingType =
 export interface AudioSet {
   AudioChannelsAndroid?: number;
   AudioEncoderAndroid?: AudioEncoderAndroidType;
+  /**
+   * Cross-platform bitrate hint introduced in `react-native-nitro-sound` 0.2.10+.
+   * Sits alongside the iOS-native `AVEncoderBitRateKeyIOS` because nitro-sound
+   * reads `AudioEncodingBitRate` on iOS (mapping it to `AVEncoderBitRateKey`),
+   * not the platform-specific key. Older nitro-sound builds and the legacy
+   * `react-native-audio-recorder-player` ignore this field, so it's safe to
+   * include unconditionally.
+   */
+  AudioEncodingBitRate?: number;
   AudioEncodingBitRateAndroid?: number;
   AudioSamplingRateAndroid?: number;
   AudioSourceAndroid?: AudioSourceAndroidType;


### PR DESCRIPTION
## 🎯 Goal

We unfortunately have an issue with audio recording on RN CLI, for iOS specifically that only happens in Testflight released builds.

After a ton of digging this is an attempt to fix it; if it indeed works I'll update this description with a more technical explanation of what I think is going on.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


