### PR TITLE
perf: prevent recycling remounting in MessageContent descendants

### DIFF
--- a/package/src/components/Attachment/FileAttachmentGroup.tsx
+++ b/package/src/components/Attachment/FileAttachmentGroup.tsx
@@ -17,7 +17,7 @@ export type FileAttachmentGroupPropsWithContext = Pick<MessageContextValue, 'fil
 };
 
 const FileAttachmentGroupWithContext = (props: FileAttachmentGroupPropsWithContext) => {
-  const { files, message, styles: stylesProp = {} } = props;
+  const { files, styles: stylesProp = {} } = props;
   const { Attachment } = useComponentsContext();
 
   const {
@@ -32,7 +32,7 @@ const FileAttachmentGroupWithContext = (props: FileAttachmentGroupPropsWithConte
     <View style={[styles.container, {}, container, stylesProp.container]}>
       {files.map((file, index) => (
         <View
-          key={`file-by-attachment-group-${message.id}-${index}`}
+          key={`file-by-attachment-group-${index}`}
           style={[styles.item, stylesProp.attachmentContainer, attachmentContainer]}
         >
           <Attachment attachment={file} />

--- a/package/src/components/Attachment/Gallery.tsx
+++ b/package/src/components/Attachment/Gallery.tsx
@@ -272,7 +272,7 @@ const GalleryThumbnail = ({
       accessibilityLabel={thumbnailAccessibilityLabel}
       accessibilityRole='button'
       disabled={preventPress}
-      key={`gallery-item-${message.id}/${colIndex}/${rowIndex}/${imagesAndVideos.length}`}
+      key={`gallery-item-${colIndex}/${rowIndex}`}
       ref={thumbnailRef}
       onLongPress={(event) => {
         if (onLongPress) {

--- a/package/src/components/Message/MessageItemView/MessageContent.tsx
+++ b/package/src/components/Message/MessageItemView/MessageContent.tsx
@@ -281,7 +281,7 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
               );
             case 'attachments':
               return otherAttachments.map((attachment, attachmentIndex) => (
-                <Attachment attachment={attachment} key={`${message.id}-${attachmentIndex}`} />
+                <Attachment attachment={attachment} key={`attachment-${attachmentIndex}`} />
               ));
             case 'files':
               return (
@@ -297,7 +297,7 @@ const MessageContentWithContext = (props: MessageContentPropsWithContext) => {
               const pollId = message.poll_id;
               const poll = pollId && client.polls.fromState(pollId);
               return pollId && poll ? (
-                <Poll key={`poll_${message.poll_id}`} message={message} poll={poll} />
+                <Poll key={`poll_${messageContentOrderIndex}`} message={message} poll={poll} />
               ) : null;
             }
             case 'location':


### PR DESCRIPTION
## 🎯 Goal

This PR fixes a relatively critical performance issue with our `MessageFlashList`, where due to how our component structure works basically any downstream leaf of `MessageContent` was being hard remounted. Passing non-recycling stable keys essentially kills the entire point of recycling and defeats our main mechanism to gain performance here. 

There are still some more (perhaps not so obvious places) where this can be improved, however we want to take this one step at a time and do it carefully since these changes are quite finicky.  

Another PR will follow with performance improvements to the way we fetch the item type (also responsible for some remounts).

Later on we can also explore using the `useMappingHelper` hook from the library itself and seeing if that'll improve even further. But, one step at a time.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


