### PR TITLE
fix: orientation awareness in bottom sheet

### DIFF
--- a/examples/SampleApp/android/app/src/main/AndroidManifest.xml
+++ b/examples/SampleApp/android/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
     android:supportsRtl="true">
     <activity android:name=".MainActivity" android:label="@string/app_name"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-      android:screenOrientation="portrait" android:launchMode="singleTask"
+      android:screenOrientation="fullSensor" android:launchMode="singleTask"
       android:windowSoftInputMode="adjustResize" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />

--- a/examples/SampleApp/ios/SampleApp/Info.plist
+++ b/examples/SampleApp/ios/SampleApp/Info.plist
@@ -57,6 +57,8 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/package/src/components/MessageMenu/EmojiPickerList.tsx
+++ b/package/src/components/MessageMenu/EmojiPickerList.tsx
@@ -13,6 +13,7 @@ import { primitives } from '../../theme';
 import { StreamBottomSheetModalFlatList } from '../UIComponents';
 
 const EMOJI_SIZE = Platform.OS === 'ios' ? 32 : 28;
+const EMOJI_CELL_SIZE = 54;
 
 const emojiKeyExtractor = (item: string) => `unicode-${item}`;
 
@@ -54,6 +55,7 @@ export const EmojiPickerList = ({
   renderFullInitially?: boolean;
 }) => {
   const styles = useStyles();
+
   const onSelectEmoji = useStableCallback((emoji: string) => {
     const scalarString = toUnicodeScalarString(emoji);
     onSelectReaction(scalarString);
@@ -94,9 +96,9 @@ const useStyles = () => {
       StyleSheet.create({
         bottomSheetColumnWrapper: {
           alignItems: 'center',
-          justifyContent: 'center',
+          justifyContent: 'space-evenly',
           width: '100%',
-          height: 54,
+          height: EMOJI_CELL_SIZE,
         },
         bottomSheetContentContainer: { paddingBottom: 16 },
         emojiContainer: {

--- a/package/src/components/UIComponents/BottomSheetModal.tsx
+++ b/package/src/components/UIComponents/BottomSheetModal.tsx
@@ -18,6 +18,7 @@ import {
   StyleSheet,
   useWindowDimensions,
   View,
+  type ModalProps,
 } from 'react-native';
 import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
 import Animated, {
@@ -45,6 +46,14 @@ import { BottomSheetProvider } from '../../contexts/bottomSheetContext/BottomShe
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
 import { useStableCallback } from '../../hooks';
 import { primitives } from '../../theme';
+
+const supportedOrientations: ModalProps['supportedOrientations'] = [
+  'portrait',
+  'portrait-upside-down',
+  'landscape',
+  'landscape-left',
+  'landscape-right',
+];
 
 export type BottomSheetModalProps = {
   /**
@@ -574,6 +583,7 @@ const BottomSheetModalInner = (props: PropsWithChildren<BottomSheetModalProps>) 
     <Modal
       onDismiss={handleNativeModalDismiss}
       onRequestClose={onClose}
+      supportedOrientations={supportedOrientations}
       transparent
       visible={visible && !isDismissing}
     >

--- a/package/src/components/UIComponents/BottomSheetModal.tsx
+++ b/package/src/components/UIComponents/BottomSheetModal.tsx
@@ -44,7 +44,7 @@ import { useAnnounceOnShow } from '../../a11y/hooks/useAnnounceOnShow';
 import { useResolvedModalAccessibilityProps } from '../../a11y/hooks/useResolvedModalAccessibilityProps';
 import { BottomSheetProvider } from '../../contexts/bottomSheetContext/BottomSheetContext';
 import { useTheme } from '../../contexts/themeContext/ThemeContext';
-import { useStableCallback } from '../../hooks';
+import { useScreenOrientation, useStableCallback } from '../../hooks';
 import { primitives } from '../../theme';
 
 const supportedOrientations: ModalProps['supportedOrientations'] = [
@@ -54,6 +54,8 @@ const supportedOrientations: ModalProps['supportedOrientations'] = [
   'landscape-left',
   'landscape-right',
 ];
+
+const LANDSCAPE_MAX_HEIGHT_RATIO = 0.9;
 
 export type BottomSheetModalProps = {
   /**
@@ -99,11 +101,16 @@ const BottomSheetModalInner = (props: PropsWithChildren<BottomSheetModalProps>) 
     },
   } = useTheme();
   const styles = useStyles();
+  const isLandscape = useScreenOrientation() === 'landscape';
 
-  const maxHeight = Math.max(
+  const availableHeight = Math.max(
     0,
     windowHeight - topInset - (Platform.OS === 'android' ? bottomInset + 16 : 0),
   );
+
+  const maxHeight = isLandscape
+    ? Math.round(availableHeight * LANDSCAPE_MAX_HEIGHT_RATIO)
+    : availableHeight;
   const fixedBaseHeight = Math.min(height, maxHeight);
 
   const contentHeight = useSharedValue<number | undefined>(undefined);

--- a/package/src/hooks/index.ts
+++ b/package/src/hooks/index.ts
@@ -15,6 +15,7 @@ export * from './useSelectedChannelState';
 export * from './useStreami18n';
 export * from './useViewport';
 export * from './useScreenDimensions';
+export * from './useScreenOrientation';
 export * from './useStateStore';
 export * from './usePendingAttachmentUpload';
 export * from './useStableCallback';

--- a/package/src/hooks/useScreenOrientation.ts
+++ b/package/src/hooks/useScreenOrientation.ts
@@ -1,0 +1,15 @@
+import { useWindowDimensions } from 'react-native';
+
+export type ScreenOrientation = 'landscape' | 'portrait';
+
+/**
+ * A custom hook that derives the current screen orientation from the window
+ * dimensions. It updates automatically on device rotation via
+ * `useWindowDimensions`.
+ *
+ * @returns {ScreenOrientation} Either `'landscape'` or `'portrait'`.
+ */
+export const useScreenOrientation = (): ScreenOrientation => {
+  const { height, width } = useWindowDimensions();
+  return width > height ? 'landscape' : 'portrait';
+};


### PR DESCRIPTION
## 🎯 Goal

Fixes [this GH issue](https://github.com/GetStream/stream-chat-react-native/issues/3706).

Our bottom sheet, along with some of its more common was not orientation aware. 

In short, this PR addresses:

- Bottom sheet orientation awareness (on iOS specifically)
- Snap point math based on orientation
- UI of the full reactions picker in different orientations

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


