### PR TITLE
fix: pin channel action order

### DIFF
--- a/package/src/hooks/actions/__tests__/useChannelActionItems.test.tsx
+++ b/package/src/hooks/actions/__tests__/useChannelActionItems.test.tsx
@@ -135,9 +135,9 @@ describe('useChannelActionItems', () => {
 
     expect(result.current.map((item) => item.id)).toEqual([
       'mute',
+      'pin',
       'muteUser',
       'block',
-      'pin',
       'leave',
       'deleteChannel',
     ]);
@@ -297,25 +297,25 @@ describe('getChannelActionItems', () => {
 
     expect(actionItems.map((item) => item.id)).toEqual([
       'mute',
+      'pin',
       'muteUser',
       'block',
-      'pin',
       'leave',
       'deleteChannel',
     ]);
     expect(actionItems.map((item) => item.action)).toEqual([
       channelActions.unmuteChannel,
+      channelActions.pin,
       channelActions.unmuteUser,
       channelActions.unblockUser,
-      channelActions.pin,
       channelActions.leave,
       expect.any(Function),
     ]);
     expect(actionItems.map((item) => item.label)).toEqual([
       'Unmute Chat',
+      'Pin Chat',
       'Unmute User',
       'Unblock User',
-      'Pin Chat',
       'Leave Chat',
       'Delete Chat',
     ]);

--- a/package/src/hooks/actions/useChannelActionItems.tsx
+++ b/package/src/hooks/actions/useChannelActionItems.tsx
@@ -142,6 +142,23 @@ export const buildDefaultChannelActionItems: BuildDefaultChannelActionItems = (
     },
   ];
 
+  if (surface !== 'details') {
+    actionItems.push({
+      action: isPinned ? unpin : pin,
+      Icon: (props) => <ChannelActionsIcon Icon={isPinned ? Unpin : Pin} {...props} />,
+      id: 'pin',
+      label: isDirectChat
+        ? isPinned
+          ? t('Unpin Chat')
+          : t('Pin Chat')
+        : isPinned
+          ? t('Unpin Group')
+          : t('Pin Group'),
+      placement: 'sheet',
+      type: 'standard',
+    });
+  }
+
   if (isDirectChat) {
     actionItems.push({
       action: userMuteActive ? unmuteUser : muteUser,
@@ -169,23 +186,6 @@ export const buildDefaultChannelActionItems: BuildDefaultChannelActionItems = (
       label: isBlocked ? t('Unblock User') : t('Block User'),
       placement: 'sheet',
       type: isBlocked ? 'standard' : 'destructive',
-    });
-  }
-
-  if (surface !== 'details') {
-    actionItems.push({
-      action: isPinned ? unpin : pin,
-      Icon: (props) => <ChannelActionsIcon Icon={isPinned ? Unpin : Pin} {...props} />,
-      id: 'pin',
-      label: isDirectChat
-        ? isPinned
-          ? t('Unpin Chat')
-          : t('Pin Chat')
-        : isPinned
-          ? t('Unpin Group')
-          : t('Pin Group'),
-      placement: 'sheet',
-      type: 'standard',
     });
   }
 


### PR DESCRIPTION
## 🎯 Goal

This PR is a quick fix of channel action ordering, for which the default was broken since the introduction of pinning.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


