### PR TITLE
fix: expose default native handlers

### DIFF
--- a/package/expo-package/src/index.js
+++ b/package/expo-package/src/index.js
@@ -24,7 +24,10 @@ import {
   Video,
 } from './optionalDependencies';
 
-registerNativeHandlers({
+/**
+ * The default native handlers this package registers with the core SDK.
+ */
+export const defaultNativeHandlers = {
   Audio,
   compressImage,
   deleteFile,
@@ -39,13 +42,17 @@ registerNativeHandlers({
   pickDocument,
   pickImage,
   saveFile,
-  SDK: 'stream-chat-expo',
   setClipboardString,
   shareImage,
   Sound,
   takePhoto,
   triggerHaptic,
   Video,
+};
+
+registerNativeHandlers({
+  ...defaultNativeHandlers,
+  SDK: 'stream-chat-expo',
 });
 
 export * from 'stream-chat-react-native-core';

--- a/package/expo-package/types/index.d.ts
+++ b/package/expo-package/types/index.d.ts
@@ -1,1 +1,30 @@
+import { registerNativeHandlers } from 'stream-chat-react-native-core';
+
 export * from 'stream-chat-react-native-core';
+
+/**
+ * The default native handlers this package registers with the core SDK.
+ *
+ * Exposed so integrators can compose or wrap a single handler (for example to
+ * force `takePhoto` to capture images only) without reimplementing it or
+ * reaching into internal module paths. Register your override *after* importing
+ * this package so it takes precedence.
+ *
+ * Example:
+ *
+ * ```ts
+ * import { registerNativeHandlers, defaultNativeHandlers } from 'stream-chat-expo';
+ *
+ * const localTakePhoto = defaultNativeHandlers.takePhoto;
+ *
+ * registerNativeHandlers({
+ *   takePhoto: localTakePhoto
+ *     ? (options) => {
+ *         console.log('[#3379 demo] wrapped takePhoto — forcing mediaType "image"', options);
+ *         return localTakePhoto({ ...options, mediaType: 'image' });
+ *       }
+ *     : undefined,
+ * });
+ * ```
+ */
+export declare const defaultNativeHandlers: Parameters<typeof registerNativeHandlers>[0];

--- a/package/native-package/src/index.js
+++ b/package/native-package/src/index.js
@@ -25,7 +25,10 @@ import {
   Video,
 } from './optionalDependencies';
 
-registerNativeHandlers({
+/**
+ * The default native handlers this package registers with the core SDK.
+ */
+export const defaultNativeHandlers = {
   Audio,
   compressImage,
   deleteFile,
@@ -40,13 +43,17 @@ registerNativeHandlers({
   pickDocument,
   pickImage,
   saveFile,
-  SDK: 'stream-chat-react-native',
   setClipboardString,
   shareImage,
   Sound,
   takePhoto,
   triggerHaptic,
   Video,
+};
+
+registerNativeHandlers({
+  ...defaultNativeHandlers,
+  SDK: 'stream-chat-react-native',
 });
 
 if (Platform.OS === 'android') {

--- a/package/native-package/types/index.d.ts
+++ b/package/native-package/types/index.d.ts
@@ -1,1 +1,30 @@
+import { registerNativeHandlers } from 'stream-chat-react-native-core';
+
 export * from 'stream-chat-react-native-core';
+
+/**
+ * The default native handlers this package registers with the core SDK.
+ *
+ * Exposed so integrators can compose or wrap a single handler (for example to
+ * force `takePhoto` to capture images only) without reimplementing it or
+ * reaching into internal module paths. Register your override *after* importing
+ * this package so it takes precedence.
+ *
+ * Example:
+ *
+ * ```ts
+ * import { registerNativeHandlers, defaultNativeHandlers } from 'stream-chat-expo';
+ *
+ * const localTakePhoto = defaultNativeHandlers.takePhoto;
+ *
+ * registerNativeHandlers({
+ *   takePhoto: localTakePhoto
+ *     ? (options) => {
+ *         console.log('[#3379 demo] wrapped takePhoto — forcing mediaType "image"', options);
+ *         return localTakePhoto({ ...options, mediaType: 'image' });
+ *       }
+ *     : undefined,
+ * });
+ * ```
+ */
+export declare const defaultNativeHandlers: Parameters<typeof registerNativeHandlers>[0];


### PR DESCRIPTION
## 🎯 Goal

This PR addresses [this GH issue](https://github.com/GetStream/stream-chat-react-native/issues/3379).

While exposing a prop might be slightly more convenient, our native handlers have a ton of arguments we don't want to expose every single one of them separately as it will cause an argument storm. 

Instead, we expose the default native handlers and allow integrators to use them as they see fit.

For example, they could invoke them with different properties, make them conditionally depend on configuration and similar. 

It would also make it easier to conditionally override the handlers in certain scenarios.

Runtime passing of different arguments should still be done on the callsites themselves, this approach is more of a global switch to something else if necessary.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


