### PR TITLE
fix: support custom channel preview username text

### DIFF
--- a/package/src/components/ChannelPreview/ChannelMessagePreviewDeliveryStatus.tsx
+++ b/package/src/components/ChannelPreview/ChannelMessagePreviewDeliveryStatus.tsx
@@ -107,7 +107,7 @@ const useStyles = () => {
     theme: {
       semantics,
       channelPreview: {
-        messageDeliveryStatus: { container, text },
+        messageDeliveryStatus: { container, text, username },
       },
     },
   } = useTheme();
@@ -132,7 +132,8 @@ const useStyles = () => {
         fontSize: primitives.typographyFontSizeSm,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightNormal,
+        ...username,
       },
     });
-  }, [semantics, text, container]);
+  }, [semantics, text, username, container]);
 };

--- a/package/src/contexts/themeContext/utils/theme.ts
+++ b/package/src/contexts/themeContext/utils/theme.ts
@@ -306,6 +306,7 @@ export type Theme = {
       checkAllIcon: IconProps;
       checkIcon: IconProps;
       timeIcon: IconProps;
+      username: TextStyle;
     };
     lowerRow: ViewStyle;
     title: TextStyle;
@@ -1356,6 +1357,7 @@ export const defaultTheme: Theme = {
       checkAllIcon: {},
       checkIcon: {},
       timeIcon: {},
+      username: {},
     },
     mutedStatus: {},
     pinnedStatus: {},


### PR DESCRIPTION
## 🎯 Goal

In a `<ChannelList />` we can customize the styles of just about all the text except for the author's name (text changed to red for demonstrating)

<img width="403" height="69" alt="image" src="https://github.com/user-attachments/assets/c9c2027c-02af-4e1b-a74e-d922e55b1e92" />

This is, as far as I can tell, because the `username` in [`ChannelMessagePreviewDeliveryStatus`](https://github.com/GetStream/stream-chat-react-native/blob/develop/package/src/components/ChannelPreview/ChannelMessagePreviewDeliveryStatus.tsx#L117-L135) doesn't have any ability to provide theme-based styles like the other props.

## 🛠 Implementation details

Have added a `username` theme property allowing styles to be provided  under `channelPreview`

## 🎨 UI Changes

Consider:

```ts
          style: {
            ...theme,
            channelPreview: {
              messageDeliveryStatus: {
                text: {
                  fontSize: 10,
                  color: 'red',
                },
                username: {
                  fontSize: 10,
                  color: 'red',
                },
              },
            },
          },
```

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <img
          width="405"
          height="321"
          alt="Before"
          src="https://github.com/user-attachments/assets/2ead9a13-15e2-44ee-ad78-f9a82b07f11a"
        />
      </td>
      <td>
        <img
          width="408"
          height="317"
          alt="After"
          src="https://github.com/user-attachments/assets/23cc67b0-2934-41e1-bf90-ec039d32206c"
        />
      </td>
    </tr>
  </tbody>
</table>

</details>

## 🧪 Testing

## ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated - n/a as far as I can tell for this change
- [x] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android  - unable as there's reanimated version issues on `develop` but should be identical
  - [x] Expo iOS and Android


