### PR TITLE
fix: prevent upload for files above size limit

### DIFF
--- a/package/src/contexts/messageInputContext/MessageInputContext.tsx
+++ b/package/src/contexts/messageInputContext/MessageInputContext.tsx
@@ -507,7 +507,19 @@ export const MessageInputProvider = ({
         ? await compressedImageURI(normalizedFile, value.compressImageQuality)
         : normalizedFile.uri;
       const updatedFile = { ...normalizedFile, uri: fileURI };
-      await attachmentManager.uploadFiles([updatedFile]);
+      const uploadedFiles = await attachmentManager.uploadFiles([updatedFile]);
+      // A blocked upload (i.e the file exceeds the size limit or has a
+      // disallowed type) is a permanent validation failure that the server
+      // will always reject, so remove it from the composer instead of leaving
+      // an unsendable preview behind. The blocked notification has already been
+      // surfaced to the user by the attachment manager at this point.
+      const blockedAttachmentIds = (uploadedFiles ?? [])
+        .filter((attachment) => attachment?.localMetadata?.uploadState === 'blocked')
+        .map((attachment) => attachment?.localMetadata.id)
+        .filter((id): id is string => typeof id === 'string');
+      if (blockedAttachmentIds.length) {
+        attachmentManager.removeAttachments(blockedAttachmentIds);
+      }
       uploadAbortControllerRef.current.delete(normalizedFile.name);
     } catch (error) {
       if (

--- a/package/src/middlewares/__tests__/attachments.test.ts
+++ b/package/src/middlewares/__tests__/attachments.test.ts
@@ -1,0 +1,75 @@
+import { LocalAttachment, MessageComposer } from 'stream-chat';
+
+import { createAttachmentsCompositionMiddleware } from '../attachments';
+
+type AttachmentUploadState = 'finished' | 'blocked' | 'pending' | 'uploading' | 'failed';
+
+const createLocalImageAttachment = (
+  id: string,
+  uploadState: AttachmentUploadState,
+): LocalAttachment =>
+  ({
+    image_url: `file://local/${id}`,
+    localMetadata: {
+      file: { name: id, uri: `file://local/${id}` },
+      id,
+      uploadState,
+    },
+    // custom marker that survives localAttachmentToAttachment mapping, used to
+    // identify which attachments ended up in the composed message
+    title: id,
+    type: 'image',
+  }) as unknown as LocalAttachment;
+
+const runComposeHandler = (attachments: LocalAttachment[]) => {
+  const composer = {
+    attachmentManager: { attachments },
+  } as unknown as MessageComposer;
+
+  const middleware = createAttachmentsCompositionMiddleware(composer);
+
+  const next = jest.fn((value: unknown) => value);
+  const forward = jest.fn();
+  const state = {
+    localMessage: { attachments: [] },
+    message: { attachments: [] },
+  };
+
+  middleware.handlers.compose({
+    forward,
+    next,
+    state,
+  } as unknown as Parameters<typeof middleware.handlers.compose>[0]);
+
+  return { forward, next };
+};
+
+describe('createAttachmentsCompositionMiddleware', () => {
+  it('excludes blocked attachments from the composed message', () => {
+    const { forward, next } = runComposeHandler([
+      createLocalImageAttachment('finished-attachment', 'finished'),
+      createLocalImageAttachment('blocked-attachment', 'blocked'),
+      createLocalImageAttachment('pending-attachment', 'pending'),
+    ]);
+
+    expect(forward).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+
+    const composedState = next.mock.calls[0][0] as {
+      message: { attachments: { title?: string }[] };
+    };
+    const titles = composedState.message.attachments.map((attachment) => attachment.title);
+
+    expect(titles).toEqual(['finished-attachment', 'pending-attachment']);
+  });
+
+  it('forwards without attachments when every attachment is blocked', () => {
+    const { forward, next } = runComposeHandler([
+      createLocalImageAttachment('blocked-1', 'blocked'),
+      createLocalImageAttachment('blocked-2', 'blocked'),
+    ]);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(forward).toHaveBeenCalledTimes(1);
+  });
+});

--- a/package/src/middlewares/attachments.ts
+++ b/package/src/middlewares/attachments.ts
@@ -55,7 +55,12 @@ export const createAttachmentsCompositionMiddleware = (
       if (!attachmentManager) return forward();
 
       const attachments = (state.message.attachments ?? []).concat(
-        attachmentManager.attachments.map(localAttachmentToAttachment),
+        attachmentManager.attachments
+          // Blocked attachments (e.g. over the size limit) are permanent
+          // validation failures the server will reject, so never serialize
+          // them into the outgoing message.
+          .filter((attachment) => attachment.localMetadata.uploadState !== 'blocked')
+          .map(localAttachmentToAttachment),
       );
 
       // prevent introducing attachments array into the payload sent to the server
@@ -90,7 +95,11 @@ export const createDraftAttachmentsCompositionMiddleware = (
       if (!attachmentManager) return forward();
 
       const attachments = (state.draft.attachments ?? []).concat(
-        attachmentManager.attachments.map(localAttachmentToAttachment),
+        attachmentManager.attachments
+          // Don't persist blocked attachments (e.g. over the size limit) into
+          // the draft — they are permanent validation failures.
+          .filter((attachment) => attachment.localMetadata.uploadState !== 'blocked')
+          .map(localAttachmentToAttachment),
       );
 
       return next({


### PR DESCRIPTION
## 🎯 Goal

This PR fixes an issue where we prevent the upload of a video asset if the requested video is above the size limit.

The upload was blocked before as well, however what we never did was prevent the `MessageComposer` from receiving it at all (which while `asyncUploads` is enabled will allow you to actually send it, for the asset to fully upload and only then fail serverside because of size limits).

The fix is to short circuit immediately without waiting for this entire ceremony.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


