### PR TITLE
fix: member label doesn't overlap with user pictures in channel avatar 2xl

### DIFF
--- a/package/src/components/ui/Avatar/AvatarGroup.tsx
+++ b/package/src/components/ui/Avatar/AvatarGroup.tsx
@@ -78,7 +78,7 @@ const avatarSize: Record<AvatarGroupProps['size'], AvatarProps['size']> = {
 };
 
 const badgeCountSize: Record<AvatarGroupProps['size'], BadgeCountProps['size']> = {
-  '2xl': 'lg',
+  '2xl': 'xl',
   xl: 'md',
   lg: 'sm',
 };

--- a/package/src/components/ui/Badge/BadgeCount.tsx
+++ b/package/src/components/ui/Badge/BadgeCount.tsx
@@ -6,10 +6,14 @@ import { primitives } from '../../../theme';
 
 export type BadgeCountProps = {
   count: string | number;
-  size: 'sm' | 'md' | 'lg';
+  size: 'sm' | 'md' | 'lg' | 'xl';
 };
 
 const sizes = {
+  xl: {
+    minWidth: 40,
+    height: 40,
+  },
   lg: {
     minWidth: 32,
     height: 32,
@@ -37,12 +41,17 @@ const textStyles = {
     fontSize: primitives.typographyFontSizeSm,
     fontWeight: primitives.typographyFontWeightBold,
   },
+  xl: {
+    fontSize: primitives.typographyFontSizeSm,
+    fontWeight: primitives.typographyFontWeightBold,
+  },
 };
 
 const paddingHorizontal: Record<BadgeCountProps['size'], number> = {
   sm: primitives.spacingXxs,
   md: primitives.spacingXs,
   lg: primitives.spacingXs,
+  xl: primitives.spacingSm,
 };
 
 export const BadgeCount = (props: BadgeCountProps) => {


### PR DESCRIPTION
## 🎯 Goal

The member label had a smaller size in `UserAvatar` in `2xl` mode.

Docs: https://github.com/GetStream/docs-content/pull/1397

## 🛠 Implementation details

A new size class, `xl`, was added to `BadgeCount`. Only the channel details use `2xl` avatar, updated screenshot below. 
Please note that [Figma](https://www.figma.com/design/BJppI3JYlPy3XeEu5MZY1E/SDK-Components-Library?node-id=8779-380677&m=dev) for `BadgeCount` defines size classes from xs-lg, but in we have sm-xl. I didn't want to reshuffle all classes for `BadgeCount`.

## 🎨 UI Changes

Before:

<img height="500" alt="IMG_3435" src="https://github.com/user-attachments/assets/4bc439da-ff63-41e2-93e5-57438a5071f7" />


After:

<img height="500" alt="Screenshot 2026-06-30 at 10 01 31" src="https://github.com/user-attachments/assets/f15fadfc-2e0b-4d1a-bea7-ae980f8937db" />


## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


