### PR TITLE
fix(a11y): focus inputs on enter and page transitions

### DIFF
--- a/examples/SampleApp/src/components/ScreenHeader.tsx
+++ b/examples/SampleApp/src/components/ScreenHeader.tsx
@@ -168,6 +168,7 @@ export const ScreenHeader: React.FC<ScreenHeaderProps> = (props) => {
             ) : (
               !!titleText && (
                 <Text
+                  accessibilityRole='header'
                   style={[
                     styles.title,
                     {

--- a/examples/SampleApp/src/screens/ChannelScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelScreen.tsx
@@ -262,7 +262,11 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({ navigation, route 
   }
 
   return (
-    <View style={[styles.flex, { backgroundColor: 'transparent' }]}>
+    <View
+      collapsable={false}
+      onAccessibilityEscape={() => navigation.goBack()}
+      style={[styles.flex, { backgroundColor: 'transparent' }]}
+    >
       <Channel
         audioRecordingEnabled={true}
         channel={channel}

--- a/examples/SampleApp/src/screens/ChannelScreen.tsx
+++ b/examples/SampleApp/src/screens/ChannelScreen.tsx
@@ -35,6 +35,7 @@ import { useChannelMembersStatus } from '../hooks/useChannelMembersStatus';
 import type { StackNavigatorParamList } from '../types';
 import { channelMessageActions } from '../utils/messageActions.tsx';
 import { useCreateDraftFocusEffect } from '../utils/useCreateDraftFocusEffect.tsx';
+import { useScreenReaderComposerFocusEffect } from '../utils/useScreenReaderComposerFocusEffect.tsx';
 // import { CustomAttachmentPickerSelectionBar } from '../components/AttachmentPickerSelectionBar.tsx';
 
 export type ChannelScreenNavigationProp = NativeStackNavigationProp<
@@ -155,6 +156,8 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({ navigation, route 
     setSelectedThread(undefined);
   });
 
+  const { setInputRef } = useScreenReaderComposerFocusEffect();
+
   const onPressMessage: NonNullable<React.ComponentProps<typeof Channel>['onPressMessage']> = (
     payload,
   ) => {
@@ -263,6 +266,7 @@ export const ChannelScreen: React.FC<ChannelScreenProps> = ({ navigation, route 
       <Channel
         audioRecordingEnabled={true}
         channel={channel}
+        setInputRef={setInputRef}
         messageInputFloating={messageInputFloating}
         onPressMessage={onPressMessage}
         initialScrollToFirstUnreadMessage

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -145,7 +145,11 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({ navigation, route })
   );
 
   return (
-    <View style={[styles.container, { backgroundColor: white }]}>
+    <View
+      collapsable={false}
+      onAccessibilityEscape={() => navigation.goBack()}
+      style={[styles.container, { backgroundColor: white }]}
+    >
       <Channel
         audioRecordingEnabled={true}
         channel={channel}

--- a/examples/SampleApp/src/screens/ThreadScreen.tsx
+++ b/examples/SampleApp/src/screens/ThreadScreen.tsx
@@ -26,6 +26,7 @@ import { useLegacyColors } from '../theme/useLegacyColors';
 import type { StackNavigatorParamList } from '../types';
 import { channelMessageActions } from '../utils/messageActions.tsx';
 import { useCreateDraftFocusEffect } from '../utils/useCreateDraftFocusEffect.tsx';
+import { useScreenReaderComposerFocusEffect } from '../utils/useScreenReaderComposerFocusEffect.tsx';
 
 // import { CustomAttachmentPickerSelectionBar } from '../components/AttachmentPickerSelectionBar.tsx';
 
@@ -82,6 +83,8 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({ navigation, route })
   const { t } = useTranslationContext();
   const { setThread } = useStreamChatContext();
   const { messageInputFloating, messageListImplementation } = useAppContext();
+
+  const { setInputRef } = useScreenReaderComposerFocusEffect();
 
   const onPressMessage: NonNullable<React.ComponentProps<typeof Channel>['onPressMessage']> = (
     payload,
@@ -146,6 +149,7 @@ export const ThreadScreen: React.FC<ThreadScreenProps> = ({ navigation, route })
       <Channel
         audioRecordingEnabled={true}
         channel={channel}
+        setInputRef={setInputRef}
         keyboardVerticalOffset={0}
         messageActions={messageActions}
         messageInputFloating={messageInputFloating}

--- a/examples/SampleApp/src/utils/useScreenReaderComposerFocusEffect.tsx
+++ b/examples/SampleApp/src/utils/useScreenReaderComposerFocusEffect.tsx
@@ -1,0 +1,42 @@
+import { useCallback, useRef } from 'react';
+import { TextInput } from 'react-native';
+
+import { ParamListBase, useFocusEffect, useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useSetAccessibilityFocus } from 'stream-chat-react-native';
+
+/**
+ * Lands the screen-reader cursor on the message composer input when this screen
+ * is entered, without opening the keyboard or activating the field (the user
+ * still double taps to type).
+ *
+ * Complements the SDK's builtin focus on mount (`useScreenReaderMountFocus` in
+ * MessageComposer), which lands Android forward navigation. This handles the
+ * cases mount can't: back navigation on both platforms and some iOS quirks,
+ * by firing on the native stack `transitionEnd` event, once the screen is the
+ * settled, active accessibility layer (a focus set mid transition on iOS races the
+ * OS's own focus pass and is dropped). `transitionEnd` fires on push and pop reveal.
+ */
+export const useScreenReaderComposerFocusEffect = () => {
+  const inputRef = useRef<TextInput | null>(null);
+  const setAccessibilityFocus = useSetAccessibilityFocus();
+  const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
+
+  const setInputRef = useCallback((ref: TextInput | null) => {
+    inputRef.current = ref;
+  }, []);
+
+  useFocusEffect(
+    useCallback(
+      () =>
+        navigation.addListener('transitionEnd', (e) => {
+          if (!e.data.closing) {
+            setAccessibilityFocus(inputRef);
+          }
+        }),
+      [navigation, setAccessibilityFocus],
+    ),
+  );
+
+  return { setInputRef };
+};

--- a/package/src/a11y/hooks/useScreenReaderMountFocus.ts
+++ b/package/src/a11y/hooks/useScreenReaderMountFocus.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+import { useScreenReaderEnabled } from './useScreenReaderEnabled';
+import {
+  type AccessibilityFocusTarget,
+  useSetAccessibilityFocus,
+} from './useSetAccessibilityFocus';
+
+/**
+ * Moves the screen reader cursor onto `target` as it mounts (and refires once the
+ * screen reader state resolves, since that is detected asynchronously). Like
+ * {@link useSetAccessibilityFocus}, it only moves accessibility focus.
+ */
+export const useScreenReaderMountFocus = (target: AccessibilityFocusTarget) => {
+  const setAccessibilityFocus = useSetAccessibilityFocus();
+  const screenReaderEnabled = useScreenReaderEnabled();
+
+  useEffect(() => {
+    setAccessibilityFocus(target);
+  }, [screenReaderEnabled, setAccessibilityFocus, target]);
+};

--- a/package/src/a11y/hooks/useSetAccessibilityFocus.ts
+++ b/package/src/a11y/hooks/useSetAccessibilityFocus.ts
@@ -1,0 +1,80 @@
+import { type RefObject, useCallback, useEffect, useRef } from 'react';
+import { AccessibilityInfo, findNodeHandle } from 'react-native';
+
+import { useScreenReaderEnabled } from './useScreenReaderEnabled';
+
+type FindNodeHandleArg = Parameters<typeof findNodeHandle>[0];
+
+/**
+ * Something the screen reader cursor can be moved onto: a ref (whose `.current` is
+ * read at call time), a raw native node handle, or nothing.
+ */
+export type AccessibilityFocusTarget = RefObject<unknown> | number | null | undefined;
+
+const resolveNode = (target: AccessibilityFocusTarget): number | null => {
+  if (target == null) {
+    return null;
+  }
+  if (typeof target === 'number') {
+    return target;
+  }
+  const current = target.current;
+  return current == null ? null : findNodeHandle(current as FindNodeHandleArg);
+};
+
+/**
+ * Returns a stable callback that moves the screen reader cursor onto a given
+ * target (a ref or a raw node handle). It ONLY moves accessibility focus and it
+ * does not activate the target: i.e no keyboard opens and no field becomes first
+ * responder. The user still double taps to act on whatever is focused.
+ *
+ * The target's `.current` is read at call time, so this is safe to wire into a
+ * deferred/event callback.
+ *
+ * Noop unless a screen reader is running. {@link useScreenReaderEnabled} returns
+ * false whenever the SDK's accessibility config is disabled, so this costs nothing
+ * for the default (a11y opted out) configuration.
+ *
+ * Note: Navigation timing is platform nuanced: Android forward navigation lands a focus
+ * set on mount, whereas iOS forward navigation and back navigation on both
+ * platforms need it set after the screen transition completes (React Navigation's
+ * `transitionEnd`). {@link useScreenReaderMountFocus} covers the mount case; wire
+ * `transitionEnd` yourself for the rest (the SampleApp's
+ * `useScreenReaderComposerFocusEffect` is a reference implementation).
+ */
+export const useSetAccessibilityFocus = () => {
+  const screenReaderEnabled = useScreenReaderEnabled();
+  // Track the latest value so the returned callback can stay referentially stable
+  // (it's typically wired into a focus effect and read much later).
+  const screenReaderEnabledRef = useRef(screenReaderEnabled);
+  screenReaderEnabledRef.current = screenReaderEnabled;
+
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    },
+    [],
+  );
+
+  return useCallback((target: AccessibilityFocusTarget) => {
+    if (!screenReaderEnabledRef.current) {
+      return;
+    }
+    const node = resolveNode(target);
+    if (node == null) {
+      return;
+    }
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+    }
+    // Defer a frame so the target has laid out before we move the cursor onto it.
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      AccessibilityInfo.setAccessibilityFocus(node);
+    });
+  }, []);
+};

--- a/package/src/a11y/index.ts
+++ b/package/src/a11y/index.ts
@@ -1,5 +1,7 @@
 export * from './a11yUtils';
 export * from './hooks/useScreenReaderEnabled';
+export * from './hooks/useSetAccessibilityFocus';
+export * from './hooks/useScreenReaderMountFocus';
 export * from './hooks/useAccessibilityServiceEnabled';
 export * from './hooks/useReducedMotionPreference';
 export * from './hooks/useResolvedModalAccessibilityProps';

--- a/package/src/components/MessageInput/MessageComposer.tsx
+++ b/package/src/components/MessageInput/MessageComposer.tsx
@@ -16,6 +16,8 @@ import { MicPositionProvider } from './contexts/MicPositionContext';
 
 import { audioRecorderSelector } from './utils/audioRecorderSelectors';
 
+import { useScreenReaderMountFocus } from '../../a11y';
+
 import {
   ChatContextValue,
   useAttachmentPickerContext,
@@ -286,6 +288,9 @@ const MessageComposerWithContext = (props: MessageComposerPropsWithContext) => {
 
     return result;
   };
+
+  // immediately focus the screen reader to the input on mount if a11y is enabled.
+  useScreenReaderMountFocus(inputBoxRef);
 
   const isFocused = inputBoxRef.current?.isFocused();
 


### PR DESCRIPTION
## 🎯 Goal

When a screen-reader user opens a channel or thread, VoiceOver/TalkBack focus previously landed on an arbitrary stop (the back button, or a message mid-list). This moves the entry point to where the user acts — the message composer — while keeping the header/back reachable via standard OS gestures.               
                                                                                                                                                                                                                                                                                                                          
- Add `useSetAccessibilityFocus()` - a public, generic primitive that moves the screen reader cursor onto a ref/node (SR-gated, RAF deferred). It only moves accessibility focus; it never opens the keyboard or activates the field.                                                                                       
- Add `useScreenReaderMountFocus(ref)` - built on the primitive; focuses on mount (and once the SR state resolves). `MessageComposer` uses it on `inputBoxRef`, so the composer is focused on entry. This is the path that lands Android forward navigation as well (but not always on iOS, which is why we need the actual transitional effect as well)                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                          
`SampleApp` reference implementation:                                                                                                                                                            
- `useScreenReaderComposerFocusEffect` - wires React Navigation's `transitionEnd` to `useSetAccessibilityFocus`, covering back navigation (both platforms) and iOS forward navigation (where firing on mount loses a race with the OS focus pass). Returns a stable `setInputRef` for `<Channel>`.
- Header reachability is done by adding `accessibilityRole='header'` on the screen header title (reachable via iOS Headings rotor / jump to top and Android Headings reading control swipe up) and `onAccessibilityEscape` -> `goBack` on the screen root for the iOS back scrub (Android uses the system Back gesture).
                                                                                                                                                                                                                                                                                                                          
Note: `onAccessibilityEscape` is inert on a layout only `View` under `Fabric` - it gets flattened and never receives the gesture. The view hosting it needs `collapsable={false}` if it does not apply any `layout` relevant props itself.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


