### PR TITLE
ci: restore SampleApp Android APK upload to S3

### DIFF
--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -94,3 +94,19 @@ jobs:
         env:
           ANDROID_FIREBASE_APP_ID: ${{ secrets.ANDROID_FIREBASE_APP_ID }}
           FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
+      # Publish the same APK to S3 for the public download link. Reuses the
+      # artifact the Fastlane step above already built (app-build/), no rebuild.
+      - name: Configure AWS credentials
+        if: github.ref == 'refs/heads/develop'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Upload APK to S3
+        if: github.ref == 'refs/heads/develop'
+        working-directory: examples/SampleApp
+        # Public download link: https://getstream.io/downloads/rn-sample-app.apk
+        run: |
+          cp app-build/reactnativesampleapp.apk rn-sample-app.apk
+          aws s3 cp rn-sample-app.apk s3://${{ secrets.AWS_S3_BUCKET }} --sse AES256


### PR DESCRIPTION
## 🎯 Goal

Restore the public download link for the SampleApp Android build: `https://getstream.io/downloads/rn-sample-app.apk`.

This S3 upload was removed in #3334 ("chore: add android build and deploy workflows and improve ios workflow"), which replaced the S3-based Android job with Firebase App Distribution. Firebase serves internal QA testers, but it dropped the public, unauthenticated download link that lives on our own domain. This PR brings that link back **alongside** Firebase.

## 🛠 Implementation details

Re-adds the S3 upload as two steps in the existing `build_and_deploy_android_firebase` job in [`sample-distribution.yml`](.github/workflows/sample-distribution.yml):

- **Configure AWS credentials** — `aws-actions/configure-aws-credentials@v4` (the previous code used the now-EOL `v1`), authenticating with the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` secrets.
- **Upload APK to S3** — copies the APK to `rn-sample-app.apk` and runs `aws s3 cp ... --sse AES256`.

Notable choices:

- **No rebuild.** The upload reuses the APK the Fastlane step already produces at `examples/SampleApp/app-build/reactnativesampleapp.apk`, so the previous manual `react-native bundle` + `gradlew assembleRelease` steps are not reintroduced.
- **Object key unchanged** (`rn-sample-app.apk`) so the existing public URL keeps working.
- **`develop`-only**, matching the original behavior.
- **Firebase distribution is kept** — this is additive.

## 🎨 UI Changes

N/A — CI/workflow-only change, no UI impact.

## 🧪 Testing

CI-only change; verified by the `develop` pipeline rather than the example apps:

1. On merge to `develop`, the `build_and_deploy_android_firebase` job runs the two new steps.
2. Confirm the `Upload APK to S3` step succeeds in the Actions logs.
3. Confirm `https://getstream.io/downloads/rn-sample-app.apk` downloads the latest build.

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android
