### PR TITLE
fix: yarn workspaces ci issues

### DIFF
--- a/package/bin/before-tag.sh
+++ b/package/bin/before-tag.sh
@@ -10,15 +10,22 @@ set -eux
 PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
 PACKAGE_VERSION_WITHOUT_SHA=$(echo "$PACKAGE_VERSION" | cut -d"+" -f1)
 
+# We bump ONLY the `version` field of the internal packages here and deliberately leave their
+# `stream-chat-react-native-core` dependency as `workspace:^`. This script runs during
+# semantic-release's *prepare* step, before the release commit + `git push origin main` (see
+# `release/prod.js`), so whatever these files look like on disk here is what gets committed.
+#
+# Bumping `version` is safe to commit: Yarn resolves workspace packages to a `0.0.0-use.local`
+# placeholder in the lockfile and keys on the `workspace:^` descriptor, so the version field
+# never affects yarn.lock. Resolving `workspace:^` to a concrete version, however, WOULD change
+# the lockfile descriptor and break `yarn install --immutable` and local workspace linking.
+# That resolution is therefore done only in the published npm tarball, at publish time, in
+# `release.sh` (which runs after this commit) and is never committed back to git.
 cd native-package
 npm version --no-workspaces --allow-same-version --no-git-tag-version "$PACKAGE_VERSION_WITHOUT_SHA"
-sed -e 's|"stream-chat-react-native-core": "[^"]*"|"stream-chat-react-native-core": "'"$PACKAGE_VERSION_WITHOUT_SHA"'"|g' -i.bak package.json
-rm package.json.bak
 
 cd ../expo-package
 npm version --no-workspaces --allow-same-version --no-git-tag-version "$PACKAGE_VERSION_WITHOUT_SHA"
-sed -e 's|"stream-chat-react-native-core": "[^"]*"|"stream-chat-react-native-core": "'"$PACKAGE_VERSION_WITHOUT_SHA"'"|g' -i.bak package.json
-rm package.json.bak
 cd ..
 
 sed -e 's|"version": "[^"]*"|"version": "'"$PACKAGE_VERSION_WITHOUT_SHA"'"|g' -i.bak src/version.json

--- a/package/bin/release.sh
+++ b/package/bin/release.sh
@@ -6,21 +6,35 @@
 set -eux
 
 PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
+PACKAGE_VERSION_WITHOUT_SHA=$(echo "$PACKAGE_VERSION" | cut -d"+" -f1)
 PACKAGE_TAG=$(sed 's/.*-\(.*\)\..*/\1/' <<< "$PACKAGE_VERSION")
+
+# Resolve the `workspace:^` protocol to the concrete published version. npm cannot understand
+# Yarn's `workspace:` protocol, so the tarball must carry a real version. We do this ONLY here,
+# at publish time as this runs after `semantic-release` has already committed and pushed the release
+# commit (see release/prod.js), on a throwaway CI checkout, so the rewrite is never committed.
+# That keeps `workspace:^` intact in git for local dev and `yarn install --immutable`, while the
+# published packages still depend on a concrete `stream-chat-react-native-core` version.
+resolve_workspace_dep() {
+    sed -e 's|"stream-chat-react-native-core": "[^"]*"|"stream-chat-react-native-core": "'"$PACKAGE_VERSION_WITHOUT_SHA"'"|g' -i.bak package.json
+    rm package.json.bak
+}
 
 # If tag === version it means that its not a prerelease and shouuld set things to latest
 if [[ "${PACKAGE_TAG}" != "${PACKAGE_VERSION}" ]]; then
     cd native-package
+    resolve_workspace_dep
     npm publish --no-workspaces --tag="$PACKAGE_TAG"
 
     cd ../expo-package
+    resolve_workspace_dep
     npm publish --no-workspaces --tag="$PACKAGE_TAG"
 else
     cd native-package
+    resolve_workspace_dep
     npm publish --no-workspaces
 
     cd ../expo-package
+    resolve_workspace_dep
     npm publish --no-workspaces
 fi
-
-

--- a/package/expo-package/package.json
+++ b/package/expo-package/package.json
@@ -27,7 +27,7 @@
   "types": "types/index.d.ts",
   "dependencies": {
     "mime": "^4.0.7",
-    "stream-chat-react-native-core": "9.6.1"
+    "stream-chat-react-native-core": "workspace:^"
   },
   "peerDependencies": {
     "expo": ">=52.0.0",

--- a/package/native-package/package.json
+++ b/package/native-package/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "es6-symbol": "^3.1.3",
     "mime": "^4.0.7",
-    "stream-chat-react-native-core": "9.6.1"
+    "stream-chat-react-native-core": "workspace:^"
   },
   "peerDependencies": {
     "@react-native-camera-roll/camera-roll": ">=7.9.0",


### PR DESCRIPTION
## 🎯 Goal

This PR fixes a regression introduced with [this change](https://github.com/GetStream/stream-chat-react-native/pull/3717).

Namely, restoring the functionality in #3717 essentially forced [this](https://github.com/GetStream/stream-chat-react-native/commit/e19a1864891b0d6c1d33e9c615cc85058e26e09e) to happen as well. We in fact want this to only be the case whenever we release a new tarball to `npm` and not in every scenario. 

While bumping `version` is fine in `package.json`, workspace dependencies need to be resolved through the `workspace:^` protocol. 

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


