### PR TITLE
fix: missing poster image bailing on thumbnails

### DIFF
--- a/package/shared-native/ios/StreamVideoThumbnailGenerator.swift
+++ b/package/shared-native/ios/StreamVideoThumbnailGenerator.swift
@@ -22,7 +22,12 @@ public final class StreamVideoThumbnailResult: NSObject {
 @objcMembers
 public final class StreamVideoThumbnailGenerator: NSObject {
   private static let compressionQuality: CGFloat = 0.8
-  private static let maxDimension: CGFloat = 512
+  // iOS uses 256: its high-quality PhotoKit scaler stays crisp at the picker cell
+  // at that size, for ~1/4 the decoded RAM of 512. The Android counterpart
+  // (shared-native/android) intentionally keeps 512 — its `getScaledFrameAtTime`
+  // scaler is cruder and needs more source pixels. The per-platform values differ
+  // on purpose; don't "align" them.
+  private static let maxDimension: CGFloat = 256
   private static let cacheVersion = "v1"
   private static let cacheDirectoryName = "@stream-io-stream-video-thumbnails"
   private static let maxConcurrentGenerations = 5
@@ -205,19 +210,13 @@ public final class StreamVideoThumbnailGenerator: NSObject {
       throw thumbnailError(code: 7, message: "Failed to find photo library asset for \(url)")
     }
 
-    // Request a thumbnail sized image instead of the full AVAsset: PhotoKit
-    // serves a locally cached thumbnail even for iCloud only assets, so this
-    // avoids downloading the entire video the way requestAVAsset(forVideo:) would.
+    // `.highQualityFormat` (not `.fastFormat`): fastFormat returns a fixed, small
+    // pre-cached rendition (~120px on the long side, ignores targetSize entirely)
+    // and returns nothing (PHPhotosError 3303) for assets with no cached
+    // derivative yet — e.g. videos added to a Simulator via `simctl addmedia`.
+    // highQualityFormat renders the poster on demand at the requested targetSize
+    // and only fetches the poster frame, not the whole video.
     let options = PHImageRequestOptions()
-    // `.highQualityFormat` instead of `.fastFormat` here, as the latter only serves
-    // an already cached poster derivative and will NOT generate one on demand, so
-    // it fails (PHPhotosError 3303) for assets that have no cached thumbnail yet,
-    // i.e videos added to a Simulator via `simctl addmedia`, which never get
-    // their derivatives generated. `.highQualityFormat` still delivers a single
-    // final image (matching the "accept the first delivered image" logic below)
-    // and only fetches the poster frame, not the whole video. If a poster frame does
-    // not exist, it will generate one on the fly (only the first time, all subsequent
-    // request will return the cached one).
     options.deliveryMode = .highQualityFormat
     options.resizeMode = .fast
     options.isNetworkAccessAllowed = true

--- a/package/shared-native/ios/StreamVideoThumbnailGenerator.swift
+++ b/package/shared-native/ios/StreamVideoThumbnailGenerator.swift
@@ -22,11 +22,10 @@ public final class StreamVideoThumbnailResult: NSObject {
 @objcMembers
 public final class StreamVideoThumbnailGenerator: NSObject {
   private static let compressionQuality: CGFloat = 0.8
-  // iOS uses 256: its high-quality PhotoKit scaler stays crisp at the picker cell
-  // at that size, for ~1/4 the decoded RAM of 512. The Android counterpart
-  // (shared-native/android) intentionally keeps 512 — its `getScaledFrameAtTime`
-  // scaler is cruder and needs more source pixels. The per-platform values differ
-  // on purpose; don't "align" them.
+  // We intentionally use a lower maxDimension for iOS, as we are trying to mimic
+  // what a .fastFormat delivery type of the image would do. Although theoretically
+  // smaller (around 120px) after some benchmarking we figured that 256 was perfectly
+  // fine and adds just a tiny bit of overhead for a visible quality increase.
   private static let maxDimension: CGFloat = 256
   private static let cacheVersion = "v1"
   private static let cacheDirectoryName = "@stream-io-stream-video-thumbnails"
@@ -210,13 +209,19 @@ public final class StreamVideoThumbnailGenerator: NSObject {
       throw thumbnailError(code: 7, message: "Failed to find photo library asset for \(url)")
     }
 
-    // `.highQualityFormat` (not `.fastFormat`): fastFormat returns a fixed, small
-    // pre-cached rendition (~120px on the long side, ignores targetSize entirely)
-    // and returns nothing (PHPhotosError 3303) for assets with no cached
-    // derivative yet — e.g. videos added to a Simulator via `simctl addmedia`.
-    // highQualityFormat renders the poster on demand at the requested targetSize
-    // and only fetches the poster frame, not the whole video.
+    // Request a thumbnail sized image instead of the full AVAsset: PhotoKit
+    // serves a locally cached thumbnail even for iCloud only assets, so this
+    // avoids downloading the entire video the way requestAVAsset(forVideo:) would.
     let options = PHImageRequestOptions()
+    // `.highQualityFormat` instead of `.fastFormat` here, as the latter only serves
+    // an already cached poster derivative and will NOT generate one on demand, so
+    // it fails (PHPhotosError 3303) for assets that have no cached thumbnail yet,
+    // i.e videos added to a Simulator via `simctl addmedia`, which never get
+    // their derivatives generated. `.highQualityFormat` still delivers a single
+    // final image (matching the "accept the first delivered image" logic below)
+    // and only fetches the poster frame, not the whole video. If a poster frame does
+    // not exist, it will generate one on the fly (only the first time, all subsequent
+    // request will return the cached one).
     options.deliveryMode = .highQualityFormat
     options.resizeMode = .fast
     options.isNetworkAccessAllowed = true

--- a/package/shared-native/ios/StreamVideoThumbnailGenerator.swift
+++ b/package/shared-native/ios/StreamVideoThumbnailGenerator.swift
@@ -209,7 +209,16 @@ public final class StreamVideoThumbnailGenerator: NSObject {
     // serves a locally cached thumbnail even for iCloud only assets, so this
     // avoids downloading the entire video the way requestAVAsset(forVideo:) would.
     let options = PHImageRequestOptions()
-    options.deliveryMode = .fastFormat
+    // `.highQualityFormat` instead of `.fastFormat` here, as the latter only serves
+    // an already cached poster derivative and will NOT generate one on demand, so
+    // it fails (PHPhotosError 3303) for assets that have no cached thumbnail yet,
+    // i.e videos added to a Simulator via `simctl addmedia`, which never get
+    // their derivatives generated. `.highQualityFormat` still delivers a single
+    // final image (matching the "accept the first delivered image" logic below)
+    // and only fetches the poster frame, not the whole video. If a poster frame does
+    // not exist, it will generate one on the fly (only the first time, all subsequent
+    // request will return the cached one).
+    options.deliveryMode = .highQualityFormat
     options.resizeMode = .fast
     options.isNetworkAccessAllowed = true
     options.isSynchronous = false
@@ -262,8 +271,8 @@ public final class StreamVideoThumbnailGenerator: NSObject {
           contentMode: .aspectFit,
           options: options
         ) { image, info in
-          // Accept the first delivered image (.fastFormat sends exactly one,
-          // thumbnail quality, possibly flagged degraded and that's what we want).
+          // Accept the first delivered image (.highQualityFormat sends exactly
+          // one and we still guard against any extra deliveries).
           state.lock.lock()
           if state.didResume {
             state.lock.unlock()


### PR DESCRIPTION
## 🎯 Goal

For some reason, it would appear that video attachments picked from the photo library show no thumbnail when `PhotoKit` had no cached poster frame for the asset, so the image request fails with `PHPhotosErrorDomain 3303` and generation bails. Hits uncached/freshly imported library videos on devic, and always hits videos added to a Simulator via `simctl addmedia` as an example (which won't immediately generate poster images unless you open the `Photos` app for example).

## 🛠 Implementation details

iOS `StreamVideoThumbnailGenerator`:

- Switched the `PhotoKit` request from `.fastFormat` to `.highQualityFormat`. `.fastFormat` only returns an already cached rendition and won't generate one on demand (contrary to my previous belief), so uncached assets come back empty. `.highQualityFormat` renders the poster on demand at the requested `targetSize`, so still only the poster frame and not the whole video
- Lowered `maxDimension` from `512` to `256`. `.highQualityFormat` honors `targetSize` (unlike `.fastFormat`, which ignores it and always returns a fixed `~120px` from my tests), so `256px` is crisp at the picker cell for ~1/4 the decoded RAM. Android intentionally stays at 512 as its `getScaledFrameAtTime` scaler is cruder and needs more source pixels (documented in a code comment)

Reducing the size of the generated tuhmbnails is considered safe as this was anyway happening with `.fastFormat` (as mentioned it appears to simply return smaller images rather than play around with downscaling specifically). If anything, it's an increase in quality as from my benchmarks it showed that loading ~200 video thumbnails all at the same time (this is a very pessimistic test of course) rounds out to about ~20MB of extra ram usage. And this is even before taking image optimizations into account, which would alleviate decoding cycles as well. So the quality should be much better while paying almost nothing. So in essence we're basically trying to mimic what `.fastFormat` does itself but with some extra exploration around it.

## 🎨 UI Changes

<details>
<summary>iOS</summary>
</details>

<details>
<summary>Android</summary>

No Android changes.
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android

