### PR TITLE
perf: screen reader queries

### DIFF
--- a/.claude/skills/perf-benchmarking/SKILL.md
+++ b/.claude/skills/perf-benchmarking/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: perf-benchmarking
+description: Measure React Native performance on-device for stream-chat-react-native — Hermes CPU profiles, deterministic call/listener counting, component render profiling, and memory/jank capture. Use when asked to benchmark a change, prove or disprove a perf claim, compare before/after, find what re-renders or what's heavy on the JS thread, or "do some perf testing". Drives the SampleApp on a connected Android device via the perf/ toolkit. Read this BEFORE measuring — it encodes which instrument to pick and the methodology mistakes never to repeat.
+---
+
+# Perf benchmarking (on-device, stream-chat-react-native)
+
+How to measure SDK performance for real, against the **SampleApp running on a physical Android device**, using the committed `perf/` toolkit. This skill exists because the methodology is full of traps that produce confidently-wrong numbers; follow the rules and recipes here instead of improvising.
+
+Prerequisites for almost everything below:
+- Metro running: `yarn workspace sampleapp start` (the device pulls the JS bundle from it; **Metro bundles the SDK from `src`** via the `react-native` package.json field, so editing `package/src/**` hot-reloads on relaunch — no `yarn build` needed).
+- A device/emulator connected: `adb devices` shows one. The SampleApp package is `io.getstream.reactnative.sampleapp`.
+
+## Non-negotiable rules
+
+1. **Measure on a real device, never Node/Jest.** The RN jest preset mocks `AccessibilityInfo` and native modules, so a micro-benchmark of any native-touching code is meaningless. Proven the hard way: a Node bench said ~6µs/call; the device said ~86µs — **14× off** — purely because Jest mocked the native call to ~free.
+2. **Prefer deterministic counts over timing.** Counting native calls / listeners / renders is reproducible and trustworthy. Wall-clock timing is noisy; a *single* timing sample proves nothing. If you report timing, take ≥5 runs, give median + spread, and label it debug-build.
+3. **Count version-agnostically — instrument the native API, not one call site.** Wrap e.g. `AccessibilityInfo.isScreenReaderEnabled` once at app startup and count *every* caller. Instrumenting a single hook undercounts and hides that a **dependency** may dominate. Real example: after centralizing our hook, the SDK made 1 call — but the app still made ~30, because RNGH `Pressable` independently queries it per instance.
+4. **"Lighter" ≠ "Faster."** Removing work from a `useEffect` (off the render/draw path) reduces JS-thread load but does **not** lower render latency. Always say which one you measured. Never claim "renders faster" from effect-phase work.
+5. **Match the instrument to the change size.**
+   - Structural per-call / per-render change → **counting** (Pattern 1).
+   - Big JS-thread cost change → **Hermes CPU profile** (Pattern 2).
+   - "What component re-renders too much / too often" → **React DevTools profile** (`analyze-react-profile.js`).
+   - Memory / jank / dropped frames → **`android-heap-dump.sh`**.
+   - A CPU-profile **`--diff` is blind to sub-noise changes** and is polluted by line-number-shift phantom deltas when you diff across a code edit. Do not use it to "prove" a tiny change.
+6. **A/B fairly.** Same scenario, same instrumentation, same device, same channel (with enough messages), same swipe count. Only the code under test differs.
+7. **Drive the device on real mount signals, not `sleep`.** Android *debug* navigation is slow and variable. Wait on testIDs (`channel-preview-button` → `message-flat-list`), never a fixed sleep after a tap — or your swipes land on the list / a half-mounted screen.
+8. **Respect git-hands-off.** To A/B a committed change, produce the baseline by editing the file back locally (or `git stash` if it's uncommitted), measure, then restore by re-writing the committed version. **Never** `git commit`, `git revert`, or rewrite history to benchmark.
+
+## The toolbox (`perf/`)
+
+| Script | Use it for | Key usage |
+|---|---|---|
+| `capture-hermes-profile.js [out]` | One Hermes CPU profile (JS-thread self/total time). | `node perf/capture-hermes-profile.js perf/profiles/x.cpuprofile` — interactive (waits for Enter). Uses `ws` + `Origin` header (RN 0.85 Fusebox). |
+| `capture-server.js [label]` | Long captures (minutes); auto-desymbolicates + analyzes. | `node perf/capture-server.js mylabel`; env `PERF_MAP`, `PERF_INSIDE`, `PERF_SKIP_DESYM`. |
+| `analyze-cpuprofile.js` | Categorize a profile / diff two. | `node perf/analyze-cpuprofile.js x.cpuprofile [--inside Foo,Bar]` or `--diff before after [--grep re]`. |
+| `analyze-react-profile.js` | **Component** render self/actual time, render counts, slowest commits, buckets (Markdown/Reanimated/RNGH/FlatList/Image). | `node perf/analyze-react-profile.js export.json` (a React DevTools Profiler export, not a `.cpuprofile`). |
+| `desymbolicate-cpuprofile.js` | Per-package attribution (dev bundles collapse to one URL). | `node perf/desymbolicate-cpuprofile.js x.cpuprofile bundle.map`. |
+| `android-heap-dump.sh` | Memory / codec / frame-time. | `perf/android-heap-dump.sh <label> [pkg]` → `perf/profiles/android-heap-<label>-<ts>.txt`. |
+| `drive-channel-scenario.sh [swipes]` | Open a channel + scroll, waiting on testIDs. Run **while** a capture is active. | `bash perf/drive-channel-scenario.sh 6`. |
+
+`perf/profiles/` is gitignored. See `perf/README.md` for the canonical capture/analyze docs.
+
+## Execution patterns
+
+### 1) Deterministic call/listener counting — the reliable default
+
+Best for "did this change make the app do less work?" Counts are exact and reproducible; no timing noise.
+
+**a. Version-agnostic instrument** — a throwaway file in the SampleApp, e.g. `examples/SampleApp/srPatch.ts`, wrapping the native API at startup:
+
+```ts
+import { AccessibilityInfo } from 'react-native';
+const g = global as any;
+g.__SR_CALLS__ = 0; g.__SR_LISTENERS__ = 0; g.__SR_US__ = 0;
+const now = g.performance?.now ? () => g.performance.now() : () => Date.now();
+const origIsSR = AccessibilityInfo.isScreenReaderEnabled;
+let stacks = 0;
+AccessibilityInfo.isScreenReaderEnabled = function () {
+  g.__SR_CALLS__ += 1;
+  if (stacks < 4) { stacks += 1; console.log(`[SR_STACK] #${g.__SR_CALLS__}\n${new Error().stack}`); } // who calls it
+  const t0 = now(); const r = origIsSR.call(AccessibilityInfo); g.__SR_US__ += (now() - t0) * 1000; return r;
+};
+const origAdd = AccessibilityInfo.addEventListener;
+AccessibilityInfo.addEventListener = function (name: any, h: any) {
+  if (name === 'screenReaderChanged') g.__SR_LISTENERS__ += 1;
+  return origAdd.call(AccessibilityInfo, name, h);
+};
+```
+
+Import it **first** in `examples/SampleApp/index.js` (`import './srPatch';` at the top) so the patch is in place before any provider mounts.
+
+**b. Read the counters** from a `React.Profiler` in the screen under test (Profiler `onRender` fires reliably; `setInterval` logging has proven flaky). Wrap the message list in `ChannelScreen.tsx`:
+
+```tsx
+const MsgProfiler = ({ children }) => {
+  const onRender = (_id, phase, dur) =>
+    console.log(`[SR_M] ${phase} render=${dur.toFixed(0)}ms calls=${(global as any).__SR_CALLS__||0} listeners=${(global as any).__SR_LISTENERS__||0} us=${((global as any).__SR_US__||0).toFixed(0)}`);
+  return <React.Profiler id='m' onRender={onRender}>{children}</React.Profiler>;
+};
+```
+
+**c. Run + read:** relaunch, drive the scenario (Pattern 3), then `adb logcat -d -s "ReactNativeJS:V" | grep -E "SR_M|SR_STACK"`. Take the **max** `calls`/`listeners` seen (they accumulate as rows mount). The `[SR_STACK]` traces tell you *who* makes the calls — read them: a React effect frame (`commitHookPassiveMountEffects`) is one of ours; an `asyncGeneratorStep`/`tryCallTwo` chain with no React frames is a dependency.
+
+**d. A/B:** measure with the change, then revert it (Pattern 4) and measure again, identical scenario. Report the delta in counts.
+
+### 2) Hermes CPU profile + diff (non-interactive)
+
+For real JS-thread cost. The capture script waits for Enter, so drive it from the background with a timed auto-stop while you run the scenario in the foreground:
+
+```bash
+# background: starts profiling, auto-stops after 50s, saves + analyzes
+( sleep 50; printf '\n' ) | node perf/capture-hermes-profile.js perf/profiles/after.cpuprofile   # run_in_background
+# foreground (inside the window): let it connect (~5s), then drive
+sleep 5 && bash perf/drive-channel-scenario.sh 8
+```
+
+Then desymbolicate + diff:
+```bash
+curl -s 'http://localhost:8081/index.map?platform=android&dev=true&minify=false' -o /tmp/dev.map.json
+node perf/desymbolicate-cpuprofile.js perf/profiles/after.cpuprofile /tmp/dev.map.json
+node perf/analyze-cpuprofile.js --diff perf/profiles/baseline.cpuprofile perf/profiles/after.cpuprofile --grep '<fn>'
+```
+
+Heed rule 5: if the change is sub-noise, the diff will show **nothing real** (only line-shift phantom deltas) — that's expected, not a failure; fall back to Pattern 1.
+
+### 3) Driving the device (deterministic)
+
+```bash
+PKG=io.getstream.reactnative.sampleapp
+# known state: cold relaunch -> channel list
+adb shell am force-stop "$PKG"; adb shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1
+# dump + parse the view tree (single line of XML!)
+adb shell uiautomator dump /sdcard/ui.xml && adb pull /sdcard/ui.xml /tmp/ui.xml
+```
+Use `perf/drive-channel-scenario.sh` — it already: waits for `channel-preview-button`, taps the first row's bounds center, waits for `message-flat-list` (mount), then `adb shell input swipe 540 700 540 1600 250` per scroll. testIDs available: `channel-list-view`, `channel-preview-button`, `message-flat-list`, `message-list-item-<uuid>`.
+
+Pick a channel with **many messages** (the "Heya!" preview in the list is just the last message — the channel still has full history). Count visible rows with `grep -oE 'resource-id="message-list-item-[^"]+"' /tmp/ui.xml | wc -l` (NOT `grep -c`).
+
+### 4) A/B around a committed change (git-hands-off-safe)
+
+1. Confirm the change's state: `git status`. If committed, the feature files won't show as modified.
+2. Make the **baseline**: edit the changed file(s) back to the pre-change version (re-`Write` them). Metro hot-reloads `src` on relaunch.
+3. Relaunch + measure (baseline).
+4. **Restore** by re-writing the committed version verbatim (read it back from git/HEAD content). Do **not** `git checkout`/`revert` over the developer's work; just rewrite the file content.
+5. Measure the changed version; report the delta.
+
+## Anti-patterns to avoid (each = a real mistake made; do the fix)
+
+- **Node/Jest microbench of native-touching code** → mocked to ~free, ~14× wrong. → Measure on device.
+- **Instrumenting one call site** → undercount; misses dependency callers. → Wrap the native API (Pattern 1a).
+- **CPU-profile `--diff` for a tiny / cross-edit change** → phantom line-shift deltas dominate, real signal is sub-noise. → Use counting (Pattern 1).
+- **`grep -c` on `uiautomator` XML** → the dump is one line, so it returns 1 regardless. → `grep -oE '…' | wc -l`.
+- **`uiautomator dump` mid-scroll-animation** → returns a partial/sparse tree (looked like "1 row" when there were 15). → Dump after the list settles.
+- **Fixed `sleep` after a tap, then swipe** → debug nav is slow; swipes hit the list / half-mounted screen. → Wait on `message-flat-list` (Pattern 3).
+- **Reading cold first-mount numbers** → dominated by startup/JIT/module-init (~2500ms "mount" is mostly not your code). → Use warm re-opens; never quote the cold mount as the row cost.
+- **Claiming "faster"/"slower" from one render sample** → it's within noise. → Lead with the deterministic count; only call timing differences real with N runs + non-overlapping spreads.
+
+## Environment gotchas
+
+- **RN 0.85 Fusebox inspector returns 401** on the WebSocket upgrade unless the `Origin` header matches the Metro host, and Node's built-in `undici` WebSocket fails the handshake (close 1006 + TypeError). `capture-hermes-profile.js` already handles both: it resolves the `ws` package (e.g. `package/node_modules/ws`) and passes `{ headers: { Origin: 'http://localhost:8081' } }`. If you write a new capture client, do the same.
+- Dev-mode profiles keep function names but collapse every frame to one bundle URL — **desymbolicate** for per-package attribution.
+- Always **tear down** throwaway instrumentation afterward (`srPatch.ts`, the Profiler wrap, the `index.js` import) and restore any files you edited for the baseline.
+
+## Worked example (the case this skill came from)
+
+Change: centralize `useScreenReaderEnabled` from a per-row hook (each `Message` row queried `AccessibilityInfo.isScreenReaderEnabled()` + added a listener on mount, ×2/row) into a single `ScreenReaderProvider` (one query + one listener app-wide; consumers read via context).
+
+Measured version-agnostically over open+scroll on the same channel:
+- **Without** the change: **83 calls / 84 listeners / 22.1 ms** synchronous JS-thread time.
+- **With** the change: **30 calls / 31 listeners / 12.4 ms**.
+- Removed ~53 calls, ~53 listeners, ~9.7 ms. Render time: **unchanged** (within noise) → the honest framing is **lighter, not faster**.
+
+The `[SR_STACK]` traces revealed the residual ~30 wasn't ours: 1 call = our provider's effect; the other ~29 = **`react-native-gesture-handler`'s `Pressable`**, whose `useIsScreenReaderEnabled` does the exact per-instance query+listener — one layer down, not fixable from our SDK. Lesson: rule 3 (count every caller) is what exposed this; hook-only counting had wrongly said "1". Full record: memory `screen_reader_hook_native_query_cost.md`.
+
+## Execution checklist
+
+- [ ] Metro running, exactly one device connected (`adb devices`).
+- [ ] Picked the right **instrument** for the change (rule 5).
+- [ ] Chose a channel with enough messages; drove it on testIDs, not sleeps.
+- [ ] Instrumented the **native API** (counts every caller), not a single call site.
+- [ ] Captured `[SR_STACK]`/equivalent to attribute the calls (ours vs dependency).
+- [ ] A/B used identical scenario + instrumentation; only code-under-test differed.
+- [ ] Reported **counts** primarily; any timing has N runs + spread + "debug build".
+- [ ] Stated **lighter vs faster** honestly; no "faster" claim from effect-phase work.
+- [ ] Tore down all throwaway instrumentation; restored any baseline-edited files.
+- [ ] Left git to the developer (no commits/reverts).
+
+## Reference files
+
+- `perf/README.md` — canonical capture/analyze/desymbolicate/heap docs.
+- `perf/capture-hermes-profile.js`, `perf/capture-server.js` — Hermes CPU capture (the `ws`+`Origin` clients).
+- `perf/analyze-cpuprofile.js` (`--inside`/`--diff`/`--grep`), `perf/analyze-react-profile.js`, `perf/desymbolicate-cpuprofile.js`.
+- `perf/drive-channel-scenario.sh` — testID-driven scenario. `perf/android-heap-dump.sh` — memory/jank.
+- `.claude/skills/accessibility/SKILL.md` — the project-skill format this mirrors.
+
+## iOS footnote (not yet validated)
+
+Everything here was validated on **Android**. The Hermes capture/analyze scripts are platform-agnostic — the Metro inspector connection is identical, so `capture-hermes-profile.js`, `analyze-cpuprofile.js`, etc. should work as-is on an iOS simulator. Only the **device-driving** (Pattern 3, `drive-channel-scenario.sh`) is Android-specific: for iOS, replace `adb`/`uiautomator` with `xcrun simctl` + the accessibility (AX) hierarchy or `idb ui` to find/tap testIDs, and screen-reader state maps to VoiceOver (`getCurrentVoiceOverState`). Treat an iOS run as unproven until done once and folded back in here.

--- a/.claude/skills/perf-benchmarking/SKILL.md
+++ b/.claude/skills/perf-benchmarking/SKILL.md
@@ -11,12 +11,21 @@ Prerequisites for almost everything below:
 - Metro running: `yarn workspace sampleapp start` (the device pulls the JS bundle from it; **Metro bundles the SDK from `src`** via the `react-native` package.json field, so editing `package/src/**` hot-reloads on relaunch — no `yarn build` needed).
 - A device/emulator connected: `adb devices` shows one. The SampleApp package is `io.getstream.reactnative.sampleapp`.
 
+## What we're measuring for
+
+The question is always: **is this change a net positive for performance, and by how much?** There are two axes, and **either one improving (without regressing the other) is a win worth shipping**:
+
+- **Lighter** — less work per message / per action: fewer native calls, fewer listeners, fewer renders, less JS-thread time. A genuine win **even if render latency is unchanged**.
+- **Faster** — the render / draw itself takes less time.
+
+Good-practice bar for this SDK: **if messages (or the action under test) end up lighter and/or render faster, that's a win.** Always quantify the delta (counts and/or ms) and state the direction — net positive / neutral / regression. Report both axes honestly: don't dress a lightness win up as "faster" (rule 4), but don't *undersell* a lightness win either — it counts.
+
 ## Non-negotiable rules
 
 1. **Measure on a real device, never Node/Jest.** The RN jest preset mocks `AccessibilityInfo` and native modules, so a micro-benchmark of any native-touching code is meaningless. Proven the hard way: a Node bench said ~6µs/call; the device said ~86µs — **14× off** — purely because Jest mocked the native call to ~free.
 2. **Prefer deterministic counts over timing.** Counting native calls / listeners / renders is reproducible and trustworthy. Wall-clock timing is noisy; a *single* timing sample proves nothing. If you report timing, take ≥5 runs, give median + spread, and label it debug-build.
 3. **Count version-agnostically — instrument the native API, not one call site.** Wrap e.g. `AccessibilityInfo.isScreenReaderEnabled` once at app startup and count *every* caller. Instrumenting a single hook undercounts and hides that a **dependency** may dominate. Real example: after centralizing our hook, the SDK made 1 call — but the app still made ~30, because RNGH `Pressable` independently queries it per instance.
-4. **"Lighter" ≠ "Faster."** Removing work from a `useEffect` (off the render/draw path) reduces JS-thread load but does **not** lower render latency. Always say which one you measured. Never claim "renders faster" from effect-phase work.
+4. **Report "lighter" and "faster" as distinct wins — don't conflate them.** Removing work from a `useEffect` (off the render/draw path) is a real win even though it doesn't lower draw latency. Both axes count (see "What we're measuring for"); just never claim "renders faster" from effect-phase work — name the axis that improved and quantify it.
 5. **Match the instrument to the change size.**
    - Structural per-call / per-render change → **counting** (Pattern 1).
    - Big JS-thread cost change → **Hermes CPU profile** (Pattern 2).
@@ -104,18 +113,21 @@ node perf/analyze-cpuprofile.js --diff perf/profiles/baseline.cpuprofile perf/pr
 
 Heed rule 5: if the change is sub-noise, the diff will show **nothing real** (only line-shift phantom deltas) — that's expected, not a failure; fall back to Pattern 1.
 
-### 3) Driving the device (deterministic)
+### 3) Driving the device — scenarios on `scenario-lib.sh`
 
+Scenarios are **thin scripts on top of `perf/scenario-lib.sh`**, which provides device-driving verbs so each scenario stays declarative and waits on real mount signals (never `sleep`). Verbs:
+`relaunch` · `wait_for <testid> [secs]` · `tap_testid <id>` · `tap_until <tap_id> <expect_id> [tries]` (tap + retry until the next screen's testID appears — taps occasionally don't register) · `swipe_up/down/left/right [ms]` · `scroll [n] [ms]` · `count_testid <prefix>` (uses `grep -o | wc -l`, never `grep -c`).
+
+The channel scenario (`perf/drive-channel-scenario.sh`) is the reference shape:
 ```bash
-PKG=io.getstream.reactnative.sampleapp
-# known state: cold relaunch -> channel list
-adb shell am force-stop "$PKG"; adb shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1
-# dump + parse the view tree (single line of XML!)
-adb shell uiautomator dump /sdcard/ui.xml && adb pull /sdcard/ui.xml /tmp/ui.xml
+source "$(dirname "$0")/scenario-lib.sh"
+wait_for channel-preview-button 30 || exit 1
+tap_until channel-preview-button message-flat-list || exit 1   # navigate (retries the tap)
+echo "MOUNTED"; scroll "${1:-10}"
+echo "rows=$(count_testid message-list-item-)"
 ```
-Use `perf/drive-channel-scenario.sh` — it already: waits for `channel-preview-button`, taps the first row's bounds center, waits for `message-flat-list` (mount), then `adb shell input swipe 540 700 540 1600 250` per scroll. testIDs available: `channel-list-view`, `channel-preview-button`, `message-flat-list`, `message-list-item-<uuid>`.
 
-Pick a channel with **many messages** (the "Heya!" preview in the list is just the last message — the channel still has full history). Count visible rows with `grep -oE 'resource-id="message-list-item-[^"]+"' /tmp/ui.xml | wc -l` (NOT `grep -c`).
+**Adding a new scenario (gallery, threads, reactions, …):** copy `perf/scenario-template.sh` → `perf/drive-<name>-scenario.sh`, discover the start/target testIDs by dumping the tree (`adb shell uiautomator dump /sdcard/ui.xml && adb pull /sdcard/ui.xml /tmp/ui.xml; grep -oE 'resource-id="[^"]+"' /tmp/ui.xml | sort -u`), then express the flow with the verbs. Always use `tap_until <x> <next-screen-testid>` for navigation and `wait_for` before interacting. Known testIDs so far: `channel-list-view`, `channel-preview-button`, `message-flat-list`, `message-list-item-<uuid>`. Pick a channel/state with **enough content** (a list preview like "Heya!" is just the last message — the channel still has full history).
 
 ### 4) A/B around a committed change (git-hands-off-safe)
 
@@ -171,7 +183,7 @@ The `[SR_STACK]` traces revealed the residual ~30 wasn't ours: 1 call = our prov
 - `perf/README.md` — canonical capture/analyze/desymbolicate/heap docs.
 - `perf/capture-hermes-profile.js`, `perf/capture-server.js` — Hermes CPU capture (the `ws`+`Origin` clients).
 - `perf/analyze-cpuprofile.js` (`--inside`/`--diff`/`--grep`), `perf/analyze-react-profile.js`, `perf/desymbolicate-cpuprofile.js`.
-- `perf/drive-channel-scenario.sh` — testID-driven scenario. `perf/android-heap-dump.sh` — memory/jank.
+- `perf/scenario-lib.sh` — device-driving verbs (source it). `perf/scenario-template.sh` — stub for a new scenario. `perf/drive-channel-scenario.sh` — reference scenario. `perf/android-heap-dump.sh` — memory/jank.
 - `.claude/skills/accessibility/SKILL.md` — the project-skill format this mirrors.
 
 ## iOS footnote (not yet validated)

--- a/package/src/a11y/hooks/useScreenReaderEnabled.ts
+++ b/package/src/a11y/hooks/useScreenReaderEnabled.ts
@@ -1,10 +1,8 @@
-import { useEffect, useState } from 'react';
-import { AccessibilityInfo } from 'react-native';
-
 import { useAccessibilityContext } from '../../contexts/accessibilityContext/AccessibilityContext';
+import { useScreenReaderContext } from '../../contexts/screenReaderContext/ScreenReaderContext';
 
 /**
- * Subscribes to AccessibilityInfo screen-reader changes and returns the live state.
+ * Returns the live screen-reader state from the app-wide {@link ScreenReaderContext}.
  * Returns false when the AccessibilityContext is disabled, regardless of the OS state,
  * so consumers don't pay the listener cost when the SDK's a11y is opted out.
  *
@@ -13,32 +11,9 @@ import { useAccessibilityContext } from '../../contexts/accessibilityContext/Acc
  */
 export const useScreenReaderEnabled = (): boolean => {
   const { enabled, forceScreenReaderMode } = useAccessibilityContext();
-  const [isEnabled, setIsEnabled] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (!enabled) {
-      setIsEnabled(false);
-      return;
-    }
-
-    let cancelled = false;
-    AccessibilityInfo.isScreenReaderEnabled()
-      .then((value) => {
-        if (!cancelled) setIsEnabled(value);
-      })
-      .catch(() => {
-        // Some platforms / environments may not implement this; fall back to false.
-      });
-
-    const subscription = AccessibilityInfo.addEventListener('screenReaderChanged', setIsEnabled);
-
-    return () => {
-      cancelled = true;
-      subscription?.remove?.();
-    };
-  }, [enabled]);
+  const { enabled: screenReaderEnabled } = useScreenReaderContext();
 
   if (!enabled) return false;
   if (forceScreenReaderMode) return true;
-  return isEnabled;
+  return screenReaderEnabled;
 };

--- a/package/src/contexts/overlayContext/OverlayProvider.tsx
+++ b/package/src/contexts/overlayContext/OverlayProvider.tsx
@@ -15,6 +15,7 @@ import { useStreami18n } from '../../hooks/useStreami18n';
 
 import { AccessibilityProvider } from '../accessibilityContext/AccessibilityContext';
 import { ImageGalleryProvider } from '../imageGalleryContext/ImageGalleryContext';
+import { ScreenReaderProvider } from '../screenReaderContext/ScreenReaderContext';
 import { ThemeProvider } from '../themeContext/ThemeContext';
 
 import {
@@ -104,21 +105,23 @@ export const OverlayProvider = (props: PropsWithChildren<OverlayProviderProps>) 
   return (
     <TranslationProvider value={{ ...translators, userLanguage: DEFAULT_USER_LANGUAGE }}>
       <AccessibilityProvider value={accessibility}>
-        <OverlayContext.Provider value={overlayContext}>
-          <ImageGalleryProvider value={imageGalleryProviderProps}>
-            <ThemeProvider style={overlayContext.style}>
-              <PortalProvider>
-                {accessibility?.enabled ? (
-                  <OverlayA11yShield>{children}</OverlayA11yShield>
-                ) : (
-                  children
-                )}
-                {overlay === 'gallery' && <ImageGallery overlayOpacity={overlayOpacity} />}
-                <MessageOverlayHostLayer />
-              </PortalProvider>
-            </ThemeProvider>
-          </ImageGalleryProvider>
-        </OverlayContext.Provider>
+        <ScreenReaderProvider>
+          <OverlayContext.Provider value={overlayContext}>
+            <ImageGalleryProvider value={imageGalleryProviderProps}>
+              <ThemeProvider style={overlayContext.style}>
+                <PortalProvider>
+                  {accessibility?.enabled ? (
+                    <OverlayA11yShield>{children}</OverlayA11yShield>
+                  ) : (
+                    children
+                  )}
+                  {overlay === 'gallery' && <ImageGallery overlayOpacity={overlayOpacity} />}
+                  <MessageOverlayHostLayer />
+                </PortalProvider>
+              </ThemeProvider>
+            </ImageGalleryProvider>
+          </OverlayContext.Provider>
+        </ScreenReaderProvider>
       </AccessibilityProvider>
     </TranslationProvider>
   );

--- a/package/src/contexts/screenReaderContext/ScreenReaderContext.tsx
+++ b/package/src/contexts/screenReaderContext/ScreenReaderContext.tsx
@@ -1,0 +1,64 @@
+import React, { PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+import { useAccessibilityContext } from '../accessibilityContext/AccessibilityContext';
+
+export type ScreenReaderContextValue = {
+  /** True when an OS screen reader (VoiceOver / TalkBack) is currently active. */
+  enabled: boolean;
+};
+
+const DEFAULT_SCREEN_READER_CONTEXT_VALUE: ScreenReaderContextValue = { enabled: false };
+
+export const ScreenReaderContext = React.createContext<ScreenReaderContextValue>(
+  DEFAULT_SCREEN_READER_CONTEXT_VALUE,
+);
+
+/**
+ * Owns the single, app wide screen reader subscription. One `isScreenReaderEnabled()`
+ * query and one `screenReaderChanged` listener for the whole tree; every consumer reads
+ * the resulting boolean from context instead of attaching its own listener per mount.
+ *
+ * Gated on the AccessibilityContext `enabled` flag: when the SDK's a11y is opted out, no
+ * query is made and no listener is attached.
+ */
+export const ScreenReaderProvider = ({ children }: PropsWithChildren) => {
+  const { enabled: a11yEnabled } = useAccessibilityContext();
+  const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
+
+  useEffect(() => {
+    if (!a11yEnabled) {
+      setScreenReaderEnabled(false);
+      return;
+    }
+
+    let cancelled = false;
+    AccessibilityInfo.isScreenReaderEnabled()
+      .then((value) => {
+        if (!cancelled) setScreenReaderEnabled(value);
+      })
+      .catch(() => {
+        // Some platforms / environments may not implement this; fall back to false.
+      });
+
+    const subscription = AccessibilityInfo.addEventListener(
+      'screenReaderChanged',
+      setScreenReaderEnabled,
+    );
+
+    return () => {
+      cancelled = true;
+      subscription?.remove?.();
+    };
+  }, [a11yEnabled]);
+
+  const value = useMemo<ScreenReaderContextValue>(
+    () => ({ enabled: screenReaderEnabled }),
+    [screenReaderEnabled],
+  );
+
+  return <ScreenReaderContext.Provider value={value}>{children}</ScreenReaderContext.Provider>;
+};
+
+export const useScreenReaderContext = (): ScreenReaderContextValue =>
+  useContext(ScreenReaderContext);

--- a/perf/capture-hermes-profile.js
+++ b/perf/capture-hermes-profile.js
@@ -29,6 +29,27 @@ const http = require('http');
 const path = require('path');
 const readline = require('readline');
 
+// Node's built-in (undici) WebSocket mishandles the Metro/Fusebox inspector
+// handshake (close 1006 + a TypeError in undici). The `ws` package handles it
+// and exposes the same addEventListener API. Prefer it; fall back to global.
+function resolveWebSocket() {
+  const candidates = [
+    'ws',
+    path.join(__dirname, '..', 'package', 'node_modules', 'ws'),
+    path.join(__dirname, '..', 'node_modules', 'ws'),
+    path.join(__dirname, '..', 'examples', 'SampleApp', 'node_modules', 'ws'),
+  ];
+  for (const c of candidates) {
+    try {
+      return require(c);
+    } catch {
+      /* try next */
+    }
+  }
+  return typeof WebSocket !== 'undefined' ? WebSocket : null;
+}
+const WS = resolveWebSocket();
+
 const OUT =
   process.argv[2] ||
   path.join(
@@ -107,14 +128,15 @@ async function main() {
   console.log(`Found target: ${target.title || '(no title)'} — ${target.deviceName || ''}`);
   console.log(`Connecting: ${target.webSocketDebuggerUrl}`);
 
-  // Node 22+ has global WebSocket; older Node would need `ws`.
-  if (typeof WebSocket === 'undefined') {
-    console.error(
-      'Global WebSocket is not available — you are on Node < 22. Either upgrade Node or `yarn add -D ws` and let me know.',
-    );
+  if (!WS) {
+    console.error('No WebSocket implementation available (no global WebSocket, no `ws` package).');
     process.exit(1);
   }
-  const ws = new WebSocket(target.webSocketDebuggerUrl);
+  // RN 0.76+ Fusebox inspector proxy rejects WS upgrades whose Origin doesn't
+  // match the Metro host (a CSRF guard) — 401 without this header.
+  const ws = new WS(target.webSocketDebuggerUrl, {
+    headers: { Origin: `http://${METRO_HOST}:${METRO_PORT}` },
+  });
 
   let msgId = 0;
   const pending = new Map();

--- a/perf/drive-channel-scenario.sh
+++ b/perf/drive-channel-scenario.sh
@@ -1,48 +1,18 @@
 #!/usr/bin/env bash
 #
-# Drive the SampleApp into a channel and scroll, waiting on REAL mount signals
-# (testIDs in the view hierarchy) instead of fixed sleeps — on Android debug,
-# navigation is slow and variable, so sleeping a fixed amount races the mount.
+# Scenario: open the first channel and scroll to mount/remount message rows.
+# Run this WHILE a perf capture is active (see perf/README.md, perf/capture-*.js).
 #
-# Signals used:
-#   channel-list-view        -> the channel list is rendered (ready to tap)
-#   channel-preview-button   -> a channel row (we tap the first one's center)
-#   message-flat-list        -> the channel screen has actually mounted
-#   message-list-item-<uuid> -> individual message rows (counted after scroll)
-#
-# Usage: perf/drive-channel-scenario.sh [num_swipes]
-# Run it WHILE a profile capture is active to capture open + scroll.
+# Usage: perf/drive-channel-scenario.sh [num_swipes]   (default 10)
 
 set -uo pipefail
+source "$(dirname "$0")/scenario-lib.sh"
+
 SWIPES="${1:-10}"
-UIXML=/tmp/scenario-ui.xml
 
-dump() { adb shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1 && adb pull /sdcard/ui.xml "$UIXML" >/dev/null 2>&1; }
-has() { grep -q "$1" "$UIXML"; }
+wait_for channel-preview-button 30 || exit 1                 # channel list rendered
+tap_until channel-preview-button message-flat-list || exit 1 # open first channel (retries tap until mounted)
+echo "MOUNTED"
 
-echo "waiting for channel rows to render..."
-for _ in $(seq 1 30); do dump; has 'resource-id="channel-preview-button"' && break; sleep 1; done
-has 'resource-id="channel-preview-button"' || { echo "ERR: channel rows never appeared"; exit 1; }
-
-BOX=$(grep -oE 'resource-id="channel-preview-button"[^>]*bounds="\[[0-9]+,[0-9]+\]\[[0-9]+,[0-9]+\]"' "$UIXML" \
-  | grep -oE '\[[0-9]+,[0-9]+\]\[[0-9]+,[0-9]+\]' | head -1)
-[ -z "$BOX" ] && { echo "ERR: no channel-preview-button found"; exit 1; }
-CX=$(echo "$BOX" | sed -E 's/\[([0-9]+),([0-9]+)\]\[([0-9]+),([0-9]+)\]/(\1+\3)\/2/' | bc)
-CY=$(echo "$BOX" | sed -E 's/\[([0-9]+),([0-9]+)\]\[([0-9]+),([0-9]+)\]/(\2+\4)\/2/' | bc)
-echo "tapping channel at $CX,$CY"
-adb shell input tap "$CX" "$CY"
-
-echo "waiting for channel to mount (message-flat-list)..."
-MOUNTED=0
-for i in $(seq 1 25); do
-  sleep 1; dump
-  if has 'resource-id="message-flat-list"'; then echo "MOUNTED after ~${i}s"; MOUNTED=1; break; fi
-done
-[ "$MOUNTED" = 1 ] || { echo "ERR: channel never mounted"; exit 1; }
-
-echo "scrolling ${SWIPES}x to mount older rows..."
-for _ in $(seq 1 "$SWIPES"); do adb shell input swipe 540 700 540 1600 250; sleep 0.6; done
-
-dump
-N=$(grep -coE 'resource-id="message-list-item-' "$UIXML")
-echo "DONE — message-list-items currently in tree: $N"
+scroll "$SWIPES"
+echo "DONE — message rows in tree: $(count_testid message-list-item-)"

--- a/perf/drive-channel-scenario.sh
+++ b/perf/drive-channel-scenario.sh
@@ -20,9 +20,9 @@ UIXML=/tmp/scenario-ui.xml
 dump() { adb shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1 && adb pull /sdcard/ui.xml "$UIXML" >/dev/null 2>&1; }
 has() { grep -q "$1" "$UIXML"; }
 
-echo "waiting for channel list..."
-for _ in $(seq 1 20); do dump; has 'resource-id="channel-list-view"' && break; sleep 1; done
-has 'resource-id="channel-list-view"' || { echo "ERR: channel list never appeared"; exit 1; }
+echo "waiting for channel rows to render..."
+for _ in $(seq 1 30); do dump; has 'resource-id="channel-preview-button"' && break; sleep 1; done
+has 'resource-id="channel-preview-button"' || { echo "ERR: channel rows never appeared"; exit 1; }
 
 BOX=$(grep -oE 'resource-id="channel-preview-button"[^>]*bounds="\[[0-9]+,[0-9]+\]\[[0-9]+,[0-9]+\]"' "$UIXML" \
   | grep -oE '\[[0-9]+,[0-9]+\]\[[0-9]+,[0-9]+\]' | head -1)

--- a/perf/drive-channel-scenario.sh
+++ b/perf/drive-channel-scenario.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Drive the SampleApp into a channel and scroll, waiting on REAL mount signals
+# (testIDs in the view hierarchy) instead of fixed sleeps — on Android debug,
+# navigation is slow and variable, so sleeping a fixed amount races the mount.
+#
+# Signals used:
+#   channel-list-view        -> the channel list is rendered (ready to tap)
+#   channel-preview-button   -> a channel row (we tap the first one's center)
+#   message-flat-list        -> the channel screen has actually mounted
+#   message-list-item-<uuid> -> individual message rows (counted after scroll)
+#
+# Usage: perf/drive-channel-scenario.sh [num_swipes]
+# Run it WHILE a profile capture is active to capture open + scroll.
+
+set -uo pipefail
+SWIPES="${1:-10}"
+UIXML=/tmp/scenario-ui.xml
+
+dump() { adb shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1 && adb pull /sdcard/ui.xml "$UIXML" >/dev/null 2>&1; }
+has() { grep -q "$1" "$UIXML"; }
+
+echo "waiting for channel list..."
+for _ in $(seq 1 20); do dump; has 'resource-id="channel-list-view"' && break; sleep 1; done
+has 'resource-id="channel-list-view"' || { echo "ERR: channel list never appeared"; exit 1; }
+
+BOX=$(grep -oE 'resource-id="channel-preview-button"[^>]*bounds="\[[0-9]+,[0-9]+\]\[[0-9]+,[0-9]+\]"' "$UIXML" \
+  | grep -oE '\[[0-9]+,[0-9]+\]\[[0-9]+,[0-9]+\]' | head -1)
+[ -z "$BOX" ] && { echo "ERR: no channel-preview-button found"; exit 1; }
+CX=$(echo "$BOX" | sed -E 's/\[([0-9]+),([0-9]+)\]\[([0-9]+),([0-9]+)\]/(\1+\3)\/2/' | bc)
+CY=$(echo "$BOX" | sed -E 's/\[([0-9]+),([0-9]+)\]\[([0-9]+),([0-9]+)\]/(\2+\4)\/2/' | bc)
+echo "tapping channel at $CX,$CY"
+adb shell input tap "$CX" "$CY"
+
+echo "waiting for channel to mount (message-flat-list)..."
+MOUNTED=0
+for i in $(seq 1 25); do
+  sleep 1; dump
+  if has 'resource-id="message-flat-list"'; then echo "MOUNTED after ~${i}s"; MOUNTED=1; break; fi
+done
+[ "$MOUNTED" = 1 ] || { echo "ERR: channel never mounted"; exit 1; }
+
+echo "scrolling ${SWIPES}x to mount older rows..."
+for _ in $(seq 1 "$SWIPES"); do adb shell input swipe 540 700 540 1600 250; sleep 0.6; done
+
+dump
+N=$(grep -coE 'resource-id="message-list-item-' "$UIXML")
+echo "DONE — message-list-items currently in tree: $N"

--- a/perf/scenario-lib.sh
+++ b/perf/scenario-lib.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# scenario-lib.sh — reusable primitives for driving the SampleApp on a connected
+# Android device during a perf capture. SOURCE this from a scenario script; do
+# not run it directly.
+#
+#   source "$(dirname "$0")/scenario-lib.sh"
+#
+# Design: every scenario is a short, declarative sequence of these verbs. The
+# golden rule is to WAIT ON REAL VIEW-HIERARCHY testIDs, never fixed sleeps —
+# Android debug navigation is slow and variable, so sleeping races the mount.
+#
+# Verbs:
+#   relaunch                  cold-restart the app to a known state (channel list)
+#   wait_for <testid> [secs]  poll uiautomator until a testID appears (default 30s)
+#   tap_testid <testid>       tap the center of the first element whose resource-id
+#                             starts with <testid> (prefix match, so a UUID suffix is fine)
+#   swipe_up [ms]             scroll content up / reveal older (default 250ms)
+#   swipe_down [ms]           scroll content down
+#   swipe_left [ms]           page forward (e.g. image gallery)
+#   swipe_right [ms]          page back
+#   scroll [n] [ms]           swipe_up n times (default 8) with a settle between each
+#   count_testid <prefix>     count elements whose resource-id starts with <prefix>
+#                             (uses grep -o | wc -l — NEVER grep -c: the dump is one line)
+#   ui_dump                   refresh the cached view tree (most verbs call this themselves)
+#
+# Env: PKG overrides the app id (default: io.getstream.reactnative.sampleapp).
+
+PKG="${PKG:-io.getstream.reactnative.sampleapp}"
+UIXML="${UIXML:-/tmp/perf-scenario-ui.xml}"
+
+ui_dump() {
+  adb shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1 &&
+    adb pull /sdcard/ui.xml "$UIXML" >/dev/null 2>&1
+}
+
+relaunch() {
+  adb shell am force-stop "$PKG"
+  adb shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1
+}
+
+wait_for() {
+  local id="$1" timeout="${2:-30}"
+  for _ in $(seq 1 "$timeout"); do
+    ui_dump
+    if grep -q "resource-id=\"$id" "$UIXML"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERR: testID '$id' never appeared within ${timeout}s" >&2
+  return 1
+}
+
+tap_testid() {
+  local id="$1"
+  ui_dump
+  local box
+  box=$(grep -oE "resource-id=\"$id[^\"]*\"[^>]*bounds=\"\[[0-9]+,[0-9]+\]\[[0-9]+,[0-9]+\]\"" "$UIXML" |
+    grep -oE '\[[0-9]+,[0-9]+\]\[[0-9]+,[0-9]+\]' | head -1)
+  if [ -z "$box" ]; then
+    echo "ERR: no element found for testID '$id'" >&2
+    return 1
+  fi
+  local cx cy
+  cx=$(echo "$box" | sed -E 's/\[([0-9]+),([0-9]+)\]\[([0-9]+),([0-9]+)\]/(\1+\3)\/2/' | bc)
+  cy=$(echo "$box" | sed -E 's/\[([0-9]+),([0-9]+)\]\[([0-9]+),([0-9]+)\]/(\2+\4)\/2/' | bc)
+  echo "tap '$id' @ $cx,$cy"
+  adb shell input tap "$cx" "$cy"
+}
+
+tap_until() {
+  # tap_until <tap_testid> <expect_testid> [tries] [wait_each_s]
+  # Taps <tap_testid>, then polls for <expect_testid>; retries the tap if it
+  # didn't land (Android taps occasionally don't register / the list isn't
+  # settled). Use this for navigation instead of a bare tap + wait_for.
+  local tap_id="$1" expect_id="$2" tries="${3:-4}" each="${4:-6}"
+  local i j
+  for i in $(seq 1 "$tries"); do
+    tap_testid "$tap_id" || return 1
+    for j in $(seq 1 "$each"); do
+      sleep 1
+      ui_dump
+      if grep -q "resource-id=\"$expect_id" "$UIXML"; then
+        return 0
+      fi
+    done
+    echo "retry $i: '$expect_id' not up after tapping '$tap_id'" >&2
+  done
+  echo "ERR: '$expect_id' never appeared after $tries taps of '$tap_id'" >&2
+  return 1
+}
+
+swipe_up() { adb shell input swipe 540 700 540 1600 "${1:-250}"; }
+swipe_down() { adb shell input swipe 540 1600 540 700 "${1:-250}"; }
+swipe_left() { adb shell input swipe 950 1200 130 1200 "${1:-250}"; }
+swipe_right() { adb shell input swipe 130 1200 950 1200 "${1:-250}"; }
+
+scroll() {
+  local n="${1:-8}" ms="${2:-250}"
+  for _ in $(seq 1 "$n"); do
+    swipe_up "$ms"
+    sleep 0.6
+  done
+}
+
+count_testid() {
+  ui_dump
+  grep -oE "resource-id=\"$1[^\"]*\"" "$UIXML" | wc -l | tr -d ' '
+}

--- a/perf/scenario-template.sh
+++ b/perf/scenario-template.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# TEMPLATE for a new perf scenario. Copy to perf/drive-<name>-scenario.sh and
+# fill in. Run it WHILE a capture is active.
+#
+# How to build one:
+#   1. Open the SampleApp to the start state and dump the tree to find testIDs:
+#        adb shell uiautomator dump /sdcard/ui.xml && adb pull /sdcard/ui.xml /tmp/ui.xml
+#        grep -oE 'resource-id="[^"]+"' /tmp/ui.xml | sort -u
+#   2. Express the flow as wait_for/tap_testid/swipe_*/scroll/count_testid verbs.
+#   3. Always wait_for the NEXT screen's testID after each tap — never sleep.
+#
+# Example — image gallery (testIDs are placeholders; discover the real ones):
+#
+#   set -uo pipefail
+#   source "$(dirname "$0")/scenario-lib.sh"
+#
+#   wait_for channel-preview-button 30 || exit 1
+#   tap_testid channel-preview-button || exit 1
+#   wait_for message-flat-list 25 || exit 1
+#   tap_testid <image-attachment-testid> || exit 1   # open an image
+#   wait_for <image-gallery-testid> 15 || exit 1      # gallery mounted
+#   echo "GALLERY OPEN"
+#   for _ in $(seq 1 "${1:-8}"); do swipe_left; sleep 0.6; done   # page through images
+#   echo "DONE"
+
+set -uo pipefail
+source "$(dirname "$0")/scenario-lib.sh"
+
+echo "Fill me in — see the header. Available verbs: relaunch, wait_for, tap_testid,"
+echo "swipe_up/down/left/right, scroll, count_testid, ui_dump."


### PR DESCRIPTION
## 🎯 Goal

`useScreenReaderEnabled` used to attach its own `AccessibilityInfo` listener and fire its own `isScreenReaderEnabled()` native query on **every mount**. It runs in every `Message` row (twice, via `useMessageActionHandlers`) plus the composer, so the app requeried the OS and resubscribed on every row mount/remount - work that grows with message count and scrolling.                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                          
This PR introduces a single app-wide **`ScreenReaderContext`**: one provider performs one query + one listener, and every consumer reads the value from context. `useScreenReaderEnabled` collapses to a context read; its public signature and the `enabled` / `forceScreenReaderMode` gating are unchanged. 

### On-device perf-testing tooling (initial pass WIP)
In addition to all of this, the PR also introduces a bootstrapping on device perf testing setup we'll keep iterating on. It's in its early conception still, but so far it's been able to run its own iteration over our `SampleApp` (on Android) and add performance related probes so as to measure this particular change. The result was ~300 microseconds less work for each message to render (asynchronous, of course, non blocking for the UI, but still). This work is of course hugely negligible and will never matter in the grand scheme of things (especially for something gated behind a flag like a11y), but it's still very interesting that it is able to find this out on a fresh agent, with almost no interaction from my side (after many, many iterations :D ). It comes with its own "verbs" (rudimentary for now) related to app actions and only works with ADB. Later own we'll extend this further and potentially add iOS support as well. 

Features so far:                                                                                                                                                                                  
- `perf/scenario-lib.sh` — reusable adb/uiautomator device-driving verbs (wait-on-testID, tap, retry tap, scroll, count).                                                                                                                                                                                                 
- `perf/scenario-template.sh` + `perf/drive-channel-scenario.sh` - template + first scenario.                                                                                                                                                                                                                             
- A `perf-benchmarking` skill capturing the methodology and pitfalls, containing some instructions on how to actually do actionable things in the app

A more proper technical document for this will be included later.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


