### PR TITLE
fix: keyboard jump on samsung non edge-to-edge devices

### DIFF
--- a/examples/SampleApp/android/gradle.properties
+++ b/examples/SampleApp/android/gradle.properties
@@ -41,7 +41,7 @@ hermesEnabled=true
 # Use this property to enable edge-to-edge display support.
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
-edgeToEdgeEnabled=false
+edgeToEdgeEnabled=true
 
 # disables the check for multiple instances for gesture handler
 # this is needed for react-native-gesture-handler to be both a devDep of core and be a dep on the expo sample app

--- a/examples/SampleApp/ios/Podfile.lock
+++ b/examples/SampleApp/ios/Podfile.lock
@@ -3227,7 +3227,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 57270ccc2b77472d7e85c4cbe45972564eff78bb
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  hermes-engine: d8f4d6c98c2ea2858468ad58fbf6b3a0b33e4da6
+  hermes-engine: 26897e4ae07f28dde638ffab1d25a07f556f7e3e
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3245,7 +3245,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 07da8c06ca047a4047eb44266cd74e1f422d7655
+  React-Core-prebuilt: 81cf85599e5cd4ab9bbbbdf4db08ab654f52e760
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 9af1e96a6069c996e3d9f1e493603e74bc9f1593
@@ -3317,7 +3317,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: 7016a2114079361a2f1536b3c91a15ceb8eb7ca4
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: b494f9d4ef665da25093dffcdd0b1a110475f404
+  ReactNativeDependencies: 08dba4ab0913ea4d2255e4fc63538742aa3e7ac5
   RNCClipboard: 7a7d4557bfd3370b35c99dfecd92ae7b9fc4948a
   RNFastImage: 14580cef91660b889645fb9e87f58a53621db993
   RNFBApp: 3b942e786ca88524ba17df665a1a360fb3eee525

--- a/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
+++ b/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
@@ -17,6 +17,7 @@ import {
   Platform,
   StatusBar,
   StyleSheet,
+  TurboModuleRegistry,
   View,
 } from 'react-native';
 
@@ -26,6 +27,34 @@ export type KeyboardCompatibleViewProps = KeyboardAvoidingViewProps;
 
 export const dismissKeyboard = () => {
   Keyboard.dismiss();
+};
+
+/**
+ * Whether the app runs edge-to-edge on Android (drawing behind the system bars). React Native
+ * exposes this as a `DeviceInfo` native constant. It's a static, app-level value, so we read it
+ * once and cache it. Defaults to `false` if the constant is unavailable (older RN / iOS).
+ *
+ * We need it to decide whether the OS resizes the window when the soft keyboard opens:
+ * edge-to-edge apps do NOT resize (RN dispatches insets instead), non edge-to-edge apps use
+ * `adjustResize` and the window shrinks. `Dimensions.screen - Dimensions.window` alone cannot
+ * tell them apart, because on API < 35 the bars are reported as an inset in BOTH cases.
+ */
+let cachedIsEdgeToEdge: boolean | undefined;
+const getIsEdgeToEdge = (): boolean => {
+  if (cachedIsEdgeToEdge === undefined) {
+    cachedIsEdgeToEdge = false;
+    if (Platform.OS === 'android') {
+      try {
+        const deviceInfo = TurboModuleRegistry.get('DeviceInfo') as {
+          getConstants?: () => { isEdgeToEdge?: boolean };
+        } | null;
+        cachedIsEdgeToEdge = deviceInfo?.getConstants?.().isEdgeToEdge ?? false;
+      } catch {
+        cachedIsEdgeToEdge = false;
+      }
+    }
+  }
+  return cachedIsEdgeToEdge;
 };
 
 type State = {
@@ -86,25 +115,27 @@ export class KeyboardCompatibleView extends React.Component<
     const keyboardY = keyboardFrame.screenY - (this.props.keyboardVerticalOffset ?? 0);
 
     if (Platform.OS === 'android') {
-      // On Android, how much (if anything) we need to move the view up depends on
-      // whether the OS resizes the window when the soft keyboard opens:
+      // On Android, whether we need a JS offset depends on whether the OS resizes the
+      // window when the soft keyboard opens:
       //
-      // - Non edge-to-edge apps: the window is inset by the system bars, so
-      //   `screen.height - window.height > 0`. With `adjustResize` (which this SDK
-      //   requires) the OS shrinks the window and already keeps the composer above the
-      //   keyboard, so no JS offset is needed. Applying one anyway double-offsets the
-      //   view. Worse, our layout `frame` only reflects the resize a render *after*
-      //   `keyboardDidShow` fires, so for that render we'd compute the offset from the
-      //   stale, full-height frame and briefly apply it on top of the native resize —
-      //   this is the transient "jump to a very high point that then settles" reported
-      //   on devices such as Samsung / Android 13.
+      // - Non edge-to-edge apps use `adjustResize`: the OS shrinks the window and already
+      //   keeps the composer above the keyboard, so no JS offset is needed. Applying one
+      //   anyway double-offsets the view — and because our layout `frame` only reflects the
+      //   resize a render *after* `keyboardDidShow` fires, that offset is briefly computed
+      //   from the stale, full-height frame and stacked on top of the native resize. That is
+      //   the transient "jump to a very high point that then settles" reported on devices
+      //   such as Samsung / Android 13. So here we skip the JS offset entirely.
       //
-      // - Edge-to-edge apps: the window spans the whole screen, so
-      //   `screen.height - window.height === 0` (the platform default on Android 15 /
-      //   API 35+). These do NOT resize the window for the keyboard, so the JS offset
-      //   below is the only thing keeping the composer visible and must be applied.
+      // - Edge-to-edge apps (the platform default on Android 15 / API 35+, and opt-in below
+      //   that) do NOT resize the window for the keyboard, so the JS offset below is the only
+      //   thing keeping the composer visible and must be applied.
+      //
+      // `screen - window` reflects the system-bar inset, which is present on non edge-to-edge
+      // AND on edge-to-edge below API 35 — so it can't distinguish the two on its own. We pair
+      // it with the `isEdgeToEdge` native flag: only skip the offset when the bars are inset
+      // (there is room for `adjustResize` to shrink into) AND the app is not edge-to-edge.
       const systemBarsInset = Dimensions.get('screen').height - Dimensions.get('window').height;
-      if (systemBarsInset > 0) {
+      if (systemBarsInset > 0 && !getIsEdgeToEdge()) {
         return 0;
       }
     }

--- a/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
+++ b/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
@@ -85,6 +85,30 @@ export class KeyboardCompatibleView extends React.Component<
 
     const keyboardY = keyboardFrame.screenY - (this.props.keyboardVerticalOffset ?? 0);
 
+    if (Platform.OS === 'android') {
+      // On Android, how much (if anything) we need to move the view up depends on
+      // whether the OS resizes the window when the soft keyboard opens:
+      //
+      // - Non edge-to-edge apps: the window is inset by the system bars, so
+      //   `screen.height - window.height > 0`. With `adjustResize` (which this SDK
+      //   requires) the OS shrinks the window and already keeps the composer above the
+      //   keyboard, so no JS offset is needed. Applying one anyway double-offsets the
+      //   view. Worse, our layout `frame` only reflects the resize a render *after*
+      //   `keyboardDidShow` fires, so for that render we'd compute the offset from the
+      //   stale, full-height frame and briefly apply it on top of the native resize —
+      //   this is the transient "jump to a very high point that then settles" reported
+      //   on devices such as Samsung / Android 13.
+      //
+      // - Edge-to-edge apps: the window spans the whole screen, so
+      //   `screen.height - window.height === 0` (the platform default on Android 15 /
+      //   API 35+). These do NOT resize the window for the keyboard, so the JS offset
+      //   below is the only thing keeping the composer visible and must be applied.
+      const systemBarsInset = Dimensions.get('screen').height - Dimensions.get('window').height;
+      if (systemBarsInset > 0) {
+        return 0;
+      }
+    }
+
     if (this.props.behavior === 'height') {
       return Math.max(this.state.bottom + frame.y + frame.height - keyboardY, 0);
     }
@@ -94,9 +118,9 @@ export class KeyboardCompatibleView extends React.Component<
     const relativeHeight = Math.max(frame.y + frame.height - keyboardY, 0);
 
     if (Platform.OS === 'android') {
-      const barHeights = Dimensions.get('screen').height - Dimensions.get('window').height;
-      const systemInsetFloor = Math.max(barHeights, StatusBar.currentHeight ?? 0);
-
+      // Edge-to-edge only reaches here (systemBarsInset === 0 above): guard against
+      // sub-status-bar noise so we don't apply a tiny bogus offset.
+      const systemInsetFloor = StatusBar.currentHeight ?? 0;
       if (relativeHeight <= systemInsetFloor) {
         return 0;
       }

--- a/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
+++ b/package/src/components/KeyboardCompatibleView/KeyboardCompatibleView.tsx
@@ -120,18 +120,18 @@ export class KeyboardCompatibleView extends React.Component<
       //
       // - Non edge-to-edge apps use `adjustResize`: the OS shrinks the window and already
       //   keeps the composer above the keyboard, so no JS offset is needed. Applying one
-      //   anyway double-offsets the view — and because our layout `frame` only reflects the
-      //   resize a render *after* `keyboardDidShow` fires, that offset is briefly computed
-      //   from the stale, full-height frame and stacked on top of the native resize. That is
-      //   the transient "jump to a very high point that then settles" reported on devices
-      //   such as Samsung / Android 13. So here we skip the JS offset entirely.
+      //   anyway double offsets the view and because our layout `frame` only reflects the
+      //   resize a render AFTER `keyboardDidShow` fires, that offset is briefly computed
+      //   from the stale, full height frame and stacked on top of the native resize. That
+      //   manifests as a transient jump to a very high point that then settles, more commonly
+      //   seen on devices such as Samsung on Android 13. So here we skip the JS offset entirely.
       //
-      // - Edge-to-edge apps (the platform default on Android 15 / API 35+, and opt-in below
+      // - Edge-to-edge apps (the platform default on Android 15/API 35+ and optin below
       //   that) do NOT resize the window for the keyboard, so the JS offset below is the only
       //   thing keeping the composer visible and must be applied.
       //
-      // `screen - window` reflects the system-bar inset, which is present on non edge-to-edge
-      // AND on edge-to-edge below API 35 — so it can't distinguish the two on its own. We pair
+      // `screen - window` reflects the system bar inset, which is present on non edge-to-edge
+      // AND on edge-to-edge below API 35, so it can't distinguish the two on its own. We pair
       // it with the `isEdgeToEdge` native flag: only skip the offset when the bars are inset
       // (there is room for `adjustResize` to shrink into) AND the app is not edge-to-edge.
       const systemBarsInset = Dimensions.get('screen').height - Dimensions.get('window').height;
@@ -150,7 +150,7 @@ export class KeyboardCompatibleView extends React.Component<
 
     if (Platform.OS === 'android') {
       // Edge-to-edge only reaches here (systemBarsInset === 0 above): guard against
-      // sub-status-bar noise so we don't apply a tiny bogus offset.
+      // sub status bar noise so we don't apply a tiny bogus offset.
       const systemInsetFloor = StatusBar.currentHeight ?? 0;
       if (relativeHeight <= systemInsetFloor) {
         return 0;


### PR DESCRIPTION
## 🎯 Goal

This PR fixes a transient issue on `Android`, opening the keyboard inside a channel could make the composer and the message list briefly shoot up to a random high point and then drop back down onto the keyboard. It's most obvious on Samsung (Android 13) and it's intermittent, since it comes down to timing.

`KeyboardCompatibleView` calculates a JS offset to lift the composer above the keyboard. But on a non edge-to-edge app the OS is already doing that for us with `adjustResize` and it shrinks the window when the keyboard shows up. The catch is our layout `frame` only reflects that resize one render *after* `keyboardDidShow` fires, so for a frame or two we compute the offset from the old, full height frame and stack it on top of the native resize. That extra offset is the jump we see.

## 🛠 Implementation details

I split the behaviour based on whether the OS resizes the window for the keyboard:                                                                                                                             
                                                                                                                                                                                                                 
- **Non edge-to-edge** - the window resizes, so we don't need a JS offset at all. We return `0` and let `adjustResize` handle it. No double offset, nothing to race against, no jump.                                                                                                                                                                                            
- **Edge-to-edge** (the default on Android 15 / API 35+, opt-in below that) - the window is *not* resized, RN dispatches insets instead, so our JS offset is the only thing keeping the composer above the keyboard and we have to apply it.                                                                                                                                       
                                                                                                                                                                                                               
The annoying part is you can't tell those two apart from `screen - window` on its own. Below API 35 the system bars get reported as an inset in *both* modes, so a plain `screen - window > 0` check wrongly triggers under edge-to-edge and ends up hiding the composer behind the keyboard. So on top of the inset check we read RN's `isEdgeToEdge`, `DeviceInfo` flag, and we only skip the JS offset when there's a bar inset (room for `adjustResize` to shrink into) *and* the app isn't edge-to-edge.

The table below provides a report of where and how this has been tested on:

| Device | Android / API | Mode | Result |                                                                                                                                                                     
  | --- | --- | --- | --- |                                                                                                                                                                                      
  | Samsung Galaxy A51 (SM-A515F) | 13 / 33 | non edge-to-edge (default) | keyboard open/close repeatedly, no jump |                                                                                             
  | Samsung Galaxy A51 (SM-A515F) | 13 / 33 | edge-to-edge (`edgeToEdgeEnabled=true`) | composer stays above keyboard (this is the case a plain inset check breaks) |                                            
  | Xiaomi 23124RA7EO | 15 / 35 | edge-to-edge (platform-enforced) | unchanged, composer stays above keyboard |                                                                                                  
                                                                                                                                                                                                                 
Opened and closed the keyboard a bunch of times on each to make sure the jump is gone and nothing regressed.                                                            

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


