### PR TITLE
fix: disappearing context menu

### DIFF
--- a/examples/ExpoMessaging/app.json
+++ b/examples/ExpoMessaging/app.json
@@ -3,7 +3,7 @@
     "name": "ExpoMessaging",
     "slug": "ExpoMessaging",
     "version": "1.0.0",
-    "orientation": "portrait",
+    "orientation": "default",
     "icon": "./assets/icon.png",
     "updates": {
       "fallbackToCacheTimeout": 0

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -26,6 +26,7 @@ import { ClosingPortalHostsLayer } from './ClosingPortalHostsLayer';
 
 import { useA11yLabel } from '../../a11y/hooks/useA11yLabel';
 import { useAccessibilityAnnouncer } from '../../components/Accessibility/useAccessibilityAnnouncer';
+import { useScreenOrientation } from '../../hooks';
 import {
   closeOverlay,
   finalizeCloseOverlay,
@@ -97,6 +98,21 @@ export const MessageOverlayHostLayer = () => {
       announcedOpenRef.current = false;
     }
   }, [isActive, overlayOpenHint, announce]);
+
+  // When orientation changes, we dismiss the overlay. While it is possible
+  // (and I have a working PoC of) a repositioning solution, it is pretty
+  // complex and probably bug prone. This is anyway how the iOS native contextual
+  // menu works (as seen on iMessage and Twitch for example, which support landscape
+  // mode).
+  const orientation = useScreenOrientation();
+  const prevOrientationRef = useRef(orientation);
+  useEffect(() => {
+    if (prevOrientationRef.current === orientation) {
+      return;
+    }
+    prevOrientationRef.current = orientation;
+    finalizeCloseOverlay();
+  }, [orientation]);
 
   const padding = 8;
   const minY = topInset + padding;

--- a/package/src/state-store/message-overlay-store.ts
+++ b/package/src/state-store/message-overlay-store.ts
@@ -115,6 +115,9 @@ export const scheduleActionOnClose = (action: () => void | Promise<void>) => {
 };
 
 export const finalizeCloseOverlay = () => {
+  if (!overlayStore.getLatestValue().id) {
+    return;
+  }
   overlayStore.next({
     ...DefaultState,
     closingPortalHostBlacklist: getCurrentClosingPortalHostBlacklist(),


### PR DESCRIPTION
## 🎯 Goal

This PR addresses an issue where due to how positioning math works in the context menu, changing orientation while it's open causes layout to break (in some instances even rendering the entire content of the context menu offscreen !).

While this can be indeed fixed (and I have a working PoC of doing so and it works significantlyu well), it's also a ton of code and edge cases (likely a ton that I'll also miss in the initial pass). 

So, for the time being we've decided to simply close the context menu if orientation changes. This is how both `iMessage` and `Twitch` (using them as examples for applications which handle `landscape` mode properly) do it and is indeed how the native iOS contextual menu works. `Telegram` simply disallows changing orientation while the menu is open. I might revisit this in the future, but for the time being this is a smooth transition that will work without any issues.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


