### PR TITLE
fix: provide a sensible way to disable sync limit

### DIFF
--- a/package/src/components/Chat/Chat.tsx
+++ b/package/src/components/Chat/Chat.tsx
@@ -59,15 +59,14 @@ export type ChatProps = Pick<ChatContextValue, 'client'> &
      * channels; inactive channels are hydrated on their next explicit query. The
      * last-sync timestamp is still advanced so the same payload is not retried.
      *
-     * Defaults to {@link DEFAULT_MAX_SYNC_EVENTS_LIMIT} (250). Pass a larger number
-     * to raise the cap, or any non-positive value (e.g. `0`) for no limit — i.e.
-     * replay every event (the historical behavior).
+     * Defaults to {@link DEFAULT_MAX_SYNC_EVENTS_LIMIT} (250). Pass `false` to
+     * disable the limit entirely (replay every event — the historical behavior).
      *
      * Only relevant when `enableOfflineSupport` is enabled.
      *
      * @default 250
      */
-    maxSyncEventsLimit?: number;
+    maxSyncEventsLimit?: number | false;
     /**
      * When true, multipart uploads use the SDK's native upload adapter when available.
      * When false, uploads stay on the default axios adapter.

--- a/package/src/components/Chat/__tests__/Chat.test.tsx
+++ b/package/src/components/Chat/__tests__/Chat.test.tsx
@@ -355,4 +355,16 @@ describe('TranslationContext', () => {
     );
     expect(DEFAULT_MAX_SYNC_EVENTS_LIMIT).toBe(250);
   });
+
+  it('disables the sync event limit when maxSyncEventsLimit is false', async () => {
+    const chatClientWithUser = await getTestClientWithUser({ id: 'testID' });
+
+    render(<Chat client={chatClientWithUser} enableOfflineSupport maxSyncEventsLimit={false} />);
+
+    await waitFor(() => {
+      expect(chatClientWithUser.offlineDb).toBeDefined();
+    });
+    // `false` opts out: the client stores no limit (undefined), so replay always runs.
+    expect(chatClientWithUser.offlineDb!.syncManager.syncMaxEventCount).toBeUndefined();
+  });
 });

--- a/package/src/store/OfflineDB.ts
+++ b/package/src/store/OfflineDB.ts
@@ -12,8 +12,17 @@ import * as api from './apis';
 import { SqliteClient } from './SqliteClient';
 
 export class OfflineDB extends AbstractOfflineDB {
-  constructor({ client, maxSyncEventsLimit }: { client: StreamChat; maxSyncEventsLimit?: number }) {
-    super({ client, syncMaxEventCount: maxSyncEventsLimit });
+  constructor({
+    client,
+    maxSyncEventsLimit,
+  }: {
+    client: StreamChat;
+    maxSyncEventsLimit?: number | false;
+  }) {
+    super({
+      client,
+      syncMaxEventCount: maxSyncEventsLimit === false ? undefined : maxSyncEventsLimit,
+    });
   }
 
   upsertCidsForQuery = api.upsertCidsForQuery;


### PR DESCRIPTION
## 🎯 Goal

This PR is a quick follow-up to the offline sync limit one, in which we provide a sensible way to disable the behaviour rather than rely on "magic numbers".

## 🛠 Implementation details

<!-- Provide a description of the implementation -->

## 🎨 UI Changes

<!-- Add relevant screenshots -->

<details>
<summary>iOS</summary>


<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>


<details>
<summary>Android</summary>

<table>
    <thead>
        <tr>
            <td>Before</td>
            <td>After</td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <!--<img src="" /> -->
            </td>
            <td>
                <!--<img src="" /> -->
            </td>
        </tr>
    </tbody>
</table>
</details>

## 🧪 Testing

<!-- Explain how this change can be tested (or why it can't be tested) -->

## ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Documentation is updated
- [ ] New code is tested in main example apps, including all possible scenarios
  - [ ] SampleApp iOS and Android
  - [ ] Expo iOS and Android


