### PR TITLE
fix: support expo-media-library 56.0.5+

### DIFF
--- a/package/expo-package/src/optionalDependencies/getLocalAssetUri.ts
+++ b/package/expo-package/src/optionalDependencies/getLocalAssetUri.ts
@@ -3,9 +3,13 @@ import { Platform } from 'react-native';
 let MediaLibrary;
 
 try {
-  MediaLibrary = require('expo-media-library');
+  MediaLibrary = require('expo-media-library/legacy');
 } catch (e) {
-  // do nothing
+  try {
+    MediaLibrary = require('expo-media-library');
+  } catch (e) {
+    // do nothing
+  }
 }
 
 if (!MediaLibrary) {

--- a/package/expo-package/src/optionalDependencies/getPhotos.ts
+++ b/package/expo-package/src/optionalDependencies/getPhotos.ts
@@ -10,9 +10,13 @@ import { getLocalAssetUri } from './getLocalAssetUri';
 let MediaLibrary;
 
 try {
-  MediaLibrary = require('expo-media-library');
+  MediaLibrary = require('expo-media-library/legacy');
 } catch (e) {
-  // do nothing
+  try {
+    MediaLibrary = require('expo-media-library');
+  } catch (e) {
+    // do nothing
+  }
 }
 
 if (!MediaLibrary) {

--- a/package/expo-package/src/optionalDependencies/iOS14RefreshGallerySelection.ts
+++ b/package/expo-package/src/optionalDependencies/iOS14RefreshGallerySelection.ts
@@ -3,9 +3,13 @@ import { Platform } from 'react-native';
 let MediaLibrary;
 
 try {
-  MediaLibrary = require('expo-media-library');
+  MediaLibrary = require('expo-media-library/legacy');
 } catch (e) {
-  // do nothing
+  try {
+    MediaLibrary = require('expo-media-library');
+  } catch (e) {
+    // do nothing
+  }
 }
 
 if (!MediaLibrary) {

--- a/package/expo-package/src/optionalDependencies/oniOS14GalleryLibrarySelectionChange.ts
+++ b/package/expo-package/src/optionalDependencies/oniOS14GalleryLibrarySelectionChange.ts
@@ -3,9 +3,13 @@ import { Platform } from 'react-native';
 let MediaLibrary;
 
 try {
-  MediaLibrary = require('expo-media-library');
+  MediaLibrary = require('expo-media-library/legacy');
 } catch (e) {
-  // do nothing
+  try {
+    MediaLibrary = require('expo-media-library');
+  } catch (e) {
+    // do nothing
+  }
 }
 
 if (!MediaLibrary) {


### PR DESCRIPTION
## 🎯 Goal

```
node_modules/expo-media-library/CHANGELOG.md, version 56.0.5 — 2026-05-20:

🛠 Breaking changes
Promote the object-oriented MediaLibrary API to the root expo-media-library import and move the legacy API to expo-media-library/legacy. (#46030 by @Wenszel)
```

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

before: 

https://github.com/user-attachments/assets/fa60387f-d9c6-4272-89f2-db35225ea59c

after:


https://github.com/user-attachments/assets/3551235c-430c-4a91-9343-a4af8d177d2c



## 🧪 Testing

Tested on both iOS and Android

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


