### PR TITLE
ci: grant write permissions for changelog preview workflow

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   generate_changelog_preview:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Fixes `generate_changelog_preview` job failure on release PRs (e.g. #3721) caused by least-privilege workflow permissions.

`yarn extract-changelog` runs semantic-release in dry-run mode, which still executes `git push --dry-run` against `develop`. With only `contents: read`, `github-actions[bot]` is denied:

```
remote: Permission to GetStream/stream-chat-react-native.git denied to github-actions[bot].
SemanticReleaseError: Cannot push to the Git repository. (EGITNOPERMISSION)
```

Also grants `pull-requests: write` for `marocchino/sticky-pull-request-comment@v3`.

## Changes

Add job-level permissions on `generate_changelog_preview`:
- `contents: write` — semantic-release git push verification
- `pull-requests: write` — sticky PR changelog comment

Workflow-level `contents: read` / `pull-requests: read` remain as the default for any future jobs.

## Test plan

- [ ] `Changelog preview` workflow passes on develop → main release PR
- [ ] Changelog comment is posted on the PR when changes exist


Made with [Cursor](https://cursor.com)