### PR TITLE
fix: advanced theming of message (myMessageTheme)

### DIFF
--- a/package/jest-setup.tsx
+++ b/package/jest-setup.tsx
@@ -109,6 +109,11 @@ jest.mock('react-native/Libraries/Components/RefreshControl/RefreshControl', () 
   __esModule: true,
   default: require('./__mocks__/RefreshControlMock'),
 }));
+jest.mock('react-native/Libraries/Utilities/Appearance', () => ({
+  addChangeListener: () => ({ remove: () => {} }),
+  getColorScheme: () => 'light',
+  setColorScheme: () => {},
+}));
 
 jest.mock('@shopify/flash-list', () => ({
   FlashList: undefined,

--- a/package/src/components/Attachment/Attachment.tsx
+++ b/package/src/components/Attachment/Attachment.tsx
@@ -257,7 +257,7 @@ const useAudioAttachmentStyles = () => {
           : semantics.chatBorderOnChatIncoming,
       },
       durationText: {
-        color: semantics.chatTextIncoming,
+        color: isMyMessage ? semantics.chatTextOutgoing : semantics.chatTextIncoming,
         fontWeight: primitives.typographyFontWeightSemiBold,
       },
       leftContainer: {

--- a/package/src/components/Attachment/Audio/PlayPauseButton.tsx
+++ b/package/src/components/Attachment/Audio/PlayPauseButton.tsx
@@ -65,7 +65,7 @@ const useStyles = () => {
         justifyContent: 'center',
         alignItems: 'center',
         borderWidth: 1,
-        borderColor: semantics.chatBorderOnChatIncoming,
+        borderColor: semantics.controlPlaybackToggleBorder,
       },
     });
   }, [semantics]);

--- a/package/src/components/Attachment/Audio/__tests__/PlayPauseButton.test.tsx
+++ b/package/src/components/Attachment/Audio/__tests__/PlayPauseButton.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { render, screen } from '@testing-library/react-native';
+
+import { mergeThemes, ThemeProvider } from '../../../../contexts/themeContext/ThemeContext';
+import { PlayPauseButton } from '../PlayPauseButton';
+
+describe('PlayPauseButton', () => {
+  const lightTheme = mergeThemes({ scheme: 'light' });
+
+  const renderButton = (containerStyle?: Record<string, unknown>) =>
+    render(
+      <ThemeProvider>
+        <PlayPauseButton
+          containerStyle={containerStyle}
+          isPlaying={false}
+          onPress={jest.fn()}
+          testID='play-pause-button'
+        />
+      </ThemeProvider>,
+    );
+
+  const borderColorOf = () => {
+    const style = screen.getByTestId('play-pause-button').props.style;
+    return StyleSheet.flatten(typeof style === 'function' ? style({ pressed: false }) : style)
+      ?.borderColor;
+  };
+
+  // This control also renders in the composer's attachment previews, which are
+  // not a message bubble - so it must not reach for a chat side token.
+  it('defaults to the neutral playback toggle border, not a chat bubble border', () => {
+    renderButton();
+
+    expect(borderColorOf()).toBe(lightTheme.semantics.controlPlaybackToggleBorder);
+    expect(borderColorOf()).not.toBe(lightTheme.semantics.chatBorderOnChatIncoming);
+  });
+
+  it('lets in-bubble callers override the border with the resolved chat side', () => {
+    renderButton({ borderColor: lightTheme.semantics.chatBorderOnChatOutgoing });
+
+    expect(borderColorOf()).toBe(lightTheme.semantics.chatBorderOnChatOutgoing);
+  });
+});

--- a/package/src/components/Attachment/UrlPreview/URLPreview.tsx
+++ b/package/src/components/Attachment/UrlPreview/URLPreview.tsx
@@ -68,10 +68,6 @@ const URLPreviewWithContext = (props: URLPreviewPropsWithContext) => {
 
   const { icons } = useComponentsContext();
 
-  const {
-    theme: { semantics },
-  } = useTheme();
-
   const { image_url, og_scrape_url, text, thumb_url, title, type } = attachment;
 
   const {
@@ -156,7 +152,7 @@ const URLPreviewWithContext = (props: URLPreviewPropsWithContext) => {
           </Text>
         ) : null}
         <View style={[styles.linkPreview, linkPreview, stylesProp.linkPreview]}>
-          <icons.Link height={12} width={12} stroke={semantics.chatTextIncoming} />
+          <icons.Link height={12} width={12} stroke={styles.linkPreviewText.color} />
           <Text
             numberOfLines={1}
             style={[styles.linkPreviewText, linkPreviewText, stylesProp.linkPreviewText]}
@@ -267,13 +263,13 @@ const useStyles = () => {
           padding: primitives.spacingSm,
         },
         title: {
-          color: semantics.chatTextIncoming,
+          color: isMyMessage ? semantics.chatTextOutgoing : semantics.chatTextIncoming,
           fontSize: primitives.typographyFontSizeSm,
           fontWeight: primitives.typographyFontWeightSemiBold,
           lineHeight: primitives.typographyLineHeightTight,
         },
         description: {
-          color: semantics.chatTextIncoming,
+          color: isMyMessage ? semantics.chatTextOutgoing : semantics.chatTextIncoming,
           fontSize: primitives.typographyFontSizeXs,
           fontWeight: primitives.typographyFontWeightRegular,
           lineHeight: primitives.typographyLineHeightTight,
@@ -284,7 +280,7 @@ const useStyles = () => {
           gap: primitives.spacingXxs,
         },
         linkPreviewText: {
-          color: semantics.chatTextIncoming,
+          color: isMyMessage ? semantics.chatTextOutgoing : semantics.chatTextIncoming,
           fontSize: primitives.typographyFontSizeXs,
           fontWeight: primitives.typographyFontWeightRegular,
           lineHeight: primitives.typographyLineHeightTight,

--- a/package/src/components/Attachment/UrlPreview/URLPreviewCompact.tsx
+++ b/package/src/components/Attachment/UrlPreview/URLPreviewCompact.tsx
@@ -64,10 +64,6 @@ const URLPreviewCompactWithContext = (props: URLPreviewCompactPropsWithContext) 
 
   const { icons } = useComponentsContext();
 
-  const {
-    theme: { semantics },
-  } = useTheme();
-
   const { image_url, og_scrape_url, text, thumb_url, title: titleText, type } = attachment;
 
   const {
@@ -158,7 +154,7 @@ const URLPreviewCompactWithContext = (props: URLPreviewCompactPropsWithContext) 
             </Text>
           ) : null}
           <View style={[styles.linkPreview, linkPreview, stylesProp.linkPreview]}>
-            <icons.Link height={12} width={12} stroke={semantics.chatTextIncoming} />
+            <icons.Link height={12} width={12} stroke={styles.linkPreviewText.color} />
             <Text
               numberOfLines={1}
               style={[styles.linkPreviewText, linkPreviewText, stylesProp.linkPreviewText]}
@@ -271,13 +267,13 @@ const useStyles = () => {
           flexShrink: 1,
         },
         title: {
-          color: semantics.chatTextIncoming,
+          color: isMyMessage ? semantics.chatTextOutgoing : semantics.chatTextIncoming,
           fontSize: primitives.typographyFontSizeSm,
           fontWeight: primitives.typographyFontWeightSemiBold,
           lineHeight: primitives.typographyLineHeightTight,
         },
         description: {
-          color: semantics.chatTextIncoming,
+          color: isMyMessage ? semantics.chatTextOutgoing : semantics.chatTextIncoming,
           fontSize: primitives.typographyFontSizeXs,
           fontWeight: primitives.typographyFontWeightRegular,
           lineHeight: primitives.typographyLineHeightTight,
@@ -288,7 +284,7 @@ const useStyles = () => {
           gap: primitives.spacingXxs,
         },
         linkPreviewText: {
-          color: semantics.chatTextIncoming,
+          color: isMyMessage ? semantics.chatTextOutgoing : semantics.chatTextIncoming,
           fontSize: primitives.typographyFontSizeXs,
           fontWeight: primitives.typographyFontWeightRegular,
           lineHeight: primitives.typographyLineHeightTight,

--- a/package/src/components/Attachment/UrlPreview/__tests__/URLPreview.test.tsx
+++ b/package/src/components/Attachment/UrlPreview/__tests__/URLPreview.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react-native';
+
+import type { MessageContextValue } from '../../../../contexts/messageContext/MessageContext';
+import { MessageProvider } from '../../../../contexts/messageContext/MessageContext';
+import type { MessagesContextValue } from '../../../../contexts/messagesContext/MessagesContext';
+import { MessagesProvider } from '../../../../contexts/messagesContext/MessagesContext';
+import { mergeThemes, ThemeProvider } from '../../../../contexts/themeContext/ThemeContext';
+import { generateCardAttachment } from '../../../../mock-builders/generator/attachment';
+import { generateMessage } from '../../../../mock-builders/generator/message';
+import { URLPreview } from '../URLPreview';
+import { URLPreviewCompact } from '../URLPreviewCompact';
+
+const lightTheme = mergeThemes({ scheme: 'light' });
+
+/**
+ * Both URL preview variants resolve every text colour from the same
+ * incoming/outgoing pair, so the assertions are shared.
+ */
+describe.each([
+  ['URLPreview', URLPreview],
+  ['URLPreviewCompact', URLPreviewCompact],
+])('%s chat text side', (_name, Component) => {
+  const renderPreview = (messageContextValue: Partial<MessageContextValue> = {}) => {
+    const attachment = generateCardAttachment({ title: 'A title', text: 'A description' });
+
+    return render(
+      <ThemeProvider>
+        <MessagesProvider value={{} as unknown as MessagesContextValue}>
+          <MessageProvider
+            value={
+              {
+                message: generateMessage(),
+                ...messageContextValue,
+              } as unknown as MessageContextValue
+            }
+          >
+            <Component attachment={attachment} />
+          </MessageProvider>
+        </MessagesProvider>
+      </ThemeProvider>,
+    );
+  };
+
+  const colorOf = (text: string) => StyleSheet.flatten(screen.getByText(text).props.style)?.color;
+
+  afterEach(cleanup);
+
+  it('uses the outgoing chat text colour on our own message', async () => {
+    renderPreview({ isMyMessage: true });
+
+    await waitFor(() => {
+      expect(colorOf('A title')).toBe(lightTheme.semantics.chatTextOutgoing);
+    });
+    expect(colorOf('A description')).toBe(lightTheme.semantics.chatTextOutgoing);
+  });
+
+  it("uses the incoming chat text colour on another user's message", async () => {
+    renderPreview({ isMyMessage: false });
+
+    await waitFor(() => {
+      expect(colorOf('A title')).toBe(lightTheme.semantics.chatTextIncoming);
+    });
+    expect(colorOf('A description')).toBe(lightTheme.semantics.chatTextIncoming);
+  });
+
+  it('uses the outgoing attachment background on our own message', async () => {
+    renderPreview({ isMyMessage: true });
+
+    await waitFor(() => {
+      expect(StyleSheet.flatten(screen.getByTestId('card-attachment').props.style)).toEqual(
+        expect.objectContaining({
+          backgroundColor: lightTheme.semantics.chatBgAttachmentOutgoing,
+        }),
+      );
+    });
+  });
+
+  it('strokes the link icon with the same colour as the link text', async () => {
+    renderPreview({ isMyMessage: true });
+
+    // The URL text and its leading icon must not disagree on the side.
+    await waitFor(() => {
+      expect(screen.getByTestId('card-attachment')).toBeTruthy();
+    });
+
+    const linkIcon = screen.UNSAFE_getByProps({ stroke: lightTheme.semantics.chatTextOutgoing });
+    expect(linkIcon).toBeTruthy();
+  });
+});

--- a/package/src/components/Attachment/__tests__/Attachment.test.tsx
+++ b/package/src/components/Attachment/__tests__/Attachment.test.tsx
@@ -218,6 +218,54 @@ describe('Attachment', () => {
     isSoundPackageAvailable.mockReturnValue(false);
   });
 
+  it('uses the outgoing audio player background on our own message', async () => {
+    const { isSoundPackageAvailable } = require('../../../native');
+    isSoundPackageAvailable.mockReturnValue(true);
+    const attachment = generateAudioAttachment({ duration: 10, waveform_data: [0.2, 0.6] });
+    const message = generateMessage({ attachments: [attachment, generateAudioAttachment()] });
+
+    const { getByLabelText } = render(
+      getAttachmentComponent(
+        { attachment },
+        { isMyMessage: true, message, messageHasOnlySingleAttachment: false },
+      ),
+    );
+
+    await waitFor(() => {
+      const style = StyleSheet.flatten(getByLabelText('audio-attachment-preview').props.style);
+      expect(style.backgroundColor).toBe(lightTheme.semantics.chatBgAttachmentOutgoing);
+    });
+    isSoundPackageAvailable.mockReturnValue(false);
+  });
+
+  it('resolves the audio duration label colour from the message side', async () => {
+    const { isSoundPackageAvailable } = require('../../../native');
+    isSoundPackageAvailable.mockReturnValue(true);
+    const attachment = generateAudioAttachment({ duration: 10, waveform_data: [0.2, 0.6] });
+    const message = generateMessage({ attachments: [attachment] });
+
+    const { getByLabelText } = render(
+      getAttachmentComponent(
+        { attachment },
+        { isMyMessage: true, message, messageHasOnlySingleAttachment: false },
+      ),
+    );
+
+    // NOTE: `StableDurationLabel` applies its own `visibleStyle` last, which
+    // always sets `color` from the playback state - so this asserts the wiring
+    // reaching the label, not the final rendered pixel. See the reserve label.
+    await waitFor(() => {
+      expect(getByLabelText('Progress Duration').props.style).toEqual(
+        expect.arrayContaining([
+          expect.arrayContaining([
+            expect.objectContaining({ color: lightTheme.semantics.chatTextOutgoing }),
+          ]),
+        ]),
+      );
+    });
+    isSoundPackageAvailable.mockReturnValue(false);
+  });
+
   it('should render UrlPreview component if attachment has title_link or og_scrape_url', async () => {
     const attachment = generateImageAttachment({
       og_scrape_url: uuidv4(),

--- a/package/src/components/Message/MessageItemView/MessageItemView.tsx
+++ b/package/src/components/Message/MessageItemView/MessageItemView.tsx
@@ -171,7 +171,6 @@ const MessageItemViewWithContext = (props: MessageItemViewPropsWithContext) => {
 
   const {
     isMessageErrorType,
-    isMessageReceivedOrErrorType,
     isMessageTypeDeleted,
     isVeryLastMessage,
     messageGroupedSingleOrBottom,
@@ -200,7 +199,7 @@ const MessageItemViewWithContext = (props: MessageItemViewPropsWithContext) => {
     backgroundColor = 'transparent';
   } else if (hasStandaloneGiphyOrImgur) {
     backgroundColor = 'transparent';
-  } else if (isMessageReceivedOrErrorType) {
+  } else if (!isMyMessage) {
     backgroundColor = semantics.chatBgIncoming;
   }
 

--- a/package/src/components/Message/MessageItemView/__tests__/MessageTextContainer.test.tsx
+++ b/package/src/components/Message/MessageItemView/__tests__/MessageTextContainer.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 
 import { cleanup, render, waitFor } from '@testing-library/react-native';
 
 import { WithComponents } from '../../../../contexts/componentsContext/ComponentsContext';
 import { OverlayProvider } from '../../../../contexts/overlayContext/OverlayProvider';
-import { ThemeProvider } from '../../../../contexts/themeContext/ThemeContext';
+import { mergeThemes, ThemeProvider } from '../../../../contexts/themeContext/ThemeContext';
 import { defaultTheme } from '../../../../contexts/themeContext/utils/theme';
 import { getOrCreateChannelApi } from '../../../../mock-builders/api/getOrCreateChannel';
 import { useMockedApis } from '../../../../mock-builders/api/useMockedApis';
@@ -22,6 +22,8 @@ import { MessageList } from '../../../MessageList/MessageList';
 import { MessageTextContainer } from '../MessageTextContainer';
 
 describe('MessageTextContainer', () => {
+  const lightTheme = mergeThemes({ scheme: 'light' });
+
   afterEach(cleanup);
 
   it('should render message text container', async () => {
@@ -108,6 +110,22 @@ describe('MessageTextContainer', () => {
 
     await waitFor(() => {
       expect(getByText(message.i18n.no_text)).toBeTruthy();
+    });
+  });
+
+  it('renders our own message text with the outgoing chat text colour', async () => {
+    const message = generateMessage({ user: generateStaticUser(1) });
+
+    const { getByText } = render(
+      <ThemeProvider>
+        <MessageTextContainer isMyMessage message={message} />
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(StyleSheet.flatten(getByText(message.text as string).props.style)?.color).toBe(
+        lightTheme.semantics.chatTextOutgoing,
+      );
     });
   });
 });

--- a/package/src/components/Message/MessageItemView/__tests__/__snapshots__/MessageAuthor.test.tsx.snap
+++ b/package/src/components/Message/MessageItemView/__tests__/__snapshots__/MessageAuthor.test.tsx.snap
@@ -22,10 +22,10 @@ exports[`MessageAuthor should render message author 1`] = `
             "width": 32,
           },
           {
-            "backgroundColor": "#006970",
+            "backgroundColor": "#a9e4ea",
           },
           {
-            "borderColor": "rgba(255, 255, 255, 0.2)",
+            "borderColor": "rgba(26, 27, 37, 0.1)",
             "borderWidth": 1,
           },
           undefined,

--- a/package/src/components/MessageList/MessageFlashList.tsx
+++ b/package/src/components/MessageList/MessageFlashList.tsx
@@ -4,6 +4,7 @@ import {
   ScrollViewProps,
   StyleSheet,
   View,
+  useColorScheme,
   ViewabilityConfig,
   ViewToken,
 } from 'react-native';
@@ -401,11 +402,12 @@ const MessageFlashListWithContext = (props: MessageFlashListPropsWithContext) =>
   const styles = useStyles();
 
   const myMessageThemeString = useMemo(() => JSON.stringify(myMessageTheme), [myMessageTheme]);
+  const scheme = useColorScheme();
 
   const modifiedTheme = useMemo(
-    () => mergeThemes({ style: myMessageTheme, theme }),
+    () => mergeThemes({ scheme, style: myMessageTheme, theme }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [myMessageThemeString, theme],
+    [myMessageThemeString, scheme, theme],
   );
 
   const { processedMessageList, rawMessageList, viewabilityChangedCallback } = useMessageList({

--- a/package/src/components/MessageList/MessageList.tsx
+++ b/package/src/components/MessageList/MessageList.tsx
@@ -7,6 +7,7 @@ import {
   ScrollViewProps,
   StyleSheet,
   View,
+  useColorScheme,
   ViewabilityConfig,
   ViewToken,
 } from 'react-native';
@@ -394,11 +395,12 @@ const MessageListWithContext = (props: MessageListPropsWithContext) => {
   });
 
   const myMessageThemeString = useMemo(() => JSON.stringify(myMessageTheme), [myMessageTheme]);
+  const scheme = useColorScheme();
 
   const modifiedTheme = useMemo(
-    () => mergeThemes({ style: myMessageTheme, theme }),
+    () => mergeThemes({ scheme, style: myMessageTheme, theme }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [myMessageThemeString, theme],
+    [myMessageThemeString, scheme, theme],
   );
 
   /**

--- a/package/src/components/Poll/Poll.tsx
+++ b/package/src/components/Poll/Poll.tsx
@@ -6,6 +6,7 @@ import { PollOption as PollOptionClass } from 'stream-chat';
 import { PollOption, ShowAllOptionsButton } from './components';
 import { PollUIStateProvider } from './contexts/PollUIStateContext';
 
+import { useIsPollCreatedByCurrentUser } from './hook/useIsPollCreatedByCurrentUser';
 import { usePollState } from './hooks/usePollState';
 
 import {
@@ -105,6 +106,7 @@ const useStyles = () => {
   const {
     theme: { semantics },
   } = useTheme();
+  const isPollCreatedByClient = useIsPollCreatedByCurrentUser();
   return useMemo(() => {
     return StyleSheet.create({
       container: {
@@ -114,14 +116,14 @@ const useStyles = () => {
       },
       headerContainer: { gap: primitives.spacingXxs },
       headerSubtitle: {
-        color: semantics.chatTextIncoming,
+        color: isPollCreatedByClient ? semantics.chatTextOutgoing : semantics.chatTextIncoming,
         fontSize: primitives.typographyFontSizeSm,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightTight,
         textAlign: 'left',
       },
       headerTitle: {
-        color: semantics.chatTextIncoming,
+        color: isPollCreatedByClient ? semantics.chatTextOutgoing : semantics.chatTextIncoming,
         fontSize: primitives.typographyFontSizeMd,
         fontWeight: primitives.typographyFontWeightSemiBold,
         lineHeight: primitives.typographyLineHeightNormal,
@@ -131,5 +133,5 @@ const useStyles = () => {
         gap: primitives.spacingMd,
       },
     });
-  }, [semantics]);
+  }, [isPollCreatedByClient, semantics]);
 };

--- a/package/src/components/Poll/__tests__/Poll.test.tsx
+++ b/package/src/components/Poll/__tests__/Poll.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { render, screen } from '@testing-library/react-native';
+
+import {
+  OwnCapabilitiesProvider,
+  PollContextProvider,
+  ThemeProvider,
+  TranslationProvider,
+} from '../../../contexts';
+import { mergeThemes } from '../../../contexts/themeContext/ThemeContext';
+import { generateMessage } from '../../../mock-builders/generator/message';
+import { PollHeader } from '../Poll';
+
+const mockIsPollCreatedByCurrentUser = jest.fn();
+
+jest.mock('../hook/useIsPollCreatedByCurrentUser', () => ({
+  useIsPollCreatedByCurrentUser: () => mockIsPollCreatedByCurrentUser(),
+}));
+
+jest.mock('../hooks/usePollState', () => ({
+  usePollState: () => ({
+    enforceUniqueVote: true,
+    isClosed: false,
+    maxVotesAllowed: undefined,
+    name: 'A poll question',
+  }),
+}));
+
+describe('PollHeader chat text side', () => {
+  const lightTheme = mergeThemes({ scheme: 'light' });
+
+  const renderHeader = () =>
+    render(
+      <ThemeProvider>
+        <TranslationProvider value={{ t: (key: string) => key } as never}>
+          <OwnCapabilitiesProvider value={{} as never}>
+            <PollContextProvider
+              value={{ message: generateMessage(), poll: { data: {} } as never }}
+            >
+              <PollHeader />
+            </PollContextProvider>
+          </OwnCapabilitiesProvider>
+        </TranslationProvider>
+      </ThemeProvider>,
+    );
+
+  const colorOf = (text: string) => StyleSheet.flatten(screen.getByText(text).props.style)?.color;
+
+  afterEach(() => {
+    mockIsPollCreatedByCurrentUser.mockReset();
+  });
+
+  it('uses the outgoing chat text colour for our own poll', () => {
+    mockIsPollCreatedByCurrentUser.mockReturnValue(true);
+    renderHeader();
+
+    expect(colorOf('A poll question')).toBe(lightTheme.semantics.chatTextOutgoing);
+    expect(colorOf('Select one')).toBe(lightTheme.semantics.chatTextOutgoing);
+  });
+
+  it("uses the incoming chat text colour for another user's poll", () => {
+    mockIsPollCreatedByCurrentUser.mockReturnValue(false);
+    renderHeader();
+
+    expect(colorOf('A poll question')).toBe(lightTheme.semantics.chatTextIncoming);
+    expect(colorOf('Select one')).toBe(lightTheme.semantics.chatTextIncoming);
+  });
+});

--- a/package/src/components/Poll/components/Button.tsx
+++ b/package/src/components/Poll/components/Button.tsx
@@ -10,6 +10,11 @@ export type PollButtonProps = {
 };
 
 export type PollVoteButtonProps = {
+  /**
+   * Render with the incoming chat tokens regardless of poll ownership. Set on
+   * surfaces that are not a message bubble, such as the full-options list.
+   */
+  forceIncoming?: boolean;
   option: PollOption;
   style?: StyleProp<ViewStyle>;
 } & Pick<PollButtonProps, 'onPress'>;

--- a/package/src/components/Poll/components/PollButtons.tsx
+++ b/package/src/components/Poll/components/PollButtons.tsx
@@ -247,6 +247,8 @@ const useStyles = () => {
           ? semantics.chatBorderOnChatOutgoing
           : semantics.chatBorderOnChatIncoming,
       },
+      // NOTE: PollButtons only ever renders on the in-bubble surface (it is what
+      // opens the full-options modal), so it needs no `forceIncoming` handling.
     });
   }, [semantics, isPollCreatedByClient]);
 };

--- a/package/src/components/Poll/components/PollOption.tsx
+++ b/package/src/components/Poll/components/PollOption.tsx
@@ -92,7 +92,11 @@ export const PollAllOptions = ({
 export const PollOption = ({ option, showProgressBar = true, forceIncoming }: PollOptionProps) => {
   const { latestVotesByOption, voteCountsByOption, voteCount } = usePollState();
   const { t } = useTranslationContext();
-  const styles = useStyles();
+  const isPollCreatedByClient = useIsPollCreatedByCurrentUser();
+  // `forceIncoming` is set on the full-options surface, which is a neutral card
+  // rather than a bubble - so it wins over poll ownership.
+  const isIncoming = !isPollCreatedByClient || !!forceIncoming;
+  const styles = useStyles({ isIncoming });
 
   const relevantVotes = useMemo(
     () => latestVotesByOption?.[option.id] || [],
@@ -111,21 +115,17 @@ export const PollOption = ({ option, showProgressBar = true, forceIncoming }: Po
       semantics,
     },
   } = useTheme();
-  const isPollCreatedByClient = useIsPollCreatedByCurrentUser();
+  const unFilledColor = isIncoming
+    ? semantics.chatPollProgressTrackIncoming
+    : semantics.chatPollProgressTrackOutgoing;
 
-  const unFilledColor =
-    isPollCreatedByClient && !forceIncoming
-      ? semantics.chatPollProgressTrackOutgoing
-      : semantics.chatPollProgressTrackIncoming;
-
-  const filledColor =
-    isPollCreatedByClient && !forceIncoming
-      ? semantics.chatPollProgressFillOutgoing
-      : semantics.chatPollProgressFillIncoming;
+  const filledColor = isIncoming
+    ? semantics.chatPollProgressFillIncoming
+    : semantics.chatPollProgressFillOutgoing;
 
   return (
     <View style={[styles.container, container]}>
-      <VoteButton option={option} />
+      <VoteButton forceIncoming={forceIncoming} option={option} />
       <View style={[styles.info, info]}>
         <View style={[styles.header, header]}>
           <Text ellipsizeMode='tail' numberOfLines={2} style={[styles.text, text]}>
@@ -163,7 +163,7 @@ export const PollOption = ({ option, showProgressBar = true, forceIncoming }: Po
   );
 };
 
-export const VoteButton = ({ onPress, option }: PollVoteButtonProps) => {
+export const VoteButton = ({ forceIncoming, onPress, option }: PollVoteButtonProps) => {
   const { icons } = useComponentsContext();
   const { message, poll } = usePollContext();
   const { isClosed, ownVotesByOptionId } = usePollState();
@@ -172,7 +172,8 @@ export const VoteButton = ({ onPress, option }: PollVoteButtonProps) => {
     theme: { semantics },
   } = useTheme();
   const isPollCreatedByClient = useIsPollCreatedByCurrentUser();
-  const styles = useStyles();
+  const isIncoming = !isPollCreatedByClient || !!forceIncoming;
+  const styles = useStyles({ isIncoming });
 
   const {
     theme: {
@@ -212,9 +213,9 @@ export const VoteButton = ({ onPress, option }: PollVoteButtonProps) => {
         {
           borderWidth: hasVote ? 0 : 1,
           backgroundColor: hasVote ? semantics.accentPrimary : 'transparent',
-          borderColor: isPollCreatedByClient
-            ? semantics.chatBorderOnChatOutgoing
-            : semantics.chatBorderOnChatIncoming,
+          borderColor: isIncoming
+            ? semantics.chatBorderOnChatIncoming
+            : semantics.chatBorderOnChatOutgoing,
         },
         voteButtonContainer,
       ]}
@@ -224,7 +225,7 @@ export const VoteButton = ({ onPress, option }: PollVoteButtonProps) => {
   ) : null;
 };
 
-const useStyles = () => {
+const useStyles = ({ isIncoming }: { isIncoming: boolean }) => {
   const {
     theme: { semantics },
   } = useTheme();
@@ -242,7 +243,7 @@ const useStyles = () => {
         minWidth: 0,
       },
       text: {
-        color: semantics.chatTextIncoming,
+        color: isIncoming ? semantics.chatTextIncoming : semantics.chatTextOutgoing,
         flexGrow: 1,
         flexShrink: 1,
         fontSize: primitives.typographyFontSizeSm,
@@ -264,7 +265,7 @@ const useStyles = () => {
         minHeight: 20,
       },
       votesText: {
-        color: semantics.chatTextIncoming,
+        color: isIncoming ? semantics.chatTextIncoming : semantics.chatTextOutgoing,
         fontSize: primitives.typographyFontSizeXs,
         fontWeight: primitives.typographyFontWeightRegular,
         lineHeight: primitives.typographyLineHeightTight,
@@ -281,7 +282,7 @@ const useStyles = () => {
         width: 24,
       },
     });
-  }, [semantics]);
+  }, [isIncoming, semantics]);
 };
 
 const useAllOptionStyles = () => {

--- a/package/src/components/Poll/components/__tests__/PollOption.test.tsx
+++ b/package/src/components/Poll/components/__tests__/PollOption.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { render, screen } from '@testing-library/react-native';
+
+import {
+  OwnCapabilitiesProvider,
+  PollContextProvider,
+  ThemeProvider,
+  TranslationProvider,
+} from '../../../../contexts';
+import { mergeThemes } from '../../../../contexts/themeContext/ThemeContext';
+import { generateMessage } from '../../../../mock-builders/generator/message';
+import { PollOption } from '../PollOption';
+
+const option = { id: 'option-1', text: 'An option' };
+
+const mockIsPollCreatedByCurrentUser = jest.fn();
+
+jest.mock('../../hook/useIsPollCreatedByCurrentUser', () => ({
+  useIsPollCreatedByCurrentUser: () => mockIsPollCreatedByCurrentUser(),
+}));
+
+jest.mock('../../hooks/usePollState', () => ({
+  usePollState: () => ({
+    isClosed: false,
+    latestVotesByOption: {},
+    ownVotesByOptionId: {},
+    voteCount: 4,
+    voteCountsByOption: { 'option-1': 2 },
+  }),
+}));
+
+jest.mock('../../hooks/usePollVoteToggle', () => ({
+  usePollVoteToggle: () => jest.fn(),
+}));
+
+describe('PollOption chat text side', () => {
+  const lightTheme = mergeThemes({ scheme: 'light' });
+
+  const renderOption = ({ forceIncoming }: { forceIncoming?: boolean } = {}) =>
+    render(
+      <ThemeProvider>
+        <TranslationProvider value={{ t: (key: string) => key } as never}>
+          <OwnCapabilitiesProvider value={{ castPollVote: true } as never}>
+            <PollContextProvider
+              value={{ message: generateMessage(), poll: { data: {} } as never }}
+            >
+              <PollOption forceIncoming={forceIncoming} option={option as never} />
+            </PollContextProvider>
+          </OwnCapabilitiesProvider>
+        </TranslationProvider>
+      </ThemeProvider>,
+    );
+
+  const optionTextColor = () =>
+    StyleSheet.flatten(screen.getByText('An option').props.style)?.color;
+
+  const voteButtonBorderColor = () => {
+    const style = screen.getByLabelText('An option').props.style;
+    return StyleSheet.flatten(typeof style === 'function' ? style({ pressed: false }) : style)
+      ?.borderColor;
+  };
+
+  afterEach(() => {
+    mockIsPollCreatedByCurrentUser.mockReset();
+  });
+
+  it('uses the outgoing chat text colour for our own poll', () => {
+    mockIsPollCreatedByCurrentUser.mockReturnValue(true);
+    renderOption();
+
+    expect(optionTextColor()).toBe(lightTheme.semantics.chatTextOutgoing);
+  });
+
+  it("uses the incoming chat text colour for another user's poll", () => {
+    mockIsPollCreatedByCurrentUser.mockReturnValue(false);
+    renderOption();
+
+    expect(optionTextColor()).toBe(lightTheme.semantics.chatTextIncoming);
+  });
+
+  // The full-options list is a neutral card, not a bubble, so `forceIncoming`
+  // has to win over ownership for every token - the vote button included.
+  it('forces incoming text and vote button border on our own poll', () => {
+    mockIsPollCreatedByCurrentUser.mockReturnValue(true);
+    renderOption({ forceIncoming: true });
+
+    expect(optionTextColor()).toBe(lightTheme.semantics.chatTextIncoming);
+    expect(voteButtonBorderColor()).toBe(lightTheme.semantics.chatBorderOnChatIncoming);
+  });
+
+  it('uses the outgoing vote button border for our own poll in the bubble', () => {
+    mockIsPollCreatedByCurrentUser.mockReturnValue(true);
+    renderOption();
+
+    expect(voteButtonBorderColor()).toBe(lightTheme.semantics.chatBorderOnChatOutgoing);
+  });
+});

--- a/package/src/components/Reply/Reply.tsx
+++ b/package/src/components/Reply/Reply.tsx
@@ -99,6 +99,7 @@ export type ReplyPropsWithContext = { ImageComponent: React.ComponentType<ImageP
 > &
   Pick<MessagesContextValue, 'quotedMessage'> & {
     isMyMessage: boolean;
+    isParentMessageMine?: boolean;
     onDismiss?: () => void;
     mode: 'reply' | 'edit';
     // This is temporary for the MessageContent Component to style the Reply component
@@ -116,6 +117,7 @@ export const ReplyWithContext = (props: ReplyPropsWithContext) => {
   const { t } = useTranslationContext();
   const {
     isMyMessage,
+    isParentMessageMine = isMyMessage,
     ImageComponent,
     message: messageFromContext,
     mode,
@@ -135,7 +137,7 @@ export const ReplyWithContext = (props: ReplyPropsWithContext) => {
       },
     },
   } = useTheme();
-  const styles = useStyles({ isMyMessage });
+  const styles = useStyles({ isMyMessage: isParentMessageMine });
 
   const title = useMemo(
     () =>
@@ -165,7 +167,8 @@ export const ReplyWithContext = (props: ReplyPropsWithContext) => {
             {title}
           </Text>
 
-          <ReplyMessageView message={quotedMessage} isMyMessage={isMyMessage} />
+          {/* `isMyMessage` here selects which side to paint, so it takes the surface. */}
+          <ReplyMessageView message={quotedMessage} isMyMessage={isParentMessageMine} />
         </View>
         <View style={[styles.rightContainer, rightContainer, stylesProp?.rightContainer]}>
           <RightContent ImageComponent={ImageComponent} message={quotedMessage} />
@@ -187,6 +190,7 @@ const areEqual = (prevProps: ReplyPropsWithContext, nextProps: ReplyPropsWithCon
   const {
     styles: prevStyles,
     isMyMessage: prevIsMyMessage,
+    isParentMessageMine: prevIsParentMessageMine,
     mode: prevMode,
     quotedMessage: prevQuotedMessage,
     onDismiss: prevOnDismiss,
@@ -194,6 +198,7 @@ const areEqual = (prevProps: ReplyPropsWithContext, nextProps: ReplyPropsWithCon
   const {
     styles: nextStyles,
     isMyMessage: nextIsMyMessage,
+    isParentMessageMine: nextIsParentMessageMine,
     mode: nextMode,
     quotedMessage: nextQuotedMessage,
     onDismiss: nextOnDismiss,
@@ -206,6 +211,12 @@ const areEqual = (prevProps: ReplyPropsWithContext, nextProps: ReplyPropsWithCon
   const isMyMessageEqual = prevIsMyMessage === nextIsMyMessage;
 
   if (!isMyMessageEqual) {
+    return false;
+  }
+
+  const isParentMessageMineEqual = prevIsParentMessageMine === nextIsParentMessageMine;
+
+  if (!isParentMessageMineEqual) {
     return false;
   }
 
@@ -275,7 +286,7 @@ const ReplyComposerAnnouncer = ({
 };
 
 export const Reply = (props: ReplyProps) => {
-  const { message: messageFromContext } = useMessageContext();
+  const { isMyMessage: isMyMessageFromContext, message: messageFromContext } = useMessageContext();
   const { client } = useChatContext();
   const { ImageComponent } = useComponentsContext();
 
@@ -292,6 +303,7 @@ export const Reply = (props: ReplyProps) => {
   // `mode='edit'` supplies the edited message via `props.quotedMessage` and leaves
   // the composer's quoted message empty, so ownership must consider both.
   const isMyMessage = client.user?.id === (props.quotedMessage ?? quotedMessage)?.user?.id;
+  const isParentMessageMine = messageFromContext ? !!isMyMessageFromContext : undefined;
 
   // Composer header passes `onDismiss`; the in-message quoted-reply renderer
   // does not. Only the composer-preview path pays for announcement work.
@@ -307,6 +319,7 @@ export const Reply = (props: ReplyProps) => {
       <MemoizedReply
         ImageComponent={ImageComponent}
         isMyMessage={isMyMessage}
+        isParentMessageMine={isParentMessageMine}
         message={messageFromContext}
         quotedMessage={quotedMessage}
         {...props}

--- a/package/src/components/Reply/Reply.tsx
+++ b/package/src/components/Reply/Reply.tsx
@@ -135,7 +135,7 @@ export const ReplyWithContext = (props: ReplyPropsWithContext) => {
       },
     },
   } = useTheme();
-  const styles = useStyles();
+  const styles = useStyles({ isMyMessage });
 
   const title = useMemo(
     () =>
@@ -289,7 +289,9 @@ export const Reply = (props: ReplyProps) => {
     ? (messageFromContext.quoted_message as MessagesContextValue['quotedMessage'])
     : quotedMessageFromComposer;
 
-  const isMyMessage = client.user?.id === quotedMessage?.user?.id;
+  // `mode='edit'` supplies the edited message via `props.quotedMessage` and leaves
+  // the composer's quoted message empty, so ownership must consider both.
+  const isMyMessage = client.user?.id === (props.quotedMessage ?? quotedMessage)?.user?.id;
 
   // Composer header passes `onDismiss`; the in-message quoted-reply renderer
   // does not. Only the composer-preview path pays for announcement work.
@@ -313,18 +315,10 @@ export const Reply = (props: ReplyProps) => {
   );
 };
 
-const useStyles = () => {
+const useStyles = ({ isMyMessage = false }: { isMyMessage?: boolean } = {}) => {
   const {
     theme: { semantics },
   } = useTheme();
-  const messageComposer = useMessageComposer();
-  const { quotedMessage: quotedMessageFromComposer } = useStateStore(
-    messageComposer.state,
-    messageComposerStateStoreSelector,
-  );
-  const { client } = useChatContext();
-
-  const isMyMessage = client.user?.id === quotedMessageFromComposer?.user?.id;
   const isRTL = I18nManager.isRTL;
 
   return useMemo(

--- a/package/src/components/Reply/__tests__/Reply.test.tsx
+++ b/package/src/components/Reply/__tests__/Reply.test.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
-import { render, waitFor } from '@testing-library/react-native';
+import { render, screen, waitFor } from '@testing-library/react-native';
 
+import type { MessageContextValue } from '../../../contexts/messageContext/MessageContext';
+import { MessageProvider } from '../../../contexts/messageContext/MessageContext';
 import { OverlayProvider } from '../../../contexts/overlayContext/OverlayProvider';
+import { mergeThemes } from '../../../contexts/themeContext/ThemeContext';
 import { getOrCreateChannelApi } from '../../../mock-builders/api/getOrCreateChannel';
 import { useMockedApis } from '../../../mock-builders/api/useMockedApis';
 import { generateChannelResponse } from '../../../mock-builders/generator/channel';
+import { generateMessage } from '../../../mock-builders/generator/message';
+import { generateUser } from '../../../mock-builders/generator/user';
 import { getTestClientWithUser } from '../../../mock-builders/mock';
 import { Channel } from '../../Channel/Channel';
 import { Chat } from '../../Chat/Chat';
@@ -48,5 +54,78 @@ describe('<Reply/>', () => {
     }
 
     process.env = oldEnvironment;
+  });
+
+  describe('chat text side', () => {
+    const lightTheme = mergeThemes({ scheme: 'light' });
+
+    const setup = async () => {
+      const chatClient = await getTestClientWithUser({ id: 'neil' });
+      const mockedChannel = generateChannelResponse();
+      useMockedApis(chatClient, [getOrCreateChannelApi(mockedChannel)]);
+      const channel = chatClient.channel('messaging', 'some-chat');
+      await channel.watch();
+      return { chatClient, channel };
+    };
+
+    const titleColor = (title: string) =>
+      StyleSheet.flatten(screen.getByText(title).props.style)?.color;
+
+    it('styles an in-message quoted reply from the quoted message, not the composer', async () => {
+      const { chatClient, channel } = await setup();
+
+      // The quoted message is ours, so the reply preview must read as outgoing
+      // even though the composer holds no quoted message at all.
+      const quotedMessage = generateMessage({ user: { id: 'neil' } });
+      const message = generateMessage({
+        quoted_message: quotedMessage,
+        quoted_message_id: quotedMessage.id,
+        user: generateUser(),
+      });
+
+      render(
+        <GestureHandlerRootView>
+          <OverlayProvider>
+            <Chat client={chatClient}>
+              <Channel channel={channel} client={chatClient}>
+                <MessageProvider
+                  value={{ isMyMessage: false, message } as unknown as MessageContextValue}
+                >
+                  <Reply mode='reply' />
+                </MessageProvider>
+              </Channel>
+            </Chat>
+          </OverlayProvider>
+        </GestureHandlerRootView>,
+      );
+
+      await waitFor(() => {
+        expect(titleColor('You')).toBe(lightTheme.semantics.chatTextOutgoing);
+      });
+    });
+
+    it('uses outgoing colors for the edit-mode composer header', async () => {
+      const { chatClient, channel } = await setup();
+
+      // `mode='edit'` supplies the message through props and leaves the
+      // composer's quoted message empty - you can only ever edit your own message.
+      const editedMessage = generateMessage({ user: { id: 'neil' } });
+
+      render(
+        <GestureHandlerRootView>
+          <OverlayProvider>
+            <Chat client={chatClient}>
+              <Channel channel={channel} client={chatClient}>
+                <Reply mode='edit' quotedMessage={editedMessage} />
+              </Channel>
+            </Chat>
+          </OverlayProvider>
+        </GestureHandlerRootView>,
+      );
+
+      await waitFor(() => {
+        expect(titleColor('Edit Message')).toBe(lightTheme.semantics.chatTextOutgoing);
+      });
+    });
   });
 });

--- a/package/src/components/Reply/__tests__/Reply.test.tsx
+++ b/package/src/components/Reply/__tests__/Reply.test.tsx
@@ -71,16 +71,23 @@ describe('<Reply/>', () => {
     const titleColor = (title: string) =>
       StyleSheet.flatten(screen.getByText(title).props.style)?.color;
 
-    it('styles an in-message quoted reply from the quoted message, not the composer', async () => {
-      const { chatClient, channel } = await setup();
-
-      // The quoted message is ours, so the reply preview must read as outgoing
-      // even though the composer holds no quoted message at all.
-      const quotedMessage = generateMessage({ user: { id: 'neil' } });
+    // An in-message quoted reply is painted inside the parent bubble, whose
+    // background `MessageContent` resolves from the parent message. The colours
+    // must follow that surface; only the title *copy* describes the quoted author.
+    // The composer holds no quoted message in either case, so these also pin that
+    // the block never styles itself from composer state.
+    const renderInMessageQuotedReply = (
+      { chatClient, channel }: Awaited<ReturnType<typeof setup>>,
+      {
+        isMyMessage,
+        quotedMessageUser,
+      }: { isMyMessage: boolean; quotedMessageUser: { id: string; name?: string } },
+    ) => {
+      const quotedMessage = generateMessage({ user: quotedMessageUser });
       const message = generateMessage({
         quoted_message: quotedMessage,
         quoted_message_id: quotedMessage.id,
-        user: generateUser(),
+        user: isMyMessage ? { id: 'neil' } : generateUser(),
       });
 
       render(
@@ -88,9 +95,7 @@ describe('<Reply/>', () => {
           <OverlayProvider>
             <Chat client={chatClient}>
               <Channel channel={channel} client={chatClient}>
-                <MessageProvider
-                  value={{ isMyMessage: false, message } as unknown as MessageContextValue}
-                >
+                <MessageProvider value={{ isMyMessage, message } as unknown as MessageContextValue}>
                   <Reply mode='reply' />
                 </MessageProvider>
               </Channel>
@@ -98,9 +103,35 @@ describe('<Reply/>', () => {
           </OverlayProvider>
         </GestureHandlerRootView>,
       );
+    };
+
+    it('styles an in-message quoted reply from the parent message, not the quoted author', async () => {
+      const setupResult = await setup();
+
+      // Our own message quoting somebody else: outgoing surface, so outgoing text
+      // even though the quoted author is not us.
+      renderInMessageQuotedReply(setupResult, {
+        isMyMessage: true,
+        quotedMessageUser: { id: 'other-user', name: 'Other User' },
+      });
 
       await waitFor(() => {
-        expect(titleColor('You')).toBe(lightTheme.semantics.chatTextOutgoing);
+        expect(titleColor('Reply to Other User')).toBe(lightTheme.semantics.chatTextOutgoing);
+      });
+    });
+
+    it('keeps the title copy on the quoted author while the colours follow the parent', async () => {
+      const setupResult = await setup();
+
+      // Somebody else's message quoting us: incoming surface, so incoming text -
+      // but the title still reads "You", because that describes the quoted author.
+      renderInMessageQuotedReply(setupResult, {
+        isMyMessage: false,
+        quotedMessageUser: { id: 'neil' },
+      });
+
+      await waitFor(() => {
+        expect(titleColor('You')).toBe(lightTheme.semantics.chatTextIncoming);
       });
     });
 

--- a/package/src/contexts/themeContext/ThemeContext.tsx
+++ b/package/src/contexts/themeContext/ThemeContext.tsx
@@ -39,7 +39,11 @@ export const mergeThemes = (params: MergedThemesParams) => {
       : JSON.parse(JSON.stringify(theme))
   ) as Theme;
 
-  const semantics = resolveTokensTopologically(scheme === 'dark' ? darkSemantics : lightSemantics);
+  let semantics = scheme === 'dark' ? darkSemantics : lightSemantics;
+  if (theme?.semantics) {
+    semantics = { ...semantics, ...theme.semantics };
+  }
+  semantics = resolveTokensTopologically(semantics);
 
   const finalTheme = { ...baseTheme, semantics };
 


### PR DESCRIPTION
## 🎯 Goal

fixes #3755 

Allow using light-on-dark for outgoing messages; and dark-on-light for outgoing messages. To achieve this, it's not enough to customize theme tokens; we have to use `myMessageTheme` to provide a completely separate theme for outgoing messages only. This is a preexsting mechanism in the SDK; but had a few small issues preventing working correctly. To verify a new cookbook is added: https://github.com/GetStream/docs-content/pull/1490 

## 🛠 Implementation details

There were a few different theming issues here; all fixed in a separate commit in this PR:
- The theme merging wiped preexisting custom semantics, causing problems when doing theme overrides on different levels (which is what is used with `myMessageTheme`)
- Message list components didn't provide the current scheme (light/dark) when merging the `myMessageTheme`
- A various number of components used incmoing semantic tokens instead of reading `isMyMessages` and selecting incoming/outgoing token based on that
- Quoted message was styled based on if qouted message was sent by current user; instead of parent message was sent by current user -> this didn't cause a UI issue with the default theme; but visible when using different text colors for incoming/outgoing texts
- The default UI visibly changed on three places; all of them are verified by figma (see screenshots later):
1. The SDK unnecessarily changed failed/moderated outgoing messages background to incoming
2. When editing a message the original in the composer was always styled as incoming not outgoing
3. Opening our own poll in the poll modal used an inaccurate color for the vote circle

## 🎨 UI Changes

Before - failed outgoing message background changed to incoming:
<img height="500" alt="IMG_1870" src="https://github.com/user-attachments/assets/8d9d6cc4-c53d-4908-8595-ccc9f33527e0" />

After - in line with Figma:
<img height="500" alt="IMG_1900" src="https://github.com/user-attachments/assets/70d657e2-f259-49ef-ad62-e69210dc16ab" />

Before - editing our own message styled as incmoing in composer:
<img height="500" alt="IMG_1867 2" src="https://github.com/user-attachments/assets/ca9635fb-147c-4426-829d-91221491c03a" />

After - in line with Figma:
<img height="500" alt="IMG_1868" src="https://github.com/user-attachments/assets/505c6f44-d8ab-4b40-bf93-94391f61f12e" />

Before - poll modal vote circle inaccurate color:
<img height="500" alt="IMG_1866 3" src="https://github.com/user-attachments/assets/41f60da0-e27a-471a-b8a1-8eed00c5c489" />

After - in line with Figma:
<img height="500" alt="IMG_1869" src="https://github.com/user-attachments/assets/2e13265a-c1a6-4b17-bc6a-3a0c815160d0" />



## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


