### PR TITLE
fix: don't exclude user from online member count; use watcher_count

### DIFF
--- a/package/src/components/ChannelList/hooks/useChannelOnlineMemberCount.ts
+++ b/package/src/components/ChannelList/hooks/useChannelOnlineMemberCount.ts
@@ -1,18 +1,13 @@
-import { Channel, EventTypes, StreamChat } from 'stream-chat';
+import { Channel, EventTypes } from 'stream-chat';
 
 import { useChatContext } from '../../../contexts';
 import { useSyncClientEventsToChannel } from '../../../hooks/useSyncClientEvents';
 
-const selector = (channel: Channel, client: StreamChat) => {
-  const members = channel.state.members;
-  const onlineMembersCount = Object.values(members).filter(
-    (member) => member.user?.id !== client.userID && member.user?.online,
-  ).length;
-
-  return onlineMembersCount ?? 0;
+const selector = (channel: Channel) => {
+  return channel.state.watcher_count ?? 0;
 };
 
-const keys: EventTypes[] = ['user.presence.changed', 'user.updated'];
+const keys: EventTypes[] = ['user.watching.start', 'user.watching.stop'];
 
 export function useChannelOnlineMemberCount(channel: Channel): number;
 export function useChannelOnlineMemberCount(channel?: Channel): number | undefined;


### PR DESCRIPTION
## 🎯 Goal

- Don't exclude the current user from the count
- Use `watcher_count` instead of `channel.data.members` -> works even if the channel has more than 100 members
- Note: `watcher_count` will include non-members too

Docs: https://github.com/GetStream/docs-content/pull/1398

https://linear.app/stream/issue/RN-405/fix-member-count-hook

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes


## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


