### PR TITLE
fix: the MessageComposerTrailingView slot moved to same row as input …

### DIFF
--- a/package/src/components/MessageInput/MessageComposer.tsx
+++ b/package/src/components/MessageInput/MessageComposer.tsx
@@ -424,6 +424,7 @@ const MessageComposerWithContext = (props: MessageComposerPropsWithContext) => {
                     </Animated.View>
                   </View>
                 </Animated.View>
+                <MessageComposerTrailingView />
               </View>
             )}
             {!isRecordingStateIdle ? (
@@ -441,9 +442,7 @@ const MessageComposerWithContext = (props: MessageComposerPropsWithContext) => {
                   style={lockIndicatorAnimatedStyle}
                 />
               </View>
-            ) : (
-              <MessageComposerTrailingView />
-            )}
+            ) : null}
           </View>
         </PortalWhileClosingView>
       </Animated.View>


### PR DESCRIPTION
…and MessageComposerLeadingView

## 🎯 Goal

The `MessageComposerTrailingView` was in a different row than  its pair the `MessageComposerLeadingView` or the other composer slots. This PR moves it to the same row, the default component just returns null, so no visual change.

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


