### PR TITLE
ci: install AWS CLI on self-hosted runner for S3 upload

### DIFF
--- a/.github/workflows/sample-distribution.yml
+++ b/.github/workflows/sample-distribution.yml
@@ -96,6 +96,26 @@ jobs:
           FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
       # Publish the same APK to S3 for the public download link. Reuses the
       # artifact the Fastlane step above already built (app-build/), no rebuild.
+      - name: Ensure AWS CLI is available
+        if: github.ref == 'refs/heads/develop'
+        # The self-hosted `public` runner does not ship the AWS CLI. Install v2
+        # only when missing, to a user-writable dir (no sudo), then expose it.
+        run: |
+          if command -v aws >/dev/null 2>&1; then
+            echo "AWS CLI already installed: $(aws --version)"
+            exit 0
+          fi
+          echo "AWS CLI not found; installing v2..."
+          case "$(uname -m)" in
+            x86_64) zip="awscli-exe-linux-x86_64.zip" ;;
+            aarch64|arm64) zip="awscli-exe-linux-aarch64.zip" ;;
+            *) echo "Unsupported architecture: $(uname -m)"; exit 1 ;;
+          esac
+          curl -fsSL "https://awscli.amazonaws.com/${zip}" -o /tmp/awscliv2.zip
+          unzip -q /tmp/awscliv2.zip -d /tmp
+          /tmp/aws/install --bin-dir "$HOME/.local/bin" --install-dir "$HOME/.local/aws-cli" --update
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/aws" --version
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/develop'
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## 🎯 Goal

Follow-up to #3725 (merged), which restored the SampleApp Android APK upload to S3 that powers `https://getstream.io/downloads/rn-sample-app.apk`. That upload fails on the self-hosted `public` runner because the AWS CLI is not installed there (the original S3 job ran on GitHub-hosted `ubuntu-latest`, where `aws` is preinstalled). This PR makes the job install the AWS CLI when it is missing so the upload can succeed.

## 🛠 Implementation details

Adds an `Ensure AWS CLI is available` step to the `build_and_deploy_android_firebase` job in [`sample-distribution.yml`](.github/workflows/sample-distribution.yml), before the AWS credentials/upload steps:

- No-op when `aws` is already on `PATH` (so it costs nothing if the runner image gains the CLI later).
- Otherwise installs AWS CLI v2 from the official bundle, architecture-aware (`x86_64` / `aarch64`).
- Installs to a user-writable location (`$HOME/.local/...`) with no `sudo`, then appends the bin dir to `$GITHUB_PATH` so the subsequent `Upload APK to S3` step picks it up.
- Runs on `develop` only, matching the rest of the S3 flow.

## 🎨 UI Changes

N/A — CI/workflow-only change, no UI impact.

## 🧪 Testing

CI-only change; verified by the `develop` pipeline rather than the example apps:

1. On merge to `develop`, the `build_and_deploy_android_firebase` job runs the new install step and logs the resolved `aws --version`.
2. Confirm the `Upload APK to S3` step now succeeds in the Actions logs.
3. Confirm `https://getstream.io/downloads/rn-sample-app.apk` serves the latest build.

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android
