### PR TITLE
fix: gallery video seeking

### DIFF
--- a/package/src/components/ImageGallery/components/ImageGalleryVideoControl.tsx
+++ b/package/src/components/ImageGallery/components/ImageGalleryVideoControl.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import type { ImageGalleryVideoControlProps } from './types';
 
 import { useTheme } from '../../../contexts/themeContext/ThemeContext';
 
+import { useStableCallback } from '../../../hooks/useStableCallback';
 import { useStateStore } from '../../../hooks/useStateStore';
 import { Pause } from '../../../icons/pause-fill';
 import { Play } from '../../../icons/play-fill';
@@ -70,6 +71,24 @@ export const ImageGalleryVideoControl = React.memo((props: ImageGalleryVideoCont
     await videoPlayer.changePlaybackRate();
   };
 
+  // Remember whether playback was ongoing so it can be resumed once the user
+  // finishes scrubbing.
+  const wasPlayingBeforeSeek = useRef(false);
+
+  // Pause while scrubbing so the incoming progress updates don't fight the
+  // user's finger on the seek bar.
+  const handleStartDrag = useStableCallback(() => {
+    wasPlayingBeforeSeek.current = videoPlayer.isPlaying;
+    videoPlayer.pause();
+  });
+
+  const handleEndDrag = useStableCallback((seekProgress: number) => {
+    videoPlayer.seek(seekProgress * duration);
+    if (wasPlayingBeforeSeek.current) {
+      videoPlayer.play();
+    }
+  });
+
   return (
     <View style={[styles.container, container]}>
       <View style={styles.leftContainer}>
@@ -93,6 +112,8 @@ export const ImageGalleryVideoControl = React.memo((props: ImageGalleryVideoCont
       <View style={styles.progressContainer}>
         <ProgressControl
           isPlaying={isPlaying}
+          onEndDrag={handleEndDrag}
+          onStartDrag={handleStartDrag}
           progress={progress}
           testID={'progress-control'}
           width={180}

--- a/package/src/components/ImageGallery/components/ImageGalleryVideoControl.tsx
+++ b/package/src/components/ImageGallery/components/ImageGalleryVideoControl.tsx
@@ -111,6 +111,7 @@ export const ImageGalleryVideoControl = React.memo((props: ImageGalleryVideoCont
 
       <View style={styles.progressContainer}>
         <ProgressControl
+          expandedTouchArea
           isPlaying={isPlaying}
           onEndDrag={handleEndDrag}
           onStartDrag={handleStartDrag}

--- a/package/src/components/ImageGallery/components/__tests__/ImageGalleryVideoControl.test.tsx
+++ b/package/src/components/ImageGallery/components/__tests__/ImageGalleryVideoControl.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
+
+import {
+  ImageGalleryContext,
+  ImageGalleryContextValue,
+} from '../../../../contexts/imageGalleryContext/ImageGalleryContext';
+import { ThemeProvider } from '../../../../contexts/themeContext/ThemeContext';
+import { defaultTheme } from '../../../../contexts/themeContext/utils/theme';
+import { ImageGalleryStateStore } from '../../../../state-store/image-gallery-state-store';
+import { ImageGalleryVideoControl } from '../ImageGalleryVideoControl';
+
+dayjs.extend(duration);
+
+// Replace ProgressControl with a lightweight stand-in that surfaces the seek
+// callbacks as pressables. This lets us exercise the seek wiring (the fix for
+// GH #3419) without a gesture-handler test harness. If the control ever stops
+// passing onStartDrag/onEndDrag, these presses become no-ops and the
+// assertions below fail.
+jest.mock('../../../ProgressControl/ProgressControl', () => {
+  const { Pressable } = require('react-native');
+  return {
+    ProgressControl: ({
+      onStartDrag,
+      onEndDrag,
+    }: {
+      onEndDrag?: (progress: number) => void;
+      onStartDrag?: (progress: number) => void;
+    }) => (
+      <>
+        <Pressable accessibilityLabel='start-drag' onPress={() => onStartDrag?.(0.5)} />
+        <Pressable accessibilityLabel='end-drag' onPress={() => onEndDrag?.(0.5)} />
+      </>
+    ),
+  };
+});
+
+const ATTACHMENT_ID = 'video-attachment-1';
+const DURATION = 10000;
+
+const setup = () => {
+  const store = new ImageGalleryStateStore();
+  const videoPlayer = store.videoPlayerPool.getOrAddPlayer({ id: ATTACHMENT_ID });
+  videoPlayer.duration = DURATION;
+
+  const seekSpy = jest.spyOn(videoPlayer, 'seek').mockImplementation(() => {});
+  const playSpy = jest.spyOn(videoPlayer, 'play').mockImplementation(() => {});
+  const pauseSpy = jest.spyOn(videoPlayer, 'pause').mockImplementation(() => {});
+
+  render(
+    <ThemeProvider theme={defaultTheme}>
+      <ImageGalleryContext.Provider
+        value={{ imageGalleryStateStore: store } as unknown as ImageGalleryContextValue}
+      >
+        <ImageGalleryVideoControl attachmentId={ATTACHMENT_ID} />
+      </ImageGalleryContext.Provider>
+    </ThemeProvider>,
+  );
+
+  return { pauseSpy, playSpy, seekSpy, videoPlayer };
+};
+
+describe('ImageGalleryVideoControl', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('seeks to the dragged position (progress * duration in ms)', () => {
+    const { seekSpy } = setup();
+
+    fireEvent.press(screen.getByLabelText('start-drag'));
+    fireEvent.press(screen.getByLabelText('end-drag'));
+
+    expect(seekSpy).toHaveBeenCalledWith(0.5 * DURATION);
+  });
+
+  it('pauses while scrubbing and resumes when it was playing before the drag', () => {
+    const { pauseSpy, playSpy, seekSpy, videoPlayer } = setup();
+    act(() => {
+      videoPlayer.isPlaying = true;
+    });
+
+    fireEvent.press(screen.getByLabelText('start-drag'));
+    expect(pauseSpy).toHaveBeenCalled();
+
+    fireEvent.press(screen.getByLabelText('end-drag'));
+    expect(seekSpy).toHaveBeenCalledWith(0.5 * DURATION);
+    expect(playSpy).toHaveBeenCalled();
+  });
+
+  it('does not resume playback when it was paused before the drag', () => {
+    const { playSpy, seekSpy, videoPlayer } = setup();
+    act(() => {
+      videoPlayer.isPlaying = false;
+    });
+
+    fireEvent.press(screen.getByLabelText('start-drag'));
+    fireEvent.press(screen.getByLabelText('end-drag'));
+
+    expect(seekSpy).toHaveBeenCalledWith(0.5 * DURATION);
+    expect(playSpy).not.toHaveBeenCalled();
+  });
+});

--- a/package/src/components/ProgressControl/ProgressControl.tsx
+++ b/package/src/components/ProgressControl/ProgressControl.tsx
@@ -50,8 +50,6 @@ export type ProgressControlProps = {
 
 const TRACK_HEIGHT = 3;
 
-// Vertical hit-slop added around the 3px track when `expandedTouchArea` is set,
-// growing the touch target to a comfortable ~27px without changing the visual track.
 const EXPANDED_TOUCH_SLOP = 12;
 
 export const ProgressControl = (props: ProgressControlProps) => {
@@ -99,7 +97,6 @@ export const ProgressControl = (props: ProgressControlProps) => {
       .withTestId(testID);
 
     if (expandedTouchArea) {
-      // The 3px track is a tiny drag target; expand the active area vertically.
       gesture.hitSlop({ bottom: EXPANDED_TOUCH_SLOP, top: EXPANDED_TOUCH_SLOP });
     }
 

--- a/package/src/components/ProgressControl/ProgressControl.tsx
+++ b/package/src/components/ProgressControl/ProgressControl.tsx
@@ -36,6 +36,13 @@ export type ProgressControlProps = {
    */
   onStartDrag?: (progress: number) => void;
   /**
+   * Expands the draggable/touchable area vertically around the thin visual
+   * track via `hitSlop`. The 3px track is easy to miss, so set this when the
+   * control is the primary seek surface (e.g. the image gallery video controls)
+   * to make it comfortably grabbable. The visual track height is unchanged.
+   */
+  expandedTouchArea?: boolean;
+  /**
    * The width of the progress control
    */
   width?: number;
@@ -43,8 +50,12 @@ export type ProgressControlProps = {
 
 const TRACK_HEIGHT = 3;
 
+// Vertical hit-slop added around the 3px track when `expandedTouchArea` is set,
+// growing the touch target to a comfortable ~27px without changing the visual track.
+const EXPANDED_TOUCH_SLOP = 12;
+
 export const ProgressControl = (props: ProgressControlProps) => {
-  const { isPlaying, onEndDrag, onStartDrag, progress, testID } = props;
+  const { expandedTouchArea, isPlaying, onEndDrag, onStartDrag, progress, testID } = props;
   const styles = useStyles();
   const [widthInNumbers, setWidthInNumbers] = useState<number>(0);
   const isRTL = I18nManager.isRTL;
@@ -67,28 +78,33 @@ export const ProgressControl = (props: ProgressControlProps) => {
     [progress],
   );
 
-  const pan = useMemo(
-    () =>
-      Gesture.Pan()
-        .enabled(isSeekable)
-        .maxPointers(1)
-        .onStart(() => {
-          if (onStartDrag) {
-            runOnJS(onStartDrag)(state.value);
-          }
-        })
-        .onUpdate((event) => {
-          const nextProgress = isRTL ? 1 - event.x / widthInNumbers : event.x / widthInNumbers;
-          state.value = Math.max(0, Math.min(nextProgress, 1));
-        })
-        .onEnd(() => {
-          if (onEndDrag) {
-            runOnJS(onEndDrag)(state.value);
-          }
-        })
-        .withTestId(testID),
-    [isRTL, isSeekable, onEndDrag, onStartDrag, state, testID, widthInNumbers],
-  );
+  const pan = useMemo(() => {
+    const gesture = Gesture.Pan()
+      .enabled(isSeekable)
+      .maxPointers(1)
+      .onStart(() => {
+        if (onStartDrag) {
+          runOnJS(onStartDrag)(state.value);
+        }
+      })
+      .onUpdate((event) => {
+        const nextProgress = isRTL ? 1 - event.x / widthInNumbers : event.x / widthInNumbers;
+        state.value = Math.max(0, Math.min(nextProgress, 1));
+      })
+      .onEnd(() => {
+        if (onEndDrag) {
+          runOnJS(onEndDrag)(state.value);
+        }
+      })
+      .withTestId(testID);
+
+    if (expandedTouchArea) {
+      // The 3px track is a tiny drag target; expand the active area vertically.
+      gesture.hitSlop({ bottom: EXPANDED_TOUCH_SLOP, top: EXPANDED_TOUCH_SLOP });
+    }
+
+    return gesture;
+  }, [expandedTouchArea, isRTL, isSeekable, onEndDrag, onStartDrag, state, testID, widthInNumbers]);
 
   const thumbStyles = useAnimatedStyle(
     () => ({

--- a/package/src/components/ProgressControl/ProgressControl.tsx
+++ b/package/src/components/ProgressControl/ProgressControl.tsx
@@ -51,6 +51,8 @@ export const ProgressControl = (props: ProgressControlProps) => {
   const thumbDirectionMultiplier = isRTL ? -1 : 1;
 
   const state = useSharedValue(progress);
+  const isSeekable = onEndDrag !== undefined;
+
   const {
     theme: {
       progressControl: { container, filledStyles, thumb },
@@ -68,6 +70,7 @@ export const ProgressControl = (props: ProgressControlProps) => {
   const pan = useMemo(
     () =>
       Gesture.Pan()
+        .enabled(isSeekable)
         .maxPointers(1)
         .onStart(() => {
           if (onStartDrag) {
@@ -84,7 +87,7 @@ export const ProgressControl = (props: ProgressControlProps) => {
           }
         })
         .withTestId(testID),
-    [isRTL, onEndDrag, onStartDrag, state, testID, widthInNumbers],
+    [isRTL, isSeekable, onEndDrag, onStartDrag, state, testID, widthInNumbers],
   );
 
   const thumbStyles = useAnimatedStyle(

--- a/package/src/native.ts
+++ b/package/src/native.ts
@@ -303,6 +303,11 @@ export type VideoType = {
   repeat?: boolean;
   replayAsync?: () => void;
   resizeMode?: string;
+  /**
+   * Absolute playback position in seconds. Assigning to it performs an absolute
+   * seek (expo-video's `VideoPlayer.currentTime`).
+   */
+  currentTime?: number;
   seek?: (seconds: number) => void;
   seekBy?: (seconds: number) => void;
   setPositionAsync?: (position: number) => void;

--- a/package/src/state-store/__tests__/video-player.test.ts
+++ b/package/src/state-store/__tests__/video-player.test.ts
@@ -11,6 +11,7 @@ jest.mock('../../native', () => ({
 }));
 
 const createMockPlayerRef = () => ({
+  currentTime: 0,
   pause: jest.fn(),
   play: jest.fn(),
   seek: jest.fn(),
@@ -92,8 +93,8 @@ describe('VideoPlayer', () => {
       player.duration = 10000;
       player.seek(5000);
 
-      // Expo uses seekBy instead of seek
-      expect(mockRef.seekBy).toHaveBeenCalled();
+      // Expo performs an absolute seek by assigning currentTime (in seconds)
+      expect(mockRef.currentTime).toBe(5);
       expect(mockRef.seek).not.toHaveBeenCalled();
     });
 
@@ -402,7 +403,7 @@ describe('VideoPlayer', () => {
       expect(mockRef.seekBy).not.toHaveBeenCalled();
     });
 
-    it('should call seekBy on playerRef for Expo SDK', () => {
+    it('should set currentTime on playerRef for Expo SDK (absolute seek)', () => {
       (NativeHandlers as { SDK: string }).SDK = 'stream-chat-expo';
       const player = new VideoPlayer({ id: 'test-player' });
       const mockRef = createMockPlayerRef();
@@ -411,7 +412,9 @@ describe('VideoPlayer', () => {
 
       player.seek(5000);
 
-      expect(mockRef.seekBy).toHaveBeenCalledWith(5000 / ONE_SECOND_IN_MILLISECONDS);
+      // seekBy is relative and must not be used to jump to a timestamp
+      expect(mockRef.currentTime).toBe(5000 / ONE_SECOND_IN_MILLISECONDS);
+      expect(mockRef.seekBy).not.toHaveBeenCalled();
       expect(mockRef.seek).not.toHaveBeenCalled();
     });
 

--- a/package/src/state-store/video-player.ts
+++ b/package/src/state-store/video-player.ts
@@ -162,13 +162,15 @@ export class VideoPlayer {
 
   seek(position: number) {
     this.position = position;
+    const positionInSeconds = position / ONE_SECOND_IN_MILLISECONDS;
     if (this.isExpoCLI) {
-      if (this.playerRef?.seekBy) {
-        this.playerRef.seekBy(position / ONE_SECOND_IN_MILLISECONDS);
+      if (this.playerRef) {
+        this.playerRef.currentTime = positionInSeconds;
       }
     } else {
+      // react-native-video's imperative `seek` takes an absolute time in seconds.
       if (this.playerRef?.seek) {
-        this.playerRef.seek(position / ONE_SECOND_IN_MILLISECONDS);
+        this.playerRef.seek(positionInSeconds);
       }
     }
   }

--- a/package/src/state-store/video-player.ts
+++ b/package/src/state-store/video-player.ts
@@ -168,7 +168,6 @@ export class VideoPlayer {
         this.playerRef.currentTime = positionInSeconds;
       }
     } else {
-      // react-native-video's imperative `seek` takes an absolute time in seconds.
       if (this.playerRef?.seek) {
         this.playerRef.seek(positionInSeconds);
       }


### PR DESCRIPTION
## 🎯 Goal

Closes [this GH issue](https://github.com/GetStream/stream-chat-react-native/issues/3419).

Historically, due to some platform limitations seeking was never implemented for gallery videos. This PR adds the usecase.

It also fixes seeking within our `video-player` as it seems to have never worked (added, but not integrated in the base components).

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


