### PR TITLE
fix: export missing base UI components and correct stale JSDoc/comments

### DIFF
--- a/package/src/components/Chat/Chat.tsx
+++ b/package/src/components/Chat/Chat.tsx
@@ -51,7 +51,7 @@ export type ChatProps = Pick<ChatContextValue, 'client'> &
      * This only controls whether the native adapter gets installed by this Chat instance.
      * It does not uninstall an adapter that was already installed on the client.
      *
-     * @default true
+     * @default false
      */
     useNativeMultipartUpload?: boolean;
     /**

--- a/package/src/components/index.ts
+++ b/package/src/components/index.ts
@@ -148,6 +148,7 @@ export * from './MessageInput/components/AttachmentPreview/AudioAttachmentUpload
 export * from './MessageInput/components/AttachmentPreview/FileAttachmentUploadPreview';
 export * from './MessageInput/components/AttachmentPreview/ImageAttachmentUploadPreview';
 export * from './MessageInput/hooks/useAudioRecorder';
+export * from './MessageInput/hooks/useCooldownRemaining';
 
 export * from './MessageList/DateHeader';
 export * from './MessageList/hooks/useMessageList';
@@ -196,6 +197,10 @@ export * from './UIComponents/SvgAwareImage';
 export * from './UIComponents/Spinner';
 export * from './UIComponents/SwipableWrapper';
 export * from './UIComponents/PortalWhileClosingView';
+export * from './UIComponents/EmptyList';
+export * from './UIComponents/EmptySearchResult';
+export * from './UIComponents/SearchInput';
+export * from './UIComponents/SelectionCircle';
 
 export * from './Thread/Thread';
 export * from './Thread/components/ThreadFooterComponent';

--- a/package/src/components/ui/index.ts
+++ b/package/src/components/ui/index.ts
@@ -2,3 +2,6 @@ export * from './Avatar';
 export * from './VideoPlayIndicator';
 export * from './Button';
 export * from './Badge';
+export * from './Input/Input';
+export * from './SpeedSettingsButton';
+export * from './GiphyChip';

--- a/package/src/contexts/attachmentPickerContext/AttachmentPickerContext.tsx
+++ b/package/src/contexts/attachmentPickerContext/AttachmentPickerContext.tsx
@@ -22,7 +22,7 @@ export type AttachmentPickerContextValue = Pick<
 > & {
   /**
    * `bottomInset` determine the height of the `AttachmentPicker` and the underlying shift to the `MessageList` when it is opened.
-   * This can also be set via the `setBottomInset` function provided by the `useAttachmentPickerContext` hook.
+   * This can be set via the `bottomInset` prop on the `Channel` component.
    *
    * Please check [OverlayProvider](https://github.com/GetStream/stream-chat-react-native/wiki/Cookbook-v3.0#overlayprovider) section in Cookbook
    * for more details.

--- a/package/src/contexts/channelsContext/ChannelsContext.tsx
+++ b/package/src/contexts/channelsContext/ChannelsContext.tsx
@@ -69,7 +69,7 @@ export type ChannelsContextValue = {
    */
   maxUnreadCount: number;
   /**
-   * Number of skeletons that should show when loading. Default: 6
+   * Number of skeletons that should show when loading. Default: 8
    */
   numberOfSkeletons: number;
   /**

--- a/package/src/contexts/pollContext/pollContext.tsx
+++ b/package/src/contexts/pollContext/pollContext.tsx
@@ -29,7 +29,7 @@ export const usePollContext = () => {
 
   if (contextValue === DEFAULT_BASE_CONTEXT_VALUE && !isTestEnvironment()) {
     throw new Error(
-      'The useCreatePollContext hook was called outside of the PollContext provider. Make sure you have configured the Poll component correctly - https://getstream.io/chat/docs/sdk/reactnative/basics/hello_stream_chat/#channel',
+      'The usePollContext hook was called outside of the PollContext provider. Make sure you have configured the Poll component correctly - https://getstream.io/chat/docs/sdk/reactnative/basics/hello_stream_chat/#channel',
     );
   }
 


### PR DESCRIPTION
## 🎯 Goal

Fix issues surfaced by a documentation audit of the RN v9 docs against the SDK source: several documented base-UI primitives were not exported from the package root, and a few source doc-comments were stale (and were the origin of doc errors).

## 🛠 Implementation details

**Missing package-root exports** (documented components/hooks that failed to import from `stream-chat-react-native`):

- `components/ui/index.ts` — export `Input`, `SpeedSettingsButton`, `GiphyChip`
- `components/index.ts` — export `EmptyList`, `EmptySearchResult`, `SearchInput`, `SelectionCircle` (were in `UIComponents/index.ts` but never re-exported, since `components/index.ts` cherry-picks `UIComponents/*` rather than re-exporting the barrel), and `useCooldownRemaining`

**Stale source doc-comments corrected** (each caused a corresponding docs bug):

- `contexts/pollContext/pollContext.tsx` — `usePollContext` error message referenced a non-existent `useCreatePollContext` hook
- `contexts/attachmentPickerContext/AttachmentPickerContext.tsx` — JSDoc referenced a non-existent `setBottomInset` setter (the context exposes only `topInset`/`bottomInset` values)
- `components/Chat/Chat.tsx` — `useNativeMultipartUpload` JSDoc `@default true` → `@default false` (matches the runtime default)
- `contexts/channelsContext/ChannelsContext.tsx` — `numberOfSkeletons` comment default `6` → `8` (matches the runtime default in `ChannelList.tsx`)

## 🎨 UI Changes

None — export additions and doc-comment corrections only. No runtime/UI behavior change.

## 🧪 Testing

- `tsc --noEmit -p package/tsconfig.json` passes clean (0 errors) — confirms all new exports resolve without name collisions.
- No behavior changes; the exported symbols were already used internally.

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Documentation is updated (companion docs PR: GetStream/docs-content#1435)
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android
