### PR TITLE
fix: context menu scrollability

### DIFF
--- a/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.tsx.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/AttachButton.test.tsx.snap
@@ -38,9 +38,9 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
         <View
           handlerTags={
             [
+              37,
+              36,
               35,
-              34,
-              33,
             ]
           }
           onGestureHandlerEvent={[Function]}
@@ -212,9 +212,9 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
             <View
               handlerTags={
                 [
+                  40,
+                  39,
                   38,
-                  37,
-                  36,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -359,9 +359,9 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
             <View
               handlerTags={
                 [
+                  43,
+                  42,
                   41,
-                  40,
-                  39,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -535,9 +535,9 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
             <View
               handlerTags={
                 [
+                  46,
+                  45,
                   44,
-                  43,
-                  42,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -678,9 +678,9 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
             <View
               handlerTags={
                 [
+                  49,
+                  48,
                   47,
-                  46,
-                  45,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -844,17 +844,16 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
       }
     >
       <View
+        collapsable={false}
         style={
           {
             "height": 0,
-            "opacity": 0,
-            "width": 0,
           }
         }
-        testID="message-overlay-top"
+        testID="message-overlay-message"
       >
         <View
-          name="top-item"
+          name="message-overlay"
           style={
             {
               "bottom": 0,
@@ -867,16 +866,17 @@ exports[`AttachButton should call handleAttachButtonPress when the button is cli
         />
       </View>
       <View
-        pointerEvents="box-none"
         style={
           {
             "height": 0,
+            "opacity": 0,
+            "width": 0,
           }
         }
-        testID="message-overlay-message"
+        testID="message-overlay-top"
       >
         <View
-          name="message-overlay"
+          name="top-item"
           style={
             {
               "bottom": 0,
@@ -954,9 +954,9 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
         <View
           handlerTags={
             [
+              20,
               19,
               18,
-              17,
             ]
           }
           onGestureHandlerEvent={[Function]}
@@ -1128,9 +1128,9 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
             <View
               handlerTags={
                 [
+                  23,
                   22,
                   21,
-                  20,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -1275,9 +1275,9 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
             <View
               handlerTags={
                 [
+                  26,
                   25,
                   24,
-                  23,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -1451,9 +1451,9 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
             <View
               handlerTags={
                 [
+                  29,
                   28,
                   27,
-                  26,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -1594,9 +1594,9 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
             <View
               handlerTags={
                 [
+                  32,
                   31,
                   30,
-                  29,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -1760,17 +1760,16 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
       }
     >
       <View
+        collapsable={false}
         style={
           {
             "height": 0,
-            "opacity": 0,
-            "width": 0,
           }
         }
-        testID="message-overlay-top"
+        testID="message-overlay-message"
       >
         <View
-          name="top-item"
+          name="message-overlay"
           style={
             {
               "bottom": 0,
@@ -1783,16 +1782,17 @@ exports[`AttachButton should render a enabled AttachButton 1`] = `
         />
       </View>
       <View
-        pointerEvents="box-none"
         style={
           {
             "height": 0,
+            "opacity": 0,
+            "width": 0,
           }
         }
-        testID="message-overlay-message"
+        testID="message-overlay-top"
       >
         <View
-          name="message-overlay"
+          name="top-item"
           style={
             {
               "bottom": 0,
@@ -2676,17 +2676,16 @@ exports[`AttachButton should render an disabled AttachButton 1`] = `
       }
     >
       <View
+        collapsable={false}
         style={
           {
             "height": 0,
-            "opacity": 0,
-            "width": 0,
           }
         }
-        testID="message-overlay-top"
+        testID="message-overlay-message"
       >
         <View
-          name="top-item"
+          name="message-overlay"
           style={
             {
               "bottom": 0,
@@ -2699,16 +2698,17 @@ exports[`AttachButton should render an disabled AttachButton 1`] = `
         />
       </View>
       <View
-        pointerEvents="box-none"
         style={
           {
             "height": 0,
+            "opacity": 0,
+            "width": 0,
           }
         }
-        testID="message-overlay-message"
+        testID="message-overlay-top"
       >
         <View
-          name="message-overlay"
+          name="top-item"
           style={
             {
               "bottom": 0,

--- a/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.tsx.snap
+++ b/package/src/components/MessageInput/__tests__/__snapshots__/SendButton.test.tsx.snap
@@ -842,17 +842,16 @@ exports[`SendButton should render a SendButton 1`] = `
       }
     >
       <View
+        collapsable={false}
         style={
           {
             "height": 0,
-            "opacity": 0,
-            "width": 0,
           }
         }
-        testID="message-overlay-top"
+        testID="message-overlay-message"
       >
         <View
-          name="top-item"
+          name="message-overlay"
           style={
             {
               "bottom": 0,
@@ -865,16 +864,17 @@ exports[`SendButton should render a SendButton 1`] = `
         />
       </View>
       <View
-        pointerEvents="box-none"
         style={
           {
             "height": 0,
+            "opacity": 0,
+            "width": 0,
           }
         }
-        testID="message-overlay-message"
+        testID="message-overlay-top"
       >
         <View
-          name="message-overlay"
+          name="top-item"
           style={
             {
               "bottom": 0,
@@ -952,9 +952,9 @@ exports[`SendButton should render a disabled SendButton 1`] = `
         <View
           handlerTags={
             [
+              20,
               19,
               18,
-              17,
             ]
           }
           onGestureHandlerEvent={[Function]}
@@ -1124,9 +1124,9 @@ exports[`SendButton should render a disabled SendButton 1`] = `
             <View
               handlerTags={
                 [
+                  23,
                   22,
                   21,
-                  20,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -1271,9 +1271,9 @@ exports[`SendButton should render a disabled SendButton 1`] = `
             <View
               handlerTags={
                 [
+                  26,
                   25,
                   24,
-                  23,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -1447,9 +1447,9 @@ exports[`SendButton should render a disabled SendButton 1`] = `
             <View
               handlerTags={
                 [
+                  29,
                   28,
                   27,
-                  26,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -1590,9 +1590,9 @@ exports[`SendButton should render a disabled SendButton 1`] = `
             <View
               handlerTags={
                 [
+                  32,
                   31,
                   30,
-                  29,
                 ]
               }
               onGestureHandlerEvent={[Function]}
@@ -1756,17 +1756,16 @@ exports[`SendButton should render a disabled SendButton 1`] = `
       }
     >
       <View
+        collapsable={false}
         style={
           {
             "height": 0,
-            "opacity": 0,
-            "width": 0,
           }
         }
-        testID="message-overlay-top"
+        testID="message-overlay-message"
       >
         <View
-          name="top-item"
+          name="message-overlay"
           style={
             {
               "bottom": 0,
@@ -1779,16 +1778,17 @@ exports[`SendButton should render a disabled SendButton 1`] = `
         />
       </View>
       <View
-        pointerEvents="box-none"
         style={
           {
             "height": 0,
+            "opacity": 0,
+            "width": 0,
           }
         }
-        testID="message-overlay-message"
+        testID="message-overlay-top"
       >
         <View
-          name="message-overlay"
+          name="top-item"
           style={
             {
               "bottom": 0,

--- a/package/src/components/Thread/__tests__/__snapshots__/Thread.test.tsx.snap
+++ b/package/src/components/Thread/__tests__/__snapshots__/Thread.test.tsx.snap
@@ -1833,9 +1833,9 @@ exports[`Thread should match thread snapshot 1`] = `
                       <View
                         handlerTags={
                           [
+                            27,
                             26,
                             25,
-                            24,
                           ]
                         }
                         onGestureHandlerEvent={[Function]}
@@ -2211,9 +2211,9 @@ exports[`Thread should match thread snapshot 1`] = `
                           <View
                             handlerTags={
                               [
+                                30,
                                 29,
                                 28,
-                                27,
                               ]
                             }
                             onGestureHandlerEvent={[Function]}
@@ -2393,9 +2393,9 @@ exports[`Thread should match thread snapshot 1`] = `
           <View
             handlerTags={
               [
+                33,
                 32,
                 31,
-                30,
               ]
             }
             onGestureHandlerEvent={[Function]}
@@ -2540,9 +2540,9 @@ exports[`Thread should match thread snapshot 1`] = `
           <View
             handlerTags={
               [
+                36,
                 35,
                 34,
-                33,
               ]
             }
             onGestureHandlerEvent={[Function]}
@@ -2716,9 +2716,9 @@ exports[`Thread should match thread snapshot 1`] = `
           <View
             handlerTags={
               [
+                39,
                 38,
                 37,
-                36,
               ]
             }
             onGestureHandlerEvent={[Function]}
@@ -2859,9 +2859,9 @@ exports[`Thread should match thread snapshot 1`] = `
           <View
             handlerTags={
               [
+                42,
                 41,
                 40,
-                39,
               ]
             }
             onGestureHandlerEvent={[Function]}

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -385,51 +385,50 @@ export const MessageOverlayHostLayer = () => {
         ) : null}
 
         {/*
-          The overlay hosts (and therefore the ScrollView) mount only while an overlay is
-          active. `isActive` stays true through the closing animation and only drops on
-          `finalizeCloseOverlay`, so the teleported subtrees stay stable for the whole
-          open -> closing session and nothing is mounted when idle.
+          The portal hosts are always mounted (matching the SDK's original behavior). We do
+          NOT gate them on `isActive`: remounting the hosts on every open makes the native
+          teleport re-lay-out its content on a fresh host, which on iOS renders the teleported
+          message/action-list at a stale/collapsed size on the first frame. Keeping the hosts
+          mounted keeps the teleport target stable. Only the backdrop press target is gated.
         */}
         <View pointerEvents='box-none' style={StyleSheet.absoluteFill}>
           {isActive ? (
-            <>
-              <Pressable
-                onPress={closeOverlay}
-                style={StyleSheet.absoluteFill}
-                testID='message-overlay-backdrop'
-              />
-
-              {MessageActions ? (
-                <MessageActions
-                  bottomItemStyle={bottomItemStyle}
-                  hostStyle={hostStyle}
-                  portalHostStyle={styles.absoluteFill}
-                  topItemStyle={topItemStyle}
-                />
-              ) : (
-                <>
-                  {/*
-                    Order matters: the message is rendered FIRST (lowest z) so it sits BEHIND
-                    the opaque top and bottom items. A tall/scrolled message therefore passes
-                    behind them and into the safe areas, with no clipping and no cut-off.
-                  */}
-                  <GestureDetector gesture={pan}>
-                    <Animated.View style={hostStyle} testID='message-overlay-message'>
-                      <PortalHost name='message-overlay' style={styles.absoluteFill} />
-                    </Animated.View>
-                  </GestureDetector>
-
-                  <Animated.View style={topItemStyle} testID='message-overlay-top'>
-                    <PortalHost name='top-item' style={styles.absoluteFill} />
-                  </Animated.View>
-
-                  <Animated.View style={bottomItemStyle} testID='message-overlay-bottom'>
-                    <PortalHost name='bottom-item' style={styles.absoluteFill} />
-                  </Animated.View>
-                </>
-              )}
-            </>
+            <Pressable
+              onPress={closeOverlay}
+              style={StyleSheet.absoluteFill}
+              testID='message-overlay-backdrop'
+            />
           ) : null}
+
+          {MessageActions ? (
+            <MessageActions
+              bottomItemStyle={bottomItemStyle}
+              hostStyle={hostStyle}
+              portalHostStyle={styles.absoluteFill}
+              topItemStyle={topItemStyle}
+            />
+          ) : (
+            <>
+              {/*
+                Order matters: the message is rendered FIRST (lowest z) so it sits BEHIND
+                the opaque top and bottom items. A tall/scrolled message therefore passes
+                behind them and into the safe areas, with no clipping and no cut-off.
+              */}
+              <GestureDetector gesture={pan}>
+                <Animated.View style={hostStyle} testID='message-overlay-message'>
+                  <PortalHost name='message-overlay' style={styles.absoluteFill} />
+                </Animated.View>
+              </GestureDetector>
+
+              <Animated.View style={topItemStyle} testID='message-overlay-top'>
+                <PortalHost name='top-item' style={styles.absoluteFill} />
+              </Animated.View>
+
+              <Animated.View style={bottomItemStyle} testID='message-overlay-bottom'>
+                <PortalHost name='bottom-item' style={styles.absoluteFill} />
+              </Animated.View>
+            </>
+          )}
         </View>
 
         <ClosingPortalHostsLayer closeCoverOpacity={closeCoverOpacity} />

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -120,12 +120,8 @@ export const MessageOverlayHostLayer = () => {
   const minY = topInset + padding;
   const maxY = screenH - bottomInset - padding;
 
-  // Scrollability: when the reaction picker + message + action list are taller than the
-  // available space, the message becomes scrollable between a pinned top item and a sticky
-  // footer. We do NOT use a ScrollView; instead a Pan gesture drives `scrollY` (a shared
-  // value) and the message content is translated by `-scrollY` inside a clipped frame,
-  // with `withDecay` momentum. Everything stays on the UI thread, consistent with the rest
-  // of this host. All of it is gated on `isActive`, so nothing is mounted when idle.
+  // When top + message + bottom don't fit the usable area, a Pan gesture drives `scrollY` and
+  // the message is translated by it (see hostStyle). No ScrollView, all on the UI thread.
   const scrollY = useSharedValue(0);
   const scrollStartY = useSharedValue(0);
 
@@ -133,17 +129,13 @@ export const MessageOverlayHostLayer = () => {
     if (!messageH.value || !topH.value || !bottomH.value) {
       return { needsScroll: false };
     }
-    // Scroll kicks in when the reaction picker + message + action list don't fit the usable
-    // area (the footer must stay above the safe area).
     const available = maxY - minY;
     const contentH = topH.value.h + messageH.value.h + bottomH.value.h;
     return { needsScroll: contentH > available };
   });
 
-  // Furthest the message can scroll: exactly the amount by which the content overflows the
-  // usable area. At max scroll the message tail lands on top of the sticky footer
-  // (`maxY - bottomH`). This is independent of the clip-frame height, so the message can run
-  // edge-to-edge into the safe area while scrolling still stops in the right place.
+  // How far the message can scroll: the amount its content overflows the usable area. At max
+  // scroll the message tail lands just above the sticky footer.
   const maxScroll = useDerivedValue(() => {
     if (!scrollGeom.value.needsScroll || !messageH.value || !topH.value || !bottomH.value) {
       return 0;
@@ -153,10 +145,8 @@ export const MessageOverlayHostLayer = () => {
     return Math.max(0, contentH - available);
   });
 
-  // We do NOT rewind the scroll during the close animation — the message closes from
-  // wherever it was scrolled to (the close target folds in the scroll; see hostStyle). On
-  // close we just freeze any in-flight fling so the offset is stable while it animates back.
-  // Only reset the scroll once the overlay is fully closed, ready for the next open.
+  // On close, freeze any inflight fling (the message closes from where it was scrolled - see
+  // `hostStyle`) and only reset the offset once fully closed, ready for the next open.
   useEffect(() => {
     if (closing) {
       cancelAnimation(scrollY);
@@ -219,8 +209,7 @@ export const MessageOverlayHostLayer = () => {
     const msgH = messageH.value.h;
     const minTop = minY + topH.value.h;
 
-    // When scrolling, the message clip frame pins directly under the (pinned) top item;
-    // the message itself scrolls within that frame via the ScrollView.
+    // When scrolling, pin the message directly under the (pinned) top item; scrollY does the rest.
     if (scrollGeom.value.needsScroll) {
       return minTop - anchorY;
     }
@@ -241,9 +230,7 @@ export const MessageOverlayHostLayer = () => {
     const msgH = messageH.value.h;
     const minMessageTop = minY + topH.value.h;
 
-    // When scrolling, the bottom item is a sticky footer pinned to the bottom of the
-    // viewport. The ScrollView content carries `bottomH` of trailing padding so the tail
-    // of the message clears the footer once fully scrolled.
+    // When scrolling, pin the bottom item as a sticky footer at the bottom of the usable area.
     if (scrollGeom.value.needsScroll) {
       return maxY - bottomH.value.h - bottomH.value.y;
     }
@@ -296,16 +283,9 @@ export const MessageOverlayHostLayer = () => {
     };
   });
 
-  // The message host. There is NO clipping: the message is rendered BEHIND the (opaque) top
-  // and bottom items, so a scrolled/overflowing message simply passes behind them and flows
-  // into the safe areas — exactly like the action list already lets it.
-  //
-  // Two translateY transforms compose: the first is the springed open/close positioning; the
-  // second is the direct scroll offset driven by the pan gesture. On CLOSE we fold the
-  // current scroll into the FIRST transform's target so the message springs from wherever it
-  // was scrolled to straight onto its row. The scroll transform (second) stays constant
-  // through the close — it does NOT rewind — so the message keeps its scrolled appearance as
-  // it animates back.
+  // Two composed `translateY`: first is the springed open/close position, second is the raw
+  // scroll offset. On close we fold the scroll into the first (springed) target so the message
+  // animates back from where it was scrolled, while the latter stays put.
   const hostStyle = useAnimatedStyle(() => {
     if (!messageH.value) return { height: 0 };
     const scroll = scrollGeom.value.needsScroll ? scrollY.value : 0;
@@ -327,9 +307,8 @@ export const MessageOverlayHostLayer = () => {
     };
   });
 
-  // Manual scroller for the message. Drags translate `scrollY` (clamped to the scrollable
-  // range); release flings with `withDecay`. When the content fits, `maxScroll` is 0 so the
-  // clamp keeps `scrollY` at 0 and the drag is an effective no-op.
+  // Drag scrolls the message (clamped to `[0, maxScroll]`); release flings with decay. When the
+  // content fits, `maxScroll` is 0 so this is a noop.
   const pan = useMemo(
     () =>
       Gesture.Pan()
@@ -395,13 +374,6 @@ export const MessageOverlayHostLayer = () => {
           </Animated.View>
         ) : null}
 
-        {/*
-          The portal hosts are always mounted (matching the SDK's original behavior). We do
-          NOT gate them on `isActive`: remounting the hosts on every open makes the native
-          teleport re-lay-out its content on a fresh host, which on iOS renders the teleported
-          message/action-list at a stale/collapsed size on the first frame. Keeping the hosts
-          mounted keeps the teleport target stable. Only the backdrop press target is gated.
-        */}
         <View pointerEvents='box-none' style={StyleSheet.absoluteFill}>
           {isActive ? (
             <Pressable
@@ -421,9 +393,8 @@ export const MessageOverlayHostLayer = () => {
           ) : (
             <>
               {/*
-                Order matters: the message is rendered FIRST (lowest z) so it sits BEHIND
-                the opaque top and bottom items. A tall/scrolled message therefore passes
-                behind them and into the safe areas, with no clipping and no cut-off.
+                Message renders first (lowest z) so it sits behind the opaque top/bottom items;
+                a scrolled/overflowing message passes behind them instead of being clipped.
               */}
               <GestureDetector gesture={pan}>
                 <Animated.View style={hostStyle} testID='message-overlay-message'>

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -17,6 +17,7 @@ import Animated, {
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
+  withDecay,
   withSpring,
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -118,6 +119,50 @@ export const MessageOverlayHostLayer = () => {
   const minY = topInset + padding;
   const maxY = screenH - bottomInset - padding;
 
+  // Scrollability: when the reaction picker + message + action list are taller than the
+  // available space, the message becomes scrollable between a pinned top item and a sticky
+  // footer. We do NOT use a ScrollView; instead a Pan gesture drives `scrollY` (a shared
+  // value) and the message content is translated by `-scrollY` inside a clipped frame,
+  // with `withDecay` momentum. Everything stays on the UI thread, consistent with the rest
+  // of this host. All of it is gated on `isActive`, so nothing is mounted when idle.
+  const scrollY = useSharedValue(0);
+  const scrollStartY = useSharedValue(0);
+
+  const scrollGeom = useDerivedValue(() => {
+    if (!messageH.value || !topH.value || !bottomH.value) {
+      return { needsScroll: false };
+    }
+    // Scroll kicks in when the reaction picker + message + action list don't fit the usable
+    // area (the footer must stay above the safe area).
+    const available = maxY - minY;
+    const contentH = topH.value.h + messageH.value.h + bottomH.value.h;
+    return { needsScroll: contentH > available };
+  });
+
+  // Furthest the message can scroll: exactly the amount by which the content overflows the
+  // usable area. At max scroll the message tail lands on top of the sticky footer
+  // (`maxY - bottomH`). This is independent of the clip-frame height, so the message can run
+  // edge-to-edge into the safe area while scrolling still stops in the right place.
+  const maxScroll = useDerivedValue(() => {
+    if (!scrollGeom.value.needsScroll || !messageH.value || !topH.value || !bottomH.value) {
+      return 0;
+    }
+    const available = maxY - minY;
+    const contentH = topH.value.h + messageH.value.h + bottomH.value.h;
+    return Math.max(0, contentH - available);
+  });
+
+  // Keep the scroll position deterministic. While closing, rewind to the top with the SAME
+  // spring the frame uses so the message slides back into its row as one coordinated motion
+  // (no jump). Hard-reset once fully closed, ready for the next open.
+  useEffect(() => {
+    if (closing) {
+      scrollY.value = withSpring(0, { duration: DURATION });
+    } else if (!isActive) {
+      scrollY.value = 0;
+    }
+  }, [closing, isActive, scrollY]);
+
   const backdrop = useSharedValue(0);
   const closeCoverOpacity = useSharedValue(0);
 
@@ -171,6 +216,13 @@ export const MessageOverlayHostLayer = () => {
     const anchorY = messageH.value.y;
     const msgH = messageH.value.h;
     const minTop = minY + topH.value.h;
+
+    // When scrolling, the message clip frame pins directly under the (pinned) top item;
+    // the message itself scrolls within that frame via the ScrollView.
+    if (scrollGeom.value.needsScroll) {
+      return minTop - anchorY;
+    }
+
     const maxTopWithBottom = maxY - (msgH + bottomH.value.h);
     const canFitBottomWithoutOverlap = minTop <= maxTopWithBottom;
     const solvedTop = canFitBottomWithoutOverlap
@@ -186,6 +238,14 @@ export const MessageOverlayHostLayer = () => {
     const anchorMessageTop = messageH.value.y;
     const msgH = messageH.value.h;
     const minMessageTop = minY + topH.value.h;
+
+    // When scrolling, the bottom item is a sticky footer pinned to the bottom of the
+    // viewport. The ScrollView content carries `bottomH` of trailing padding so the tail
+    // of the message clears the footer once fully scrolled.
+    if (scrollGeom.value.needsScroll) {
+      return maxY - bottomH.value.h - bottomH.value.y;
+    }
+
     const maxMessageTopWithBottom = maxY - (msgH + bottomH.value.h);
     const canFitBottomWithoutOverlap = minMessageTop <= maxMessageTopWithBottom;
     const solvedMessageTop = canFitBottomWithoutOverlap
@@ -234,18 +294,45 @@ export const MessageOverlayHostLayer = () => {
     };
   });
 
+  // The message host. There is NO clipping: the message is rendered BEHIND the (opaque) top
+  // and bottom items, so a scrolled/overflowing message simply passes behind them and flows
+  // into the safe areas — exactly like the action list already lets it. Two translateY
+  // transforms compose: the first is the springed open/close positioning; the second is the
+  // direct, un-springed scroll offset driven by the pan gesture.
   const hostStyle = useAnimatedStyle(() => {
     if (!messageH.value) return { height: 0 };
     const translateY = isActive ? (closing ? closeCorrectionY.value : messageShiftY.value) : 0;
+    const scroll = scrollGeom.value.needsScroll ? scrollY.value : 0;
     return {
       height: messageH.value.h,
       left: messageH.value.x,
       position: 'absolute',
       top: messageH.value.y,
-      transform: [{ translateY: withSpring(translateY, { duration: DURATION }) }],
+      transform: [
+        { translateY: withSpring(translateY, { duration: DURATION }) },
+        { translateY: scroll === 0 ? 0 : -scroll },
+      ],
       width: messageH.value.w,
     };
   });
+
+  // Manual scroller for the message. Drags translate `scrollY` (clamped to the scrollable
+  // range); release flings with `withDecay`. When the content fits, `maxScroll` is 0 so the
+  // clamp keeps `scrollY` at 0 and the drag is an effective no-op.
+  const pan = useMemo(
+    () =>
+      Gesture.Pan()
+        .onBegin(() => {
+          scrollStartY.value = scrollY.value;
+        })
+        .onUpdate((e) => {
+          scrollY.value = clamp(scrollStartY.value - e.translationY, 0, maxScroll.value);
+        })
+        .onEnd((e) => {
+          scrollY.value = withDecay({ clamp: [0, maxScroll.value], velocity: -e.velocityY });
+        }),
+    [maxScroll, scrollStartY, scrollY],
+  );
 
   const tap = useMemo(
     () =>
@@ -279,8 +366,9 @@ export const MessageOverlayHostLayer = () => {
         })
         .onEnd(() => {
           runOnJS(closeOverlay)();
-        }),
-    [bottomH, bottomShiftY, messageShiftY, topH],
+        })
+        .requireExternalGestureToFail(pan),
+    [bottomH, bottomShiftY, messageShiftY, pan, topH],
   );
 
   return (
@@ -296,41 +384,52 @@ export const MessageOverlayHostLayer = () => {
           </Animated.View>
         ) : null}
 
+        {/*
+          The overlay hosts (and therefore the ScrollView) mount only while an overlay is
+          active. `isActive` stays true through the closing animation and only drops on
+          `finalizeCloseOverlay`, so the teleported subtrees stay stable for the whole
+          open -> closing session and nothing is mounted when idle.
+        */}
         <View pointerEvents='box-none' style={StyleSheet.absoluteFill}>
           {isActive ? (
-            <Pressable
-              onPress={closeOverlay}
-              style={StyleSheet.absoluteFill}
-              testID='message-overlay-backdrop'
-            />
-          ) : null}
-
-          {MessageActions ? (
-            <MessageActions
-              bottomItemStyle={bottomItemStyle}
-              hostStyle={hostStyle}
-              portalHostStyle={styles.absoluteFill}
-              topItemStyle={topItemStyle}
-            />
-          ) : (
             <>
-              <Animated.View style={topItemStyle} testID='message-overlay-top'>
-                <PortalHost name='top-item' style={styles.absoluteFill} />
-              </Animated.View>
+              <Pressable
+                onPress={closeOverlay}
+                style={StyleSheet.absoluteFill}
+                testID='message-overlay-backdrop'
+              />
 
-              <Animated.View
-                pointerEvents='box-none'
-                style={hostStyle}
-                testID='message-overlay-message'
-              >
-                <PortalHost name='message-overlay' style={styles.absoluteFill} />
-              </Animated.View>
+              {MessageActions ? (
+                <MessageActions
+                  bottomItemStyle={bottomItemStyle}
+                  hostStyle={hostStyle}
+                  portalHostStyle={styles.absoluteFill}
+                  topItemStyle={topItemStyle}
+                />
+              ) : (
+                <>
+                  {/*
+                    Order matters: the message is rendered FIRST (lowest z) so it sits BEHIND
+                    the opaque top and bottom items. A tall/scrolled message therefore passes
+                    behind them and into the safe areas, with no clipping and no cut-off.
+                  */}
+                  <GestureDetector gesture={pan}>
+                    <Animated.View style={hostStyle} testID='message-overlay-message'>
+                      <PortalHost name='message-overlay' style={styles.absoluteFill} />
+                    </Animated.View>
+                  </GestureDetector>
 
-              <Animated.View style={bottomItemStyle} testID='message-overlay-bottom'>
-                <PortalHost name='bottom-item' style={styles.absoluteFill} />
-              </Animated.View>
+                  <Animated.View style={topItemStyle} testID='message-overlay-top'>
+                    <PortalHost name='top-item' style={styles.absoluteFill} />
+                  </Animated.View>
+
+                  <Animated.View style={bottomItemStyle} testID='message-overlay-bottom'>
+                    <PortalHost name='bottom-item' style={styles.absoluteFill} />
+                  </Animated.View>
+                </>
+              )}
             </>
-          )}
+          ) : null}
         </View>
 
         <ClosingPortalHostsLayer closeCoverOpacity={closeCoverOpacity} />

--- a/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
+++ b/package/src/contexts/overlayContext/MessageOverlayHostLayer.tsx
@@ -12,6 +12,7 @@ import {
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   type AnimatedStyle,
+  cancelAnimation,
   clamp,
   runOnJS,
   useAnimatedStyle,
@@ -152,12 +153,13 @@ export const MessageOverlayHostLayer = () => {
     return Math.max(0, contentH - available);
   });
 
-  // Keep the scroll position deterministic. While closing, rewind to the top with the SAME
-  // spring the frame uses so the message slides back into its row as one coordinated motion
-  // (no jump). Hard-reset once fully closed, ready for the next open.
+  // We do NOT rewind the scroll during the close animation — the message closes from
+  // wherever it was scrolled to (the close target folds in the scroll; see hostStyle). On
+  // close we just freeze any in-flight fling so the offset is stable while it animates back.
+  // Only reset the scroll once the overlay is fully closed, ready for the next open.
   useEffect(() => {
     if (closing) {
-      scrollY.value = withSpring(0, { duration: DURATION });
+      cancelAnimation(scrollY);
     } else if (!isActive) {
       scrollY.value = 0;
     }
@@ -296,13 +298,22 @@ export const MessageOverlayHostLayer = () => {
 
   // The message host. There is NO clipping: the message is rendered BEHIND the (opaque) top
   // and bottom items, so a scrolled/overflowing message simply passes behind them and flows
-  // into the safe areas — exactly like the action list already lets it. Two translateY
-  // transforms compose: the first is the springed open/close positioning; the second is the
-  // direct, un-springed scroll offset driven by the pan gesture.
+  // into the safe areas — exactly like the action list already lets it.
+  //
+  // Two translateY transforms compose: the first is the springed open/close positioning; the
+  // second is the direct scroll offset driven by the pan gesture. On CLOSE we fold the
+  // current scroll into the FIRST transform's target so the message springs from wherever it
+  // was scrolled to straight onto its row. The scroll transform (second) stays constant
+  // through the close — it does NOT rewind — so the message keeps its scrolled appearance as
+  // it animates back.
   const hostStyle = useAnimatedStyle(() => {
     if (!messageH.value) return { height: 0 };
-    const translateY = isActive ? (closing ? closeCorrectionY.value : messageShiftY.value) : 0;
     const scroll = scrollGeom.value.needsScroll ? scrollY.value : 0;
+    const translateY = isActive
+      ? closing
+        ? closeCorrectionY.value + scroll
+        : messageShiftY.value
+      : 0;
     return {
       height: messageH.value.h,
       left: messageH.value.x,

--- a/package/src/contexts/overlayContext/__tests__/MessageOverlayHostLayer.test.tsx
+++ b/package/src/contexts/overlayContext/__tests__/MessageOverlayHostLayer.test.tsx
@@ -229,7 +229,7 @@ describe('MessageOverlayHostLayer', () => {
     });
   });
 
-  it('unmounts the overlay hosts after finalizeCloseOverlay', () => {
+  it('keeps the hosts mounted but resets their geometry after finalizeCloseOverlay', () => {
     const renderTree = () => (
       <WithComponents overrides={{ MessageOverlayBackground: NoopBackground }}>
         <MessageOverlayHostLayer />
@@ -261,11 +261,17 @@ describe('MessageOverlayHostLayer', () => {
 
     rerender(renderTree());
 
-    // The default host subtree (and therefore the ScrollView) is gated on `isActive`, so
-    // once the overlay is fully closed nothing overlay-related stays mounted.
-    expect(screen.queryByTestId('message-overlay-top')).toBeNull();
-    expect(screen.queryByTestId('message-overlay-message')).toBeNull();
-    expect(screen.queryByTestId('message-overlay-bottom')).toBeNull();
+    // The hosts stay mounted (not gated on isActive) so the native teleport target is stable
+    // across opens; only their geometry resets to 0. The backdrop press target is gated.
+    expect(StyleSheet.flatten(screen.getByTestId('message-overlay-top').props.style)).toMatchObject(
+      { height: 0 },
+    );
+    expect(
+      StyleSheet.flatten(screen.getByTestId('message-overlay-message').props.style),
+    ).toMatchObject({ height: 0 });
+    expect(
+      StyleSheet.flatten(screen.getByTestId('message-overlay-bottom').props.style),
+    ).toMatchObject({ height: 0 });
     expect(screen.queryByTestId('message-overlay-backdrop')).toBeNull();
   });
 

--- a/package/src/contexts/overlayContext/__tests__/MessageOverlayHostLayer.test.tsx
+++ b/package/src/contexts/overlayContext/__tests__/MessageOverlayHostLayer.test.tsx
@@ -215,7 +215,8 @@ describe('MessageOverlayHostLayer', () => {
       left: MESSAGE_RECT.x,
       position: 'absolute',
       top: MESSAGE_RECT.y,
-      transform: [{ translateY: 38 }],
+      // First transform = springed open/close position; second = scroll offset (0 here).
+      transform: [{ translateY: 38 }, { translateY: 0 }],
       width: MESSAGE_RECT.w,
     });
     expect(StyleSheet.flatten(bottomSlot.props.style)).toMatchObject({
@@ -228,7 +229,7 @@ describe('MessageOverlayHostLayer', () => {
     });
   });
 
-  it('resets host geometry after finalizeCloseOverlay clears the registered rects', () => {
+  it('unmounts the overlay hosts after finalizeCloseOverlay', () => {
     const renderTree = () => (
       <WithComponents overrides={{ MessageOverlayBackground: NoopBackground }}>
         <MessageOverlayHostLayer />
@@ -260,18 +261,67 @@ describe('MessageOverlayHostLayer', () => {
 
     rerender(renderTree());
 
+    // The default host subtree (and therefore the ScrollView) is gated on `isActive`, so
+    // once the overlay is fully closed nothing overlay-related stays mounted.
+    expect(screen.queryByTestId('message-overlay-top')).toBeNull();
+    expect(screen.queryByTestId('message-overlay-message')).toBeNull();
+    expect(screen.queryByTestId('message-overlay-bottom')).toBeNull();
+    expect(screen.queryByTestId('message-overlay-backdrop')).toBeNull();
+  });
+
+  it('pins the top item, leaves the message unclipped (behind the items), and sticks the bottom item when the content overflows', () => {
+    // window height 200, insets top 10 / bottom 15, padding 8 => minY 18, maxY 177.
+    // Available height is 159; the rects below sum to 190 so scrolling kicks in.
+    const SCROLL_TOP_RECT = { h: 20, w: 90, x: 5, y: 20 };
+    const SCROLL_MESSAGE_RECT = { h: 140, w: 180, x: 10, y: 40 };
+    const SCROLL_BOTTOM_RECT = { h: 30, w: 140, x: 20, y: 180 };
+
+    const renderTree = () => (
+      <WithComponents overrides={{ MessageOverlayBackground: NoopBackground }}>
+        <MessageOverlayHostLayer />
+      </WithComponents>
+    );
+    const { rerender } = render(renderTree());
+
+    act(() => {});
+
+    act(() => {
+      setOverlayTopH(SCROLL_TOP_RECT);
+      setOverlayMessageH(SCROLL_MESSAGE_RECT);
+      setOverlayBottomH(SCROLL_BOTTOM_RECT);
+      openOverlay('message-1');
+    });
+
+    rerender(renderTree());
+
+    // Top item pinned to minY (18): 20 + (-2) = 18.
     expect(StyleSheet.flatten(screen.getByTestId('message-overlay-top').props.style)).toMatchObject(
       {
-        height: 0,
+        top: SCROLL_TOP_RECT.y,
+        transform: [{ scale: 1 }, { translateY: -2 }],
       },
     );
-    expect(
-      StyleSheet.flatten(screen.getByTestId('message-overlay-message').props.style),
-    ).toMatchObject({ height: 0 });
+
+    // Message host keeps its natural height and is NOT clipped (no overflow:hidden). It is
+    // pinned under the top item (top 40 + first translateY -2 = contentTop 38); the second
+    // translateY is the scroll offset (0 at rest). It renders behind the opaque items.
+    const messageStyle = StyleSheet.flatten(
+      screen.getByTestId('message-overlay-message').props.style,
+    );
+    expect(messageStyle).toMatchObject({
+      height: SCROLL_MESSAGE_RECT.h,
+      left: SCROLL_MESSAGE_RECT.x,
+      top: SCROLL_MESSAGE_RECT.y,
+      transform: [{ translateY: -2 }, { translateY: 0 }],
+    });
+    expect(messageStyle.overflow).toBeUndefined();
+
+    // Bottom item sticks to the bottom of the usable area (maxY - bottomH) = 147: 180 + (-33).
     expect(
       StyleSheet.flatten(screen.getByTestId('message-overlay-bottom').props.style),
     ).toMatchObject({
-      height: 0,
+      top: SCROLL_BOTTOM_RECT.y,
+      transform: [{ scale: 1 }, { translateY: -33 }],
     });
   });
 


### PR DESCRIPTION
## 🎯 Goal

This PR adds scrollability to our context menu whenever the space all of the items take up is larger than the current vertical size of the screen.

When  he top item + message + bottom item don't fit the usable area, the message becomes scrollable between a **pinned reaction picker** (top) and a **sticky action list** (bottom):                                                                                                                                     
                                                                                                                                                                                                                                                                                                                          
- A `Pan` gesture drives a `scrollY` shared value (clamped to the overflow amount), with `withDecay` momentum on release
- No clipping so the message renders behind the opaque top/bottom items, so overflow passes behind them instead of being cut off                                                                                                                                                                                       
- On close, the scroll offset is folded into the close animation so the message animates back from wherever it was scrolled (no snap/rewind), then resets once fully closed.                                                                                                                                              

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


