### PR TITLE
fix: export OutputButtons from the SDK

### DIFF
--- a/package/src/components/index.ts
+++ b/package/src/components/index.ts
@@ -130,6 +130,7 @@ export * from './MessageInput/MessageInputFooterView';
 export * from './MessageInput/MessageInputHeaderView';
 export * from './MessageInput/MessageInputLeadingView';
 export * from './MessageInput/MessageInputTrailingView';
+export * from './MessageInput/components/OutputButtons';
 export * from './MessageInput/components/OutputButtons/SendButton';
 export * from './MessageInput/SendMessageDisallowedIndicator';
 export * from './MessageInput/ShowThreadMessageInChannelButton';


### PR DESCRIPTION
## 🎯 Goal

Docs PR: https://github.com/GetStream/docs-content/pull/1418

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


