### PR TITLE
ci: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -6,6 +6,10 @@ on:
       - main
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   generate_changelog_preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -8,6 +8,10 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+*beta*'
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check_pr:
     runs-on: public

--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -11,6 +11,10 @@ on:
       - 'package/**'
       - 'examples/SampleApp/**'
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   build_and_deploy_ios_testflight_qa:
     name: Build SampleApp iOS and Deploy-${{ github.ref == 'refs/heads/develop' }}

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -13,6 +13,10 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   sdk_size:
     name: Metrics


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **5** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
