### PR TITLE
fix: core ui component alignment fixes

### DIFF
--- a/package/src/components/AttachmentPicker/components/AttachmentMediaPicker/AttachmentPickerItem.tsx
+++ b/package/src/components/AttachmentPicker/components/AttachmentMediaPicker/AttachmentPickerItem.tsx
@@ -238,6 +238,7 @@ const useStyles = () => {
       fontWeight: primitives.typographyFontWeightSemiBold,
       fontSize: primitives.typographyFontSizeSm,
       color: semantics.textTertiary,
+      textAlign: 'center',
     },
   });
 };

--- a/package/src/components/ui/Avatar/AvatarGroup.tsx
+++ b/package/src/components/ui/Avatar/AvatarGroup.tsx
@@ -36,8 +36,8 @@ const sizes = {
     height: 48,
   },
   lg: {
-    width: 44,
-    height: 44,
+    width: 40,
+    height: 40,
   },
 };
 


### PR DESCRIPTION
## 🎯 Goal

This PR fixes two small alignment bugs:

- The `iOS` limited button for the `AttachmentMediaPicker` when system font size is set to max
- The alignment overlap specifically for `lg` versions of `GroupAvatar`

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


