### PR TITLE
fix: pinned message translations in channel details

### DIFF
--- a/package/src/components/ChannelDetails/components/__tests__/navigation-section/PinnedMessageItem.test.tsx
+++ b/package/src/components/ChannelDetails/components/__tests__/navigation-section/PinnedMessageItem.test.tsx
@@ -15,7 +15,10 @@ jest.mock('../../../../ChannelPreview/ChannelLastMessagePreview', () => {
   const { Text } = require('react-native');
   return {
     ChannelLastMessagePreview: ({ message }: { message: MessageResponse }) =>
-      ReactLib.createElement(Text, { testID: 'preview-message' }, message.id),
+      ReactLib.createElement(ReactLib.Fragment, null, [
+        ReactLib.createElement(Text, { key: 'id', testID: 'preview-message' }, message.id),
+        ReactLib.createElement(Text, { key: 'text', testID: 'preview-message-text' }, message.text),
+      ]),
   };
 });
 
@@ -37,6 +40,7 @@ const channel = { cid: 'messaging:1' } as never;
 const renderItem = (
   message: MessageResponse,
   formatMessageDate?: (date?: string | Date) => string,
+  userLanguage = 'en',
 ) =>
   render(
     <ThemeProvider theme={defaultTheme}>
@@ -44,7 +48,7 @@ const renderItem = (
         value={{
           t: ((key: string) => key) as never,
           tDateTimeParser: ((input: unknown) => input) as never,
-          userLanguage: 'en',
+          userLanguage: userLanguage as never,
         }}
       >
         <PinnedMessageItem
@@ -108,5 +112,29 @@ describe('PinnedMessageItem', () => {
     renderItem(message);
 
     expect(screen.getByTestId('pinned-message-item-m-1')).toBeTruthy();
+  });
+
+  it('renders the translated text for the user language in the last message preview', () => {
+    const message = generateMessage({
+      i18n: { es_text: '¡Hola mundo!' } as never,
+      id: 'm-es',
+      text: 'Hello world!',
+    }) as unknown as MessageResponse;
+
+    renderItem(message, undefined, 'es');
+
+    expect(screen.getByTestId('preview-message-text')).toHaveTextContent('¡Hola mundo!');
+  });
+
+  it('renders the original text when no translation exists for the user language', () => {
+    const message = generateMessage({
+      i18n: { es_text: '¡Hola mundo!' } as never,
+      id: 'm-en',
+      text: 'Hello world!',
+    }) as unknown as MessageResponse;
+
+    renderItem(message, undefined, 'en');
+
+    expect(screen.getByTestId('preview-message-text')).toHaveTextContent('Hello world!');
   });
 });

--- a/package/src/components/ChannelDetails/components/navigation-section/PinnedMessageItem.tsx
+++ b/package/src/components/ChannelDetails/components/navigation-section/PinnedMessageItem.tsx
@@ -5,6 +5,7 @@ import type { Channel, MessageResponse } from 'stream-chat';
 
 import { useComponentsContext } from '../../../../contexts';
 import { useTheme } from '../../../../contexts/themeContext/ThemeContext';
+import { useTranslatedMessage } from '../../../../hooks/useTranslatedMessage';
 import { primitives } from '../../../../theme';
 import { ChannelPreviewStatusProps } from '../../../ChannelPreview/ChannelPreviewStatus';
 import { UserAvatar } from '../../../ui/Avatar/UserAvatar';
@@ -17,7 +18,7 @@ export type PinnedMessageItemProps = {
 } & { formatMessageDate?: ChannelPreviewStatusProps['formatLatestMessageDate'] };
 
 export const PinnedMessageItem = (props: PinnedMessageItemProps) => {
-  const { channel, message, formatMessageDate } = props;
+  const { channel, message: propMessage, formatMessageDate } = props;
   const {
     theme: {
       channelDetails: { pinnedMessageItem },
@@ -26,6 +27,9 @@ export const PinnedMessageItem = (props: PinnedMessageItemProps) => {
   } = useTheme();
   const { ChannelPreviewLastMessage, ChannelPreviewStatus } = useComponentsContext();
   const styles = useStyles();
+
+  const translatedMessage = useTranslatedMessage(propMessage);
+  const message = translatedMessage ?? propMessage;
 
   const senderName = message.user?.name || message.user?.id || '';
 


### PR DESCRIPTION
## 🎯 Goal

This fixes missing message translations for pinned messages within `ChannelDetails`.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


