### PR TITLE
MVCP autoscroll-to-bottom pin fights a message resizing in place (relates to #3670)

### DIFF
--- a/examples/ExpoMessaging/components/ExpoMessagingComponentOverrides.tsx
+++ b/examples/ExpoMessaging/components/ExpoMessagingComponentOverrides.tsx
@@ -4,7 +4,15 @@ import type { ComponentOverrides } from 'stream-chat-expo';
 
 import InputButtons from './InputButtons';
 import { MessageLocation } from './LocationSharing/MessageLocation';
+import { QuickReplyMessageBottomView } from './QuickReplyMessageBottomView';
 
 export const useExpoMessagingComponentOverrides = () => {
-  return useMemo<ComponentOverrides>(() => ({ InputButtons, MessageLocation }), []);
+  return useMemo<ComponentOverrides>(
+    () => ({
+      InputButtons,
+      MessageLocation,
+      MessageContentBottomView: QuickReplyMessageBottomView,
+    }),
+    [],
+  );
 };

--- a/examples/ExpoMessaging/components/QuickReplyMessageBottomView.tsx
+++ b/examples/ExpoMessaging/components/QuickReplyMessageBottomView.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+
+import { useMessageContext } from 'stream-chat-expo';
+
+import QuickReplyPills from './QuickReplyPills';
+
+// Minimal CIT-1311 repro harness: mimics Robin's `quick_replies` field
+// attaching to an already-rendered, already-measured message some time
+// after it first appears. Hardcoded trigger + replies for now — send a
+// message containing "1311" and watch the scroll position once the pills
+// mount ~1.5s later.
+const TRIGGER_KEYWORD = '1311';
+const REPLY_DELAY_MS = 1500;
+const HARDCODED_REPLIES = ['Yes', 'No'];
+
+export const QuickReplyMessageBottomView = () => {
+  const { message } = useMessageContext();
+  const [showPills, setShowPills] = useState(false);
+  const messageId = message.id;
+  const messageText = message.text;
+
+  useEffect(() => {
+    if (!messageText?.includes(TRIGGER_KEYWORD)) {
+      return;
+    }
+    const timeoutId = setTimeout(() => setShowPills(true), REPLY_DELAY_MS);
+    return () => clearTimeout(timeoutId);
+  }, [messageId, messageText]);
+
+  if (!showPills) {
+    return null;
+  }
+
+  return <QuickReplyPills replies={HARDCODED_REPLIES} />;
+};

--- a/examples/ExpoMessaging/components/QuickReplyPills.tsx
+++ b/examples/ExpoMessaging/components/QuickReplyPills.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+
+// Ported from Hinge Health's Phoenix app (src/modules/in-app-messaging/components/QuickReplyPills.tsx)
+// for a minimal CIT-1311 repro against stock stream-chat-expo. The original pulls these values
+// from the `@hinge-health/heal` design system, which isn't available here — hardcoded to the
+// same pixel values (heal's `sN` spacing scale is N px; `radius.pill` is a large constant used
+// purely to force a fully-rounded pill regardless of height). Colors are placeholders: the bug
+// this is reproducing is about layout/scroll timing, not visual fidelity.
+const SPACE_4 = 4;
+const SPACE_8 = 8;
+const SPACE_16 = 16;
+const SPACE_20 = 20;
+const RADIUS_PILL = 999;
+const COLOR_BORDER = '#D6D3D1';
+const COLOR_FILL = '#FFFFFF';
+
+// Design-approved cap for LLM-generated reply text — no matching space token
+// (this constrains a single pill's width, not inter-element spacing).
+const MAX_PILL_WIDTH = 280;
+// Design-approved touch target — no matching space token.
+const PILL_MIN_HEIGHT = 44;
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: SPACE_4,
+  },
+  contentContainer: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    paddingHorizontal: SPACE_16,
+    gap: SPACE_16,
+  },
+  // Background/border live on the pill itself, not a wrapper, to avoid
+  // bleed/seam artifacts (mirrors ConversationStarterPills' PillView).
+  pill: {
+    minHeight: PILL_MIN_HEIGHT,
+    maxWidth: MAX_PILL_WIDTH,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: SPACE_20,
+    paddingVertical: SPACE_8,
+    borderRadius: RADIUS_PILL,
+    borderWidth: 1,
+    borderColor: COLOR_BORDER,
+    backgroundColor: COLOR_FILL,
+  },
+  // heal's HLText type="body1" — approximated; not load-bearing for this repro.
+  pillText: {
+    fontSize: 16,
+    lineHeight: 22,
+  },
+});
+
+function QuickReplyPill({
+  label,
+  onPress,
+}: Readonly<{
+  label: string;
+  onPress?: () => void;
+}>) {
+  // No handler wired yet — render inert presentation rather than a disabled
+  // button. A disabled Pressable still announces "button, dimmed" to
+  // screen readers, telling AT users an action exists when it doesn't.
+  if (!onPress) {
+    return (
+      <View style={styles.pill}>
+        <Text style={styles.pillText}>{label}</Text>
+      </View>
+    );
+  }
+  return (
+    <Pressable
+      style={styles.pill}
+      onPress={onPress}
+      disabled={false}
+      accessibilityRole='button'
+      accessibilityLabel={label}
+    >
+      <Text style={styles.pillText}>{label}</Text>
+    </Pressable>
+  );
+}
+
+type PillDatum = Readonly<{
+  key: string;
+  label: string;
+  handlePress?: () => void;
+}>;
+
+// Module-level and reads only its own parameter, so it's a stable reference
+// across renders — FlatList's item memoization isn't defeated by a fresh
+// closure on every render of QuickReplyPills.
+function renderPill({ item }: { item: PillDatum }) {
+  return <QuickReplyPill label={item.label} onPress={item.handlePress} />;
+}
+
+function keyExtractor(item: PillDatum): string {
+  return item.key;
+}
+
+// LLM-generated replies can repeat text, so the reply string alone isn't a
+// safe React key. Prefixing with the index guarantees uniqueness even when
+// multiple replies share identical text.
+function buildPillData(
+  replies: string[],
+  onPressItem?: (reply: string, index: number) => void,
+): PillDatum[] {
+  return replies.map((label, index) => ({
+    key: `${index}-${label}`,
+    label,
+    handlePress: onPressItem ? () => onPressItem(label, index) : undefined,
+  }));
+}
+
+type Props = Readonly<{
+  replies: string[];
+  // When omitted, pills render as inert presentation (no button role)
+  onPressItem?: (reply: string, index: number) => void;
+}>;
+
+export default function QuickReplyPills({ replies, onPressItem }: Props) {
+  const data = buildPillData(replies, onPressItem);
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={data}
+        renderItem={renderPill}
+        keyExtractor={keyExtractor}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        keyboardShouldPersistTaps='handled'
+        testID='quick-reply-pills-flatlist'
+        contentContainerStyle={styles.contentContainer}
+        accessibilityHint='Scrollable list of quick replies'
+      />
+    </View>
+  );
+}


### PR DESCRIPTION
What
A minimal repro (in examples/ExpoMessaging) for a scroll-position bug: when an already-rendered, already-measured message grows in place — a reaction, an edit, or (here) a delayed sub-view mounting below the text — maintainVisibleContentPosition's autoscroll-to-bottom pin fights the resize. The list ends up anchored past the real content until you drag to reveal it, then snaps back to the wrong position on release.

Uses the stock <MessageList/> with no custom additionalFlatListProps/MVCP override, so this isolates the behavior to the SDK itself.

Repro steps
Run examples/ExpoMessaging on iOS or Android.
Send a message containing 1311.
Stay scrolled to the bottom.
~1.5s later, a small pill row mounts below the message text (QuickReplyMessageBottomView in this branch, simulating a real-world delayed content attach — e.g. quick-reply suggestions, AI-generated follow-ups, etc.).
Observe: the list doesn't smoothly grow to reveal the new content — it renders blank/past the real content until you manually drag, and snaps back to the same wrong position on release.
Why we think this matches #3670
#3670 describes a reaction added to a recent message corrupting the MVCP anchor via a content-only update with no new message inserted. This repro hits the same failure shape through a different trigger (a sub-view mounting rather than a reaction), which suggests the root cause is in how MVCP recompensates for an existing cell's height changing near the anchor, not something specific to reactions.

We hit this in production via a custom message renderer that attaches quick-reply pills to an AI response ~1-2s after the message finishes streaming (i.e. after the row is already measured). We tried several client-side mitigations (pre-reserving the pill's height, relaxing autoscrollToTopThreshold for a settling window) and none fully closed it — which points at the native resize-compensation logic itself rather than something app-side timing can route around.

Happy to pair with someone from GetStream on this if useful — this is currently blocking us from shipping quick-reply-style UI in our AI chat surface.

